### PR TITLE
负样本空标签的导入与导出逻辑

### DIFF
--- a/core/annotation_importer.py
+++ b/core/annotation_importer.py
@@ -94,6 +94,7 @@ class AnnotationImporter:
                 
                 # 读取YOLO标注
                 annotations = self._parse_yolo_file(txt_file, image_info)
+                is_empty_label_file = txt_file.read_text(encoding='utf-8').strip() == ""
                 
                 # 导入标注
                 for ann in annotations:
@@ -116,6 +117,10 @@ class AnnotationImporter:
                         annotation_type=annotation_type,
                         data=ann['data']
                     )
+
+                # 空标签文件代表负样本，应视为“已标注”而不是继续保持 pending
+                if not annotations and is_empty_label_file:
+                    db.update_image_status(image_record['id'], 'annotated')
                 
                 imported += len(annotations)
                 

--- a/gui/pages/annotate_page.py
+++ b/gui/pages/annotate_page.py
@@ -4619,12 +4619,14 @@ Esc - 取消操作
                 
                 # 导出每个图片的标注
                 exported_count = 0
+                negative_count = 0
                 for image in images:
                     image_id = image['id']
                     annotations = db.get_image_annotations(image_id)
+                    image_status = image.get('status', 'pending')
                     
-                    if annotations:
-                        # 创建标注文件
+                    if annotations or image_status == 'annotated':
+                        # 已标注图片都应生成标签文件；负样本生成空txt
                         filename = os.path.splitext(image['filename'])[0] + '.txt'
                         label_file = os.path.join(labels_dir, filename)
                         
@@ -4674,6 +4676,8 @@ Esc - 取消操作
                                             f.write(f"{class_id} {' '.join(normalized_points)}\n")
                         
                         exported_count += 1
+                        if not annotations:
+                            negative_count += 1
                 
                 # 创建classes.txt文件
                 classes_file = os.path.join(export_path, 'classes.txt')
@@ -4681,7 +4685,12 @@ Esc - 取消操作
                     for cls in sorted(self.classes, key=lambda x: x['id']):
                         f.write(f"{cls['name']}\n")
                 
-                QMessageBox.information(self, "导出成功", f"已导出 {exported_count} 个标注文件到\n{export_path}")
+                QMessageBox.information(
+                    self,
+                    "导出成功",
+                    f"已导出 {exported_count} 个标注文件到\n{export_path}\n\n"
+                    f"- 负样本空标签: {negative_count} 个"
+                )
                 
             elif export_format == "COCO格式":
                 # 导出COCO格式
@@ -5238,6 +5247,7 @@ Esc - 取消操作
             # 复制图片并导出标注
             copied_count = 0
             exported_count = 0
+            negative_count = 0
             
             for image in images:
                 # 复制图片
@@ -5250,9 +5260,10 @@ Esc - 取消操作
                 # 导出标注
                 image_id = image['id']
                 annotations = db.get_image_annotations(image_id)
+                image_status = image.get('status', 'pending')
                 
-                if annotations:
-                    # 创建标注文件
+                if annotations or image_status == 'annotated':
+                    # 已标注图片都应生成标签文件；负样本生成空txt
                     filename = os.path.splitext(image['filename'])[0] + '.txt'
                     label_file = os.path.join(labels_dir, filename)
                     
@@ -5305,6 +5316,8 @@ Esc - 取消操作
                                         f.write(f"{class_id} {' '.join(normalized_points)}\n")
                     
                     exported_count += 1
+                    if not annotations:
+                        negative_count += 1
             
             # 创建classes.txt文件
             classes_file = os.path.join(dataset_dir, 'classes.txt')
@@ -5326,9 +5339,14 @@ names: {[cls['name'] for cls in sorted(self.classes, key=lambda x: x['id'])]}
             with open(yaml_file, 'w', encoding='utf-8') as f:
                 f.write(yaml_content)
             
-            QMessageBox.information(self, "导出成功", f"已导出完整数据集到\n{dataset_dir}\n\n" 
-                                   f"- 复制图片: {copied_count} 张\n" 
-                                   f"- 导出标注: {exported_count} 个")
+            QMessageBox.information(
+                self,
+                "导出成功",
+                f"已导出完整数据集到\n{dataset_dir}\n\n"
+                f"- 复制图片: {copied_count} 张\n"
+                f"- 导出标注: {exported_count} 个\n"
+                f"- 负样本空标签: {negative_count} 个"
+            )
             
         except Exception as e:
             QMessageBox.critical(self, "导出失败", f"导出过程中出错:\n{str(e)}")


### PR DESCRIPTION
## 变更说明

本次修改主要修复负样本（空标签文件）在 EzYOLO 中的导入与导出问题。

## 修复内容

1. 修复 YOLO 标注导入逻辑
- 当标签文件存在但内容为空时，将其视为负样本
- 导入后将对应图片状态标记为“已标注”，而不是继续保持 `pending`

2. 修复标注导出逻辑
- 在导出 YOLO 标注文件时：
  - 有标注框的图片正常导出标注内容
  - 已标注但无目标的负样本图片，导出同名空 `txt`
- 避免负样本在导出后丢失标签文件

3. 修复完整数据集导出逻辑
- 在“导出完整数据集”时，同样为负样本生成空标签文件
- 导出结果统计中增加“负样本空标签”数量提示，便于核对

## 修复原因

之前的逻辑只在图片存在标注框时才：
- 将图片标记为已标注
- 导出对应标签文件

这会导致负样本虽然已经完成人工确认，但：
- 导入后界面仍显示为未标注
- 导出数据集时缺少空标签文件
- 后续再次导入或训练时，负样本信息不完整

## 影响范围

涉及文件：
- `core/annotation_importer.py`
- `gui/pages/annotate_page.py`

## 验证情况

已验证以下行为：
- 空 `txt` 标签可作为负样本正确导入
- 负样本导入后图片状态为已标注
- 导出标注文件时会为负样本生成空 `txt`
- 导出完整数据集时也会保留负样本空标签