### PR TITLE
修复导入页加载残留并优化标注页与训练页交互

### DIFF
--- a/gui/pages/annotate_page.py
+++ b/gui/pages/annotate_page.py
@@ -8,10 +8,10 @@ from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QScrollArea, QGridLayout, QFrame, QFileDialog, QProgressBar,
     QMenu, QMessageBox, QComboBox, QLineEdit, QSplitter,
-    QListWidget, QListWidgetItem, QToolBar, QButtonGroup,
+    QListWidget, QListWidgetItem, QButtonGroup,
     QRadioButton, QSpinBox, QDoubleSpinBox, QFormLayout,
     QGroupBox, QCheckBox, QSlider, QTextEdit, QInputDialog,
-    QSizePolicy,
+    QSizePolicy, QToolButton,
     QColorDialog, QDialog, QApplication, QAbstractSpinBox
 )
 import math
@@ -2249,6 +2249,7 @@ class AnnotatePage(QWidget):
         self._sample_class_counts_cache = {}
         self._negative_sample_count_cache = 0
         self._sample_stats_dirty = True
+        self.default_draw_tool = 'rectangle'
         
         # 自动标注相关属性
         self.auto_label_dialog = None
@@ -2284,6 +2285,9 @@ class AnnotatePage(QWidget):
         
         # 设置分割器比例
         splitter.setSizes([250, 700, 250])
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setStretchFactor(2, 0)
         
         self.main_layout.addWidget(splitter)
         
@@ -2424,6 +2428,7 @@ class AnnotatePage(QWidget):
     def create_center_panel(self) -> QWidget:
         """创建中间面板 - 标注画布"""
         panel = QWidget()
+        panel.setMinimumWidth(620)
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
@@ -2446,43 +2451,47 @@ class AnnotatePage(QWidget):
         
         return panel
     
-    def create_toolbar(self) -> QToolBar:
+    def create_toolbar(self) -> QWidget:
         """创建工具栏"""
-        toolbar = QToolBar()
+        toolbar = QFrame()
         toolbar.setStyleSheet(f"""
-            QToolBar {{
+            QFrame {{
                 background-color: {COLORS['panel']};
                 border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                padding: 4px;
+                border-radius: 6px;
             }}
         """)
+        toolbar_layout = QHBoxLayout(toolbar)
+        toolbar_layout.setContentsMargins(6, 3, 6, 3)
+        toolbar_layout.setSpacing(14)
+        base_tool_button_style = self._toolbar_chip_style('tool')
         
         # 工具按钮组
         self.tool_group = QButtonGroup(self)
         self.tool_group.setExclusive(True)
         
-        # 矩形工具
-        self.btn_rectangle = QPushButton("🟦 矩形")
-        self.btn_rectangle.setCheckable(True)
-        self.btn_rectangle.clicked.connect(lambda: self.set_tool('rectangle'))
-        toolbar.addWidget(self.btn_rectangle)
-        self.btn_rectangle.hide()  # 默认隐藏
-        self.tool_group.addButton(self.btn_rectangle)
-        
-        # 多边形工具
-        self.btn_polygon = QPushButton("🛑 多边形")
-        self.btn_polygon.setCheckable(True)
-        self.btn_polygon.clicked.connect(lambda: self.set_tool('polygon'))
-        toolbar.addWidget(self.btn_polygon)
-        self.btn_polygon.hide()  # 默认隐藏
-        self.tool_group.addButton(self.btn_polygon)
+        # 绘制工具（矩形/多边形合并）
+        self.btn_draw_tool = QToolButton()
+        self.btn_draw_tool.setCheckable(True)
+        self.btn_draw_tool.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+        self.btn_draw_tool.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.btn_draw_tool.setStyleSheet(base_tool_button_style)
+        self.btn_draw_tool.clicked.connect(self.activate_default_draw_tool)
+        self.draw_tool_menu = QMenu(self)
+        self.action_draw_rectangle = self.draw_tool_menu.addAction("矩形")
+        self.action_draw_polygon = self.draw_tool_menu.addAction("多边形")
+        self.action_draw_rectangle.triggered.connect(lambda: self.select_draw_tool('rectangle'))
+        self.action_draw_polygon.triggered.connect(lambda: self.select_draw_tool('polygon'))
+        self.btn_draw_tool.setMenu(self.draw_tool_menu)
+        self.btn_draw_tool.hide()  # 默认隐藏
+        self.tool_group.addButton(self.btn_draw_tool)
         
         # 关键点工具
         self.btn_keypoint = QPushButton("📍 关键点")
+        self.btn_keypoint.setToolTip("关键点工具")
         self.btn_keypoint.setCheckable(True)
         self.btn_keypoint.clicked.connect(lambda: self.set_tool('keypoint'))
-        toolbar.addWidget(self.btn_keypoint)
+        self.btn_keypoint.setStyleSheet(base_tool_button_style)
         self.btn_keypoint.hide()  # 默认隐藏
         self.tool_group.addButton(self.btn_keypoint)
         
@@ -2496,129 +2505,230 @@ class AnnotatePage(QWidget):
         
         # 移动工具
         self.btn_move = QPushButton("✋ 移动")
+        self.btn_move.setToolTip("移动视图")
         self.btn_move.setCheckable(True)
         self.btn_move.clicked.connect(lambda: self.set_tool('move'))
-        toolbar.addWidget(self.btn_move)
+        self.btn_move.setStyleSheet(base_tool_button_style)
         self.tool_group.addButton(self.btn_move)
-        
-        toolbar.addSeparator()
-        
-        # 删除按钮
-        self.btn_delete = QPushButton("🗑️ 删除 (D)")
+
+        # 删除按钮（主动作删标注，下拉菜单删图片）
+        self.btn_delete = QToolButton()
+        self.btn_delete.setText("🗑️ 删除")
+        self.btn_delete.setToolTip("删除当前选中标注\n快捷键: D")
+        self.btn_delete.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.btn_delete.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+        self.btn_delete.setStyleSheet(self._toolbar_chip_style('danger'))
         self.btn_delete.clicked.connect(self.delete_selected_annotation)
-        toolbar.addWidget(self.btn_delete)
+        self.delete_menu = QMenu(self)
+        self.action_delete_current_image = self.delete_menu.addAction("删除当前图片")
+        self.action_delete_current_image.triggered.connect(self.delete_current_image)
+        self.delete_menu.aboutToShow.connect(self.update_delete_menu_state)
+        self.btn_delete.setMenu(self.delete_menu)
         
         # 撤销按钮
-        self.btn_undo = QPushButton("↶ 撤销 (Ctrl+Z)")
+        self.btn_undo = QPushButton("↶ 撤销")
+        self.btn_undo.setToolTip("撤销上一步\n快捷键: Ctrl+Z")
         self.btn_undo.clicked.connect(self.undo)
-        toolbar.addWidget(self.btn_undo)
+        self.btn_undo.setStyleSheet(base_tool_button_style)
         
         # 自动标注按钮
-        toolbar.addSeparator()
         self.btn_auto_label = QPushButton("🤖 自动标注")
         self.btn_auto_label.setMenu(self.create_auto_label_menu())
-        # 美化按钮样式
-        primary_color = COLORS['primary']
-        self.btn_auto_label.setStyleSheet(
-            f"QPushButton {{"  
-            f"    background-color: {primary_color};" 
-            f"    color: white;" 
-            f"    border: none;" 
-            f"    border-radius: 4px;" 
-            f"    padding: 6px 12px;" 
-            f"    font-weight: bold;" 
-            f"}}" 
-            f"QPushButton:hover {{" 
-            f"    background-color: {primary_color};" 
-            f"}}" 
-            f"QPushButton::menu-indicator {{" 
-            f"    image: none;" 
-            f"    subcontrol-position: right center;" 
-            f"    subcontrol-origin: padding;" 
-            f"    width: 16px;" 
-            f"    height: 16px;" 
-            f"}}" 
-            f"QPushButton::menu-indicator::hover {{" 
-            f"    image: none;" 
-            f"}}"
-        )
-        toolbar.addWidget(self.btn_auto_label)
+        self.btn_auto_label.setStyleSheet(self._toolbar_chip_style('ai_blue'))
         
         # SAM自动标注按钮
-        toolbar.addSeparator()
         self.btn_sam = QPushButton("🎯 SAM")
         self.btn_sam.setToolTip("使用SAM进行交互式分割标注")
-        sam_btn_style = (
-            f"QPushButton {{"
-            f"    background-color: {COLORS['success']};"
-            f"    color: white;"
-            f"    border: none;"
-            f"    border-radius: 4px;"
-            f"    padding: 6px 12px;"
-            f"    font-weight: bold;"
-            f"}}"
-            f"QPushButton:hover {{"
-            f"    background-color: {COLORS['success']};"
-            f"}}"
-            f"QPushButton::menu-indicator {{"
-            f"    image: none;"
-            f"}}"
-            f"QPushButton::menu-indicator::hover {{"
-            f"    image: none;"
-            f"}}"
-        )
-        self.btn_sam.setStyleSheet(sam_btn_style)
-        toolbar.addWidget(self.btn_sam)
+        self.btn_sam.setStyleSheet(self._toolbar_chip_style('ai_green'))
         self.apply_sam_button_mode()
         
         # LLM自动标注按钮
-        toolbar.addSeparator()
         self.btn_llm_label = QPushButton("🧠 LLM")
         self.btn_llm_label.setToolTip("使用多模态大模型进行自动标注")
         self.btn_llm_label.setMenu(self.create_llm_menu())
-        llm_btn_style = (
-            f"QPushButton {{"
-            f"    background-color: {COLORS['warning']};"
-            f"    color: white;"
-            f"    border: none;"
-            f"    border-radius: 4px;"
-            f"    padding: 6px 12px;"
-            f"    font-weight: bold;"
-            f"}}"
-            f"QPushButton:hover {{"
-            f"    background-color: {COLORS['warning']};"
-            f"}}"
-            f"QPushButton::menu-indicator {{"
-            f"    image: none;"
-            f"}}"
-            f"QPushButton::menu-indicator::hover {{"
-            f"    image: none;"
-            f"}}"
-        )
-        self.btn_llm_label.setStyleSheet(llm_btn_style)
-        toolbar.addWidget(self.btn_llm_label)
+        self.btn_llm_label.setStyleSheet(self._toolbar_chip_style('ai_gold'))
         
         # 批量处理按钮
-        toolbar.addSeparator()
-        self.btn_batch_process = QPushButton("📋 批量处理")
+        self.btn_batch_process = QPushButton("📋 批处理")
         self.btn_batch_process.clicked.connect(self.show_batch_process_dialog)
-        self.btn_batch_process.setStyleSheet(
-            f"QPushButton {{"  
-            f"    background-color: {COLORS['secondary']};" 
-            f"    color: white;" 
-            f"    border: none;" 
-            f"    border-radius: 4px;" 
-            f"    padding: 6px 12px;" 
-            f"    font-weight: bold;" 
-            f"}}" 
-            f"QPushButton:hover {{" 
-            f"    background-color: {COLORS['secondary']};" 
-            f"}}"
-        )
-        toolbar.addWidget(self.btn_batch_process)
+        self.btn_batch_process.setToolTip("批量处理工具")
+        self.btn_batch_process.setStyleSheet(self._toolbar_chip_style('ai_olive'))
+
+        self.toolbar_draw_buttons = [self.btn_draw_tool, self.btn_keypoint, self.btn_move]
+        self.toolbar_edit_buttons = [self.btn_delete, self.btn_undo]
+        self.toolbar_ai_buttons = [self.btn_auto_label, self.btn_sam, self.btn_llm_label, self.btn_batch_process]
+        self.toolbar_draw_group = self._create_toolbar_button_group(self.toolbar_draw_buttons)
+        self.toolbar_edit_group = self._create_toolbar_button_group(self.toolbar_edit_buttons)
+        self.toolbar_ai_group = self._create_toolbar_button_group(self.toolbar_ai_buttons)
+        self.toolbar_groups = [
+            (self.toolbar_draw_group, self.toolbar_draw_buttons),
+            (self.toolbar_edit_group, self.toolbar_edit_buttons),
+            (self.toolbar_ai_group, self.toolbar_ai_buttons),
+        ]
+
+        toolbar_layout.addWidget(self.toolbar_draw_group)
+        toolbar_layout.addWidget(self.toolbar_edit_group)
+        toolbar_layout.addWidget(self.toolbar_ai_group)
+        toolbar_layout.addStretch(1)
+
+        self.refresh_draw_tool_button()
+        self.refresh_toolbar_button_layout()
         
         return toolbar
 
+    def _create_toolbar_button_group(self, buttons) -> QWidget:
+        """创建工具栏按钮组，显式控制组内间距。"""
+        group_widget = QWidget()
+        layout = QHBoxLayout(group_widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for button in buttons:
+            layout.addWidget(button)
+        return group_widget
+
+    def _toolbar_chip_style(self, role: str) -> str:
+        """生成顶部工具栏按钮样式。"""
+        palette_map = {
+            'tool': {
+                'bg': '#154B78',
+                'hover': '#1D629B',
+                'active': COLORS['primary'],
+                'border': '#2871A8',
+                'text': '#F7FBFF',
+            },
+            'danger': {
+                'bg': '#154B78',
+                'hover': '#1D629B',
+                'active': COLORS['primary'],
+                'border': '#2871A8',
+                'text': '#F7FBFF',
+            },
+            'ai_blue': {
+                'bg': '#154B78',
+                'hover': '#1D629B',
+                'active': COLORS['primary'],
+                'border': '#2871A8',
+                'text': '#F7FBFF',
+            },
+            'ai_green': {
+                'bg': '#154B78',
+                'hover': '#1D629B',
+                'active': COLORS['primary'],
+                'border': '#2871A8',
+                'text': '#F7FBFF',
+            },
+            'ai_gold': {
+                'bg': '#154B78',
+                'hover': '#1D629B',
+                'active': COLORS['primary'],
+                'border': '#2871A8',
+                'text': '#F7FBFF',
+            },
+            'ai_olive': {
+                'bg': '#154B78',
+                'hover': '#1D629B',
+                'active': COLORS['primary'],
+                'border': '#2871A8',
+                'text': '#F7FBFF',
+            },
+        }
+        palette = palette_map[role]
+        return f"""
+            QPushButton, QToolButton {{
+                background-color: {palette['bg']};
+                color: {palette['text']};
+                border: 1px solid {palette['border']};
+                border-radius: 6px;
+                padding: 4px 10px;
+                font-weight: 600;
+            }}
+            QPushButton:hover, QToolButton:hover {{
+                background-color: {palette['hover']};
+                border-color: {palette['active']};
+            }}
+            QPushButton:checked, QToolButton:checked {{
+                background-color: {palette['active']};
+                color: white;
+                border-color: {palette['active']};
+            }}
+            QToolButton::menu-button {{
+                subcontrol-origin: padding;
+                subcontrol-position: right center;
+                width: 16px;
+                background-color: rgba(255, 255, 255, 0.08);
+                border-left: 1px solid rgba(255, 255, 255, 0.14);
+                border-top-right-radius: 6px;
+                border-bottom-right-radius: 6px;
+            }}
+            QToolButton::menu-button:hover {{
+                background-color: rgba(255, 255, 255, 0.14);
+            }}
+        """
+
+    def _get_toolbar_button_width(self, button) -> int:
+        """计算按钮建议宽度，菜单按钮额外预留箭头空间。"""
+        text_width = button.fontMetrics().horizontalAdvance(button.text())
+        extra_padding = 40
+        if isinstance(button, QToolButton) and button.menu() is not None:
+            extra_padding += 18
+        return text_width + extra_padding
+
+    def refresh_toolbar_button_layout(self):
+        """按分组统一顶部按钮尺寸。"""
+        button_height = 32
+        for group_widget, group in getattr(self, 'toolbar_groups', []):
+            visible_buttons = [
+                button for button in group
+                if button is not None and not button.isHidden()
+            ]
+            group_widget.setVisible(bool(visible_buttons))
+            if not visible_buttons:
+                continue
+            group_width = max(self._get_toolbar_button_width(button) for button in visible_buttons)
+            for button in visible_buttons:
+                button.setFixedHeight(button_height)
+                button.setFixedWidth(group_width)
+
+    def refresh_draw_tool_button(self):
+        """刷新绘制工具按钮文本与选项状态。"""
+        if not hasattr(self, 'btn_draw_tool'):
+            return
+
+        if self.default_draw_tool == 'polygon':
+            self.btn_draw_tool.setText("🛑 绘制")
+            self.btn_draw_tool.setToolTip("当前默认绘制模式: 多边形\n点击主按钮直接进入多边形绘制")
+        else:
+            self.btn_draw_tool.setText("🟦 绘制")
+            self.btn_draw_tool.setToolTip("当前默认绘制模式: 矩形\n点击主按钮直接进入矩形绘制")
+
+        if hasattr(self, 'action_draw_rectangle'):
+            self.action_draw_rectangle.setCheckable(True)
+            self.action_draw_rectangle.setChecked(self.default_draw_tool == 'rectangle')
+        if hasattr(self, 'action_draw_polygon'):
+            self.action_draw_polygon.setCheckable(True)
+            self.action_draw_polygon.setChecked(self.default_draw_tool == 'polygon')
+
+        self.refresh_toolbar_button_layout()
+
+    def select_draw_tool(self, tool: str):
+        """选择默认绘制工具，并立即切换到该工具。"""
+        if tool not in ('rectangle', 'polygon'):
+            return
+        self.default_draw_tool = tool
+        self.refresh_draw_tool_button()
+        self.btn_draw_tool.setChecked(True)
+        self.set_tool(tool)
+
+    def activate_default_draw_tool(self):
+        """激活当前默认绘制工具。"""
+        self.btn_draw_tool.setChecked(True)
+        self.set_tool(self.default_draw_tool)
+
+    def update_delete_menu_state(self):
+        """更新删除菜单状态。"""
+        if hasattr(self, 'action_delete_current_image'):
+            self.action_delete_current_image.setEnabled(bool(self.current_image_id))
+    
     def apply_sam_button_mode(self):
         """根据SAM设置刷新按钮行为：普通模式/记忆模式。"""
         if not hasattr(self, "btn_sam"):
@@ -2641,6 +2751,7 @@ class AnnotatePage(QWidget):
             self.btn_sam.setText("🎯 SAM")
             self.btn_sam.setToolTip("使用SAM进行交互式分割标注")
             self.btn_sam.clicked.connect(self.start_sam_annotation)
+        self.refresh_toolbar_button_layout()
 
     def create_sam_memory_menu(self) -> QMenu:
         menu = QMenu(self)
@@ -4438,21 +4549,16 @@ class AnnotatePage(QWidget):
     def adjust_tool_visibility(self, task_type):
         """根据任务类型调整标注工具的显示"""
         # 隐藏所有标注工具
-        self.btn_rectangle.hide()
-        self.btn_polygon.hide()
+        self.btn_draw_tool.hide()
         self.btn_keypoint.hide()
         
         # 根据任务类型显示对应的工具
         if task_type == 'detect':
-            self.btn_rectangle.show()
-            # 默认选中矩形工具
-            self.btn_rectangle.setChecked(True)
-            self.set_tool('rectangle')
+            self.btn_draw_tool.show()
+            self.select_draw_tool('rectangle')
         elif task_type == 'segment':
-            self.btn_polygon.show()
-            # 默认选中多边形工具
-            self.btn_polygon.setChecked(True)
-            self.set_tool('polygon')
+            self.btn_draw_tool.show()
+            self.select_draw_tool('polygon')
         elif task_type == 'pose':
             self.btn_keypoint.show()
             # 默认选中关键点工具
@@ -4464,10 +4570,12 @@ class AnnotatePage(QWidget):
         
         # 移动工具始终显示
         self.btn_move.show()
+        self.refresh_toolbar_button_layout()
     
     def load_image(self, image_id: int):
         """加载图片"""
         self.current_image_id = image_id
+        self.update_delete_menu_state()
         
         # 找到图片数据
         image_data = next((img for img in self.images if img['id'] == image_id), None)
@@ -4516,6 +4624,16 @@ class AnnotatePage(QWidget):
     def set_tool(self, tool: str):
         """设置工具"""
         self.canvas.set_tool(tool)
+
+        if tool in ('rectangle', 'polygon'):
+            self.default_draw_tool = tool
+            if hasattr(self, 'btn_draw_tool'):
+                self.btn_draw_tool.setChecked(True)
+                self.refresh_draw_tool_button()
+        elif tool == 'keypoint' and hasattr(self, 'btn_keypoint'):
+            self.btn_keypoint.setChecked(True)
+        elif tool == 'move' and hasattr(self, 'btn_move'):
+            self.btn_move.setChecked(True)
         
         # 确保status_tool存在时才更新
         if hasattr(self, 'status_tool'):
@@ -4527,6 +4645,68 @@ class AnnotatePage(QWidget):
                 'obb': '旋转矩形'
             }
             self.status_tool.setText(f"工具: {tool_names.get(tool, tool)}")
+
+    def clear_current_image_view(self):
+        """清空当前图片显示与相关状态。"""
+        self.current_image_id = None
+        self.current_image_data = None
+        self.annotations = []
+        self.history = []
+        self.history_index = -1
+        self.canvas.selected_annotation_id = None
+        self.canvas.set_annotations([])
+        self.canvas.load_image("")
+        self.clear_attribute_panel(refresh_sample_panel=False)
+        self.update_status_bar()
+        self.update_delete_menu_state()
+
+    def delete_current_image(self):
+        """删除当前图片及其全部标注和实际文件。"""
+        if not self.current_project_id or not self.current_image_id:
+            QMessageBox.warning(self, "提示", "当前没有可删除的图片")
+            return
+
+        current_index = next(
+            (i for i, image in enumerate(self.images) if image['id'] == self.current_image_id),
+            -1
+        )
+        current_image = next(
+            (image for image in self.images if image['id'] == self.current_image_id),
+            None
+        )
+        if current_index < 0 or current_image is None:
+            QMessageBox.warning(self, "提示", "当前图片不存在或已失效，请先重新加载")
+            return
+
+        filename = current_image.get('filename', str(self.current_image_id))
+        reply = QMessageBox.question(
+            self,
+            "确认删除当前图片",
+            (
+                f"将删除当前图片“{filename}”及其全部标注，并删除实际文件。\n"
+                "此操作不可恢复，是否继续？"
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        fallback_index = current_index if current_index < len(self.images) - 1 else current_index - 1
+        deleted = db.delete_image(self.current_image_id)
+        if not deleted:
+            QMessageBox.warning(self, "提示", "删除当前图片失败")
+            return
+
+        self.load_image_list()
+        self.update_class_list()
+
+        if self.images:
+            fallback_index = max(0, min(fallback_index, len(self.images) - 1))
+            next_image_id = self.images[fallback_index]['id']
+            self.load_image(next_image_id)
+        else:
+            self.clear_current_image_view()
     
     def on_annotation_created(self, annotation: dict):
         """标注创建事件"""
@@ -4807,14 +4987,7 @@ class AnnotatePage(QWidget):
             elif self.current_image_id:
                 self.load_image(self.current_image_id)
         else:
-            self.current_image_id = None
-            self.current_image_data = None
-            self.annotations = []
-            self.canvas.selected_annotation_id = None
-            self.canvas.set_annotations([])
-            self.canvas.load_image("")
-            self.clear_attribute_panel(refresh_sample_panel=False)
-            self.update_status_bar()
+            self.clear_current_image_view()
 
         if canceled:
             QMessageBox.information(
@@ -5126,6 +5299,14 @@ class AnnotatePage(QWidget):
         
         self.status_image.setText(f"当前: {current}/{total}")
         self.status_annotation.setText(f"标注: {len(self.annotations)}")
+        tool_names = {
+            'rectangle': '矩形',
+            'polygon': '多边形',
+            'move': '移动',
+            'keypoint': '关键点',
+            'obb': '旋转矩形'
+        }
+        self.status_tool.setText(f"工具: {tool_names.get(self.canvas.current_tool, self.canvas.current_tool)}")
     
     def keyPressEvent(self, event: QKeyEvent):
         """键盘事件"""
@@ -5141,12 +5322,10 @@ class AnnotatePage(QWidget):
         # 处理工具快捷键
         key_text = event.text().upper()
         if key_text == rect_tool_key:
-            self.btn_rectangle.setChecked(True)
-            self.set_tool('rectangle')
+            self.select_draw_tool('rectangle')
             return
         elif key_text == poly_tool_key:
-            self.btn_polygon.setChecked(True)
-            self.set_tool('polygon')
+            self.select_draw_tool('polygon')
             return
         elif key_text == move_tool_key:
             self.btn_move.setChecked(True)

--- a/gui/pages/import_page.py
+++ b/gui/pages/import_page.py
@@ -14,7 +14,7 @@ from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QIcon
 import cv2
 import numpy as np
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 import os
 
 from gui.styles import COLORS
@@ -64,16 +64,16 @@ class ImageLoadWorker(QThread):
     image_loaded = pyqtSignal(int, object, str)  # 索引, 缩略图, 存储路径
     finished_loading = pyqtSignal()
     
-    def __init__(self, images: List[Dict]):
+    def __init__(self, image_tasks: List[Tuple[int, Dict]]):
         super().__init__()
-        self.images = images
+        self.image_tasks = image_tasks
         self._is_running = True
     
     def run(self):
         """在后台线程中加载图片"""
-        total = len(self.images)
+        total = len(self.image_tasks)
         
-        for i, image_data in enumerate(self.images):
+        for task_index, (row_index, image_data) in enumerate(self.image_tasks):
             if not self._is_running:
                 break
             
@@ -101,11 +101,11 @@ class ImageLoadWorker(QThread):
                 pixmap.fill(QColor(COLORS['sidebar']))
             
             # 发送信号到主线程更新UI
-            self.image_loaded.emit(i, pixmap, storage_path)
-            self.progress.emit(i + 1, total)
+            self.image_loaded.emit(row_index, pixmap, storage_path)
+            self.progress.emit(task_index + 1, total)
             
             # 每加载10张图片休眠一下，让UI有机会更新
-            if i % 10 == 0:
+            if task_index % 10 == 0:
                 self.msleep(1)
         
         self.finished_loading.emit()
@@ -124,8 +124,26 @@ class ImportPage(QWidget):
         self.images = []
         self.thumbnail_cache = {}
         self.load_worker = None
+        self._image_load_generation = 0
         self.thumbnail_widgets = []  # 存储缩略图控件引用
         self.init_ui()
+
+    def _remove_cached_thumbnails(self, storage_paths):
+        """按路径移除缩略图缓存。"""
+        for path in storage_paths:
+            if path in self.thumbnail_cache:
+                del self.thumbnail_cache[path]
+
+    def stop_image_loading(self, reset_progress: bool = True):
+        """停止当前缩略图加载线程，并可选清理进度状态。"""
+        self._image_load_generation += 1
+        if self.load_worker and self.load_worker.isRunning():
+            self.load_worker.stop()
+            self.load_worker.wait()
+        self.load_worker = None
+        if reset_progress and hasattr(self, 'progress_bar'):
+            self.progress_bar.setVisible(False)
+            self.progress_bar.setValue(0)
     
     def init_ui(self):
         """初始化界面"""
@@ -339,8 +357,22 @@ class ImportPage(QWidget):
         layout.addWidget(self.status_pending)
         
         layout.addStretch()
+
+        self.btn_refresh_status = QPushButton("刷新")
+        self.btn_refresh_status.setObjectName("secondary")
+        self.btn_refresh_status.setMinimumWidth(72)
+        self.btn_refresh_status.setFixedHeight(34)
+        self.btn_refresh_status.setToolTip("重新读取当前项目的图片与标注状态")
+        self.btn_refresh_status.clicked.connect(self.refresh_project_images)
+        layout.addWidget(self.btn_refresh_status)
+        self._update_refresh_button_state()
         
         return status_bar
+
+    def _update_refresh_button_state(self):
+        """根据当前项目状态更新刷新按钮可用性。"""
+        if hasattr(self, 'btn_refresh_status'):
+            self.btn_refresh_status.setEnabled(bool(self.current_project_id))
     
     def load_projects(self):
         """加载项目列表"""
@@ -350,22 +382,34 @@ class ImportPage(QWidget):
         projects = db.get_all_projects()
         for project in projects:
             self.project_combo.addItem(project['name'], project['id'])
+        self._update_refresh_button_state()
     
     def on_project_changed(self, index):
         """项目选择改变"""
         project_id = self.project_combo.currentData()
         if project_id:
             self.current_project_id = project_id
+            self._update_refresh_button_state()
             self.load_project_images()
             # 更新任务类别显示
             self.update_task_type_display()
         else:
+            self.stop_image_loading()
             self.current_project_id = None
+            self._update_refresh_button_state()
             self.image_list.clear()
             self.images = []
+            self.thumbnail_widgets.clear()
+            self.progress_bar.setVisible(False)
             self.update_status_bar()
             # 重置任务类别显示
             self.task_type_label.setText("任务类别: 未设置")
+
+    def refresh_project_images(self):
+        """手动刷新当前项目图片与标注状态。"""
+        if not self.current_project_id:
+            return
+        self.load_project_images()
     
     def update_task_type_display(self):
         """更新任务类别显示"""
@@ -593,6 +637,7 @@ class ImportPage(QWidget):
         
         if reply == QMessageBox.StandardButton.Yes:
             try:
+                self.stop_image_loading()
                 # 获取项目信息，包括存储路径
                 project = db.get_project(project_id)
                 project_storage_path = project.get('storage_path', '') if project else ''
@@ -611,12 +656,13 @@ class ImportPage(QWidget):
                 
                 # 清空当前项目ID
                 self.current_project_id = None
+                removed_storage_paths = [img.get('storage_path', '') for img in self.images]
                 
                 # 清空图片列表
                 self.image_list.clear()
                 self.images = []
                 self.thumbnail_widgets.clear()
-                self.thumbnail_cache.clear()
+                self._remove_cached_thumbnails(removed_storage_paths)
                 
                 # 更新状态栏
                 self.update_status_bar()
@@ -633,26 +679,26 @@ class ImportPage(QWidget):
         """加载项目图像 - 使用多线程"""
         if not self.current_project_id:
             return
-        
-        # 停止之前的加载
-        if self.load_worker and self.load_worker.isRunning():
-            self.load_worker.stop()
-            self.load_worker.wait()
+
+        # 停止之前的加载，并创建新的加载世代
+        self.stop_image_loading(reset_progress=False)
+        current_generation = self._image_load_generation
         
         # 清空列表
         self.image_list.clear()
         self.thumbnail_widgets.clear()
-        self.thumbnail_cache.clear()
         
         # 从数据库获取图片列表（很快）
         self.images = db.get_project_images(self.current_project_id)
         self.update_status_bar()
         
         if not self.images:
+            self.progress_bar.setVisible(False)
             return
         
         # 先创建所有列表项（显示占位符）
-        for image_data in self.images:
+        uncached_tasks = []
+        for index, image_data in enumerate(self.images):
             item = QListWidgetItem()
             item.setData(Qt.ItemDataRole.UserRole, image_data['id'])
             item.setText(image_data['filename'])
@@ -665,27 +711,48 @@ class ImportPage(QWidget):
             
             # 设置项目大小提示，确保即使没有图标也有足够高度
             item.setSizeHint(QSize(180, 200))
+
+            storage_path = image_data.get('storage_path', '')
+            cached_pixmap = self.thumbnail_cache.get(storage_path)
+            if cached_pixmap is not None and not cached_pixmap.isNull():
+                item.setIcon(QIcon(cached_pixmap))
+            else:
+                uncached_tasks.append((index, image_data))
             
             self.image_list.addItem(item)
+
+        self.filter_images(self.view_combo.currentText())
         
-        # 显示加载遮罩
-        self.loading_overlay = LoadingOverlay(self, f"正在加载 {len(self.images)} 张图片...")
-        self.loading_overlay.show_loading()
-        
-        # 显示进度条
+        if not uncached_tasks:
+            self.progress_bar.setVisible(False)
+            return
+
+        # 仅对未命中的缩略图显示非阻塞进度条
         self.progress_bar.setVisible(True)
-        self.progress_bar.setMaximum(len(self.images))
+        self.progress_bar.setMaximum(len(uncached_tasks))
         self.progress_bar.setValue(0)
         
         # 启动后台加载线程
-        self.load_worker = ImageLoadWorker(self.images)
-        self.load_worker.image_loaded.connect(self.on_image_loaded)
-        self.load_worker.progress.connect(self.on_load_progress)
-        self.load_worker.finished_loading.connect(self.on_load_finished)
+        self.load_worker = ImageLoadWorker(uncached_tasks)
+        self.load_worker.image_loaded.connect(
+            lambda index, pixmap, storage_path, generation=current_generation: self.on_image_loaded(
+                generation, index, pixmap, storage_path
+            )
+        )
+        self.load_worker.progress.connect(
+            lambda current, total, generation=current_generation: self.on_load_progress(
+                generation, current, total
+            )
+        )
+        self.load_worker.finished_loading.connect(
+            lambda generation=current_generation: self.on_load_finished(generation)
+        )
         self.load_worker.start()
     
-    def on_image_loaded(self, index: int, pixmap: QPixmap, storage_path: str):
+    def on_image_loaded(self, generation: int, index: int, pixmap: QPixmap, storage_path: str):
         """单个图片加载完成回调（在主线程执行）"""
+        if generation != self._image_load_generation:
+            return
         if index < self.image_list.count():
             item = self.image_list.item(index)
             if item:
@@ -695,19 +762,18 @@ class ImportPage(QWidget):
                 # 缓存
                 self.thumbnail_cache[storage_path] = pixmap
     
-    def on_load_progress(self, current: int, total: int):
+    def on_load_progress(self, generation: int, current: int, total: int):
         """加载进度回调"""
+        if generation != self._image_load_generation:
+            return
         self.progress_bar.setValue(current)
-        if hasattr(self, 'loading_overlay'):
-            self.loading_overlay.label.setText(f"正在加载... {current}/{total}")
     
-    def on_load_finished(self):
+    def on_load_finished(self, generation: int):
         """加载完成回调"""
+        if generation != self._image_load_generation:
+            return
+        self.load_worker = None
         self.progress_bar.setVisible(False)
-        if hasattr(self, 'loading_overlay'):
-            self.loading_overlay.hide_loading()
-            self.loading_overlay.deleteLater()
-            delattr(self, 'loading_overlay')
     
     def filter_images(self, filter_text: str):
         """筛选图像"""
@@ -1302,6 +1368,7 @@ class ImportPage(QWidget):
         )
         
         if reply == QMessageBox.StandardButton.Yes:
+            self.stop_image_loading()
             deleted = 0
             failed = 0
             
@@ -1315,9 +1382,11 @@ class ImportPage(QWidget):
 
             # 全部删除成功时，直接本地清空，避免触发整页重载
             if failed == 0:
+                removed_storage_paths = [img.get('storage_path', '') for img in self.images]
                 self.images.clear()
                 self.image_list.clear()
-                self.thumbnail_cache.clear()
+                self.thumbnail_widgets.clear()
+                self._remove_cached_thumbnails(removed_storage_paths)
                 self.update_status_bar()
             else:
                 # 部分失败时回退到全量重载，确保UI与数据库一致
@@ -1344,7 +1413,8 @@ class ImportPage(QWidget):
         
         if reply != QMessageBox.StandardButton.Yes:
             return
-        
+
+        self.stop_image_loading()
         deleted = 0
         failed = 0
         deleted_ids = []

--- a/gui/pages/train_page.py
+++ b/gui/pages/train_page.py
@@ -5,9 +5,10 @@ from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QComboBox, QSpinBox, QDoubleSpinBox, QGroupBox, QFormLayout,
     QCheckBox, QSlider, QProgressBar, QTextEdit, QSplitter,
-    QTabWidget, QFileDialog, QMessageBox, QScrollArea, QFrame
+    QTabWidget, QFileDialog, QMessageBox, QScrollArea, QFrame,
+    QInputDialog
 )
-from PyQt6.QtCore import Qt, pyqtSignal, QThread
+from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSettings
 import os
 import json
 import shutil
@@ -96,6 +97,64 @@ SIZE_NAMES = {
     "b": "balanced (平衡)",
     "u": "ultra (超大)",
 }
+
+NO_TEMPLATE_OPTION = "不使用模板"
+
+
+class NoWheelSpinBox(QSpinBox):
+    """未聚焦时忽略滚轮，交给外层滚动区域处理。"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def wheelEvent(self, event):
+        if self.hasFocus():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
+
+
+class NoWheelDoubleSpinBox(QDoubleSpinBox):
+    """未聚焦时忽略滚轮，交给外层滚动区域处理。"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def wheelEvent(self, event):
+        if self.hasFocus():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
+
+
+class NoWheelComboBox(QComboBox):
+    """未聚焦时忽略滚轮，交给外层滚动区域处理。"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def wheelEvent(self, event):
+        if self.hasFocus():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
+
+
+class NoWheelSlider(QSlider):
+    """未聚焦时忽略滚轮，交给外层滚动区域处理。"""
+
+    def __init__(self, orientation, *args, **kwargs):
+        super().__init__(orientation, *args, **kwargs)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def wheelEvent(self, event):
+        if self.hasFocus():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
 
 
 class TrainingThread(QThread):
@@ -583,8 +642,11 @@ class TrainPage(QWidget):
         self.current_project_id = None
         self.training_thread = None
         self.training_history = []
+        self.settings = QSettings("EzYOLO", "Settings")
+        self.training_templates = {}
         
         self.init_ui()
+        self.load_training_templates()
     
     def set_project(self, project_id: int):
         """设置当前项目"""
@@ -655,6 +717,9 @@ class TrainPage(QWidget):
         title.setObjectName("title")
         title.setStyleSheet("font-size: 20px; font-weight: bold;")
         layout.addWidget(title)
+
+        template_bar = self.create_template_bar()
+        layout.addWidget(template_bar)
         
         # 创建滚动区域
         scroll = QScrollArea()
@@ -690,6 +755,50 @@ class TrainPage(QWidget):
         layout.addWidget(scroll)
         
         return panel
+
+    def create_template_bar(self) -> QWidget:
+        """创建训练模板工具条。"""
+        bar = QFrame()
+        bar.setStyleSheet(f"""
+            QFrame {{
+                background-color: {COLORS['panel']};
+                border: 1px solid {COLORS['border']};
+                border-radius: 6px;
+            }}
+        """)
+        layout = QVBoxLayout(bar)
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(8)
+
+        top_row = QHBoxLayout()
+        top_row.setSpacing(8)
+        top_row.addWidget(QLabel("训练模板:"))
+
+        self.template_combo = NoWheelComboBox()
+        self.template_combo.currentTextChanged.connect(self.on_template_selection_changed)
+        top_row.addWidget(self.template_combo, 1)
+        layout.addLayout(top_row)
+
+        button_row = QHBoxLayout()
+        button_row.setSpacing(8)
+        self.btn_apply_template = QPushButton("套用模板")
+        self.btn_apply_template.clicked.connect(self.apply_selected_template)
+        button_row.addWidget(self.btn_apply_template)
+
+        self.btn_save_template = QPushButton("保存为模板")
+        self.btn_save_template.clicked.connect(self.save_current_as_template)
+        button_row.addWidget(self.btn_save_template)
+
+        self.btn_update_template = QPushButton("更新模板")
+        self.btn_update_template.clicked.connect(self.update_selected_template)
+        button_row.addWidget(self.btn_update_template)
+
+        self.btn_delete_template = QPushButton("删除模板")
+        self.btn_delete_template.clicked.connect(self.delete_selected_template)
+        button_row.addWidget(self.btn_delete_template)
+
+        layout.addLayout(button_row)
+        return bar
     
     def get_group_style(self) -> str:
         """获取分组框样式"""
@@ -717,17 +826,17 @@ class TrainPage(QWidget):
         layout.setSpacing(10)
         
         # YOLO版本选择
-        self.model_version = QComboBox()
+        self.model_version = NoWheelComboBox()
         self.model_version.addItems(sorted(ULTRALYTICS_MODELS.keys()))
         self.model_version.currentTextChanged.connect(self.on_version_changed)
         layout.addRow("版本:", self.model_version)
         
         # 模型型号选择
-        self.model_size = QComboBox()
+        self.model_size = NoWheelComboBox()
         layout.addRow("型号:", self.model_size)
         
         # 任务类型
-        self.task_type = QComboBox()
+        self.task_type = NoWheelComboBox()
         layout.addRow("任务:", self.task_type)
         
         # 立即初始化型号和任务列表
@@ -769,26 +878,26 @@ class TrainPage(QWidget):
         layout.setSpacing(10)
         
         # Epochs
-        self.epochs = QSpinBox()
+        self.epochs = NoWheelSpinBox()
         self.epochs.setRange(1, 1000)
         self.epochs.setValue(100)
         layout.addRow("Epochs:", self.epochs)
         
         # Batch Size
-        self.batch_size = QSpinBox()
+        self.batch_size = NoWheelSpinBox()
         self.batch_size.setRange(1, 128)
         self.batch_size.setValue(16)
         layout.addRow("Batch Size:", self.batch_size)
         
         # Image Size
-        self.img_size = QSpinBox()
+        self.img_size = NoWheelSpinBox()
         self.img_size.setRange(320, 1280)
         self.img_size.setValue(640)
         self.img_size.setSingleStep(32)
         layout.addRow("Image Size:", self.img_size)
         
         # Learning Rate
-        self.lr = QDoubleSpinBox()
+        self.lr = NoWheelDoubleSpinBox()
         self.lr.setRange(0.0001, 0.1)
         self.lr.setValue(0.01)
         self.lr.setDecimals(4)
@@ -796,17 +905,17 @@ class TrainPage(QWidget):
         layout.addRow("Learning Rate:", self.lr)
         
         # Optimizer
-        self.optimizer = QComboBox()
+        self.optimizer = NoWheelComboBox()
         self.optimizer.addItems(["SGD", "Adam", "AdamW", "LION"])
         layout.addRow("Optimizer:", self.optimizer)
         
         # Device
-        self.device = QComboBox()
+        self.device = NoWheelComboBox()
         self.device.addItems(["自动选择", "CPU", "CUDA:0", "CUDA:1", "CUDA:2", "CUDA:3"])
         layout.addRow("Device:", self.device)
         
         # Workers
-        self.workers = QSpinBox()
+        self.workers = NoWheelSpinBox()
         self.workers.setRange(0, 32)
         self.workers.setValue(4)
         self.workers.setSingleStep(1)
@@ -845,7 +954,7 @@ class TrainPage(QWidget):
         self.hsv = QCheckBox("HSV增强")
         self.hsv.setChecked(True)
         hsv_layout.addWidget(self.hsv)
-        self.hsv_strength = QSlider(Qt.Orientation.Horizontal)
+        self.hsv_strength = NoWheelSlider(Qt.Orientation.Horizontal)
         self.hsv_strength.setRange(0, 100)
         self.hsv_strength.setValue(50)
         hsv_layout.addWidget(self.hsv_strength)
@@ -862,7 +971,7 @@ class TrainPage(QWidget):
         layout.setSpacing(10)
         
         # 训练集比例
-        self.train_split = QSlider(Qt.Orientation.Horizontal)
+        self.train_split = NoWheelSlider(Qt.Orientation.Horizontal)
         self.train_split.setRange(50, 95)
         self.train_split.setValue(80)
         self.train_split.valueChanged.connect(self.on_split_changed)
@@ -873,7 +982,7 @@ class TrainPage(QWidget):
         layout.addRow("训练集:", split_layout)
         
         # 验证集比例
-        self.val_split = QSlider(Qt.Orientation.Horizontal)
+        self.val_split = NoWheelSlider(Qt.Orientation.Horizontal)
         self.val_split.setRange(5, 30)
         self.val_split.setValue(10)
         self.val_split.valueChanged.connect(self.on_split_changed)
@@ -884,7 +993,7 @@ class TrainPage(QWidget):
         layout.addRow("验证集:", split_layout)
         
         # 测试集比例
-        self.test_split = QSlider(Qt.Orientation.Horizontal)
+        self.test_split = NoWheelSlider(Qt.Orientation.Horizontal)
         self.test_split.setRange(0, 20)
         self.test_split.setValue(10)
         self.test_split.valueChanged.connect(self.on_split_changed)
@@ -973,6 +1082,271 @@ class TrainPage(QWidget):
         layout.addLayout(btn_layout)
         
         return group
+
+    def load_training_templates(self):
+        """加载全局训练模板。"""
+        raw_templates = self.settings.value("training_templates", "{}")
+        try:
+            templates = json.loads(raw_templates) if raw_templates else {}
+        except (TypeError, json.JSONDecodeError):
+            templates = {}
+
+        self.training_templates = templates if isinstance(templates, dict) else {}
+        selected_name = str(self.settings.value("training_selected_template", NO_TEMPLATE_OPTION))
+
+        self.template_combo.blockSignals(True)
+        self.template_combo.clear()
+        self.template_combo.addItem(NO_TEMPLATE_OPTION)
+        for template_name in sorted(self.training_templates.keys()):
+            self.template_combo.addItem(template_name)
+
+        if selected_name in self.training_templates:
+            self.template_combo.setCurrentText(selected_name)
+        else:
+            self.template_combo.setCurrentText(NO_TEMPLATE_OPTION)
+        self.template_combo.blockSignals(False)
+        self.refresh_template_ui_state()
+        self.save_training_templates()
+
+    def save_training_templates(self):
+        """保存全局训练模板。"""
+        self.settings.setValue(
+            "training_templates",
+            json.dumps(self.training_templates, ensure_ascii=False)
+        )
+        current_name = self.template_combo.currentText() if hasattr(self, "template_combo") else NO_TEMPLATE_OPTION
+        self.settings.setValue(
+            "training_selected_template",
+            current_name if current_name in self.training_templates else NO_TEMPLATE_OPTION
+        )
+
+    def on_template_selection_changed(self, _text: str):
+        """模板选择变化。"""
+        self.refresh_template_ui_state()
+        self.save_training_templates()
+
+    def refresh_template_ui_state(self):
+        """刷新模板相关按钮状态。"""
+        current_name = self.template_combo.currentText() if hasattr(self, "template_combo") else NO_TEMPLATE_OPTION
+        has_template = current_name in self.training_templates
+        self.btn_apply_template.setEnabled(has_template)
+        self.btn_update_template.setEnabled(has_template)
+        self.btn_delete_template.setEnabled(has_template)
+
+    def collect_training_form_config(self) -> dict:
+        """收集当前表单配置。"""
+        return {
+            'version': self.model_version.currentText(),
+            'model_size': self.model_size.currentData(),
+            'task': self.task_type.currentData(),
+            'epochs': self.epochs.value(),
+            'batch_size': self.batch_size.value(),
+            'img_size': self.img_size.value(),
+            'lr': self.lr.value(),
+            'optimizer': self.optimizer.currentText(),
+            'device': self.device.currentText(),
+            'workers': self.workers.value(),
+            'mosaic': self.mosaic.isChecked(),
+            'mixup': self.mixup.isChecked(),
+            'flip': self.flip.isChecked(),
+            'rotate': self.rotate.isChecked(),
+            'hsv': self.hsv.isChecked(),
+            'hsv_strength': self.hsv_strength.value(),
+            'train_split': self.train_split.value(),
+            'val_split': self.val_split.value(),
+            'test_split': self.test_split.value(),
+        }
+
+    def _set_combo_by_text(self, combo: QComboBox, value: str) -> bool:
+        index = combo.findText(value)
+        if index < 0:
+            return False
+        combo.setCurrentIndex(index)
+        return True
+
+    def _set_combo_by_data(self, combo: QComboBox, value: str) -> bool:
+        index = combo.findData(value)
+        if index < 0:
+            return False
+        combo.setCurrentIndex(index)
+        return True
+
+    def apply_training_form_config(self, config: dict) -> bool:
+        """将配置写回到训练页面表单。"""
+        version = config.get('version')
+        if version not in ULTRALYTICS_MODELS:
+            QMessageBox.warning(self, "模板无效", f"模板中的模型版本不可用: {version}")
+            return False
+
+        if not self._set_combo_by_text(self.model_version, version):
+            QMessageBox.warning(self, "模板无效", f"无法切换到模板中的模型版本: {version}")
+            return False
+        self.on_version_changed(version)
+
+        model_size = config.get('model_size')
+        task = config.get('task')
+        if not self._set_combo_by_data(self.model_size, model_size):
+            QMessageBox.warning(self, "模板无效", f"模板中的模型型号不可用: {model_size}")
+            return False
+        if not self._set_combo_by_data(self.task_type, task):
+            QMessageBox.warning(self, "模板无效", f"模板中的任务类型不可用: {task}")
+            return False
+
+        self.epochs.setValue(int(config.get('epochs', self.epochs.value())))
+        self.batch_size.setValue(int(config.get('batch_size', self.batch_size.value())))
+        self.img_size.setValue(int(config.get('img_size', self.img_size.value())))
+        self.lr.setValue(float(config.get('lr', self.lr.value())))
+        self._set_combo_by_text(self.optimizer, str(config.get('optimizer', self.optimizer.currentText())))
+        self._set_combo_by_text(self.device, str(config.get('device', self.device.currentText())))
+        self.workers.setValue(int(config.get('workers', self.workers.value())))
+
+        self.mosaic.setChecked(bool(config.get('mosaic', self.mosaic.isChecked())))
+        self.mixup.setChecked(bool(config.get('mixup', self.mixup.isChecked())))
+        self.flip.setChecked(bool(config.get('flip', self.flip.isChecked())))
+        self.rotate.setChecked(bool(config.get('rotate', self.rotate.isChecked())))
+        self.hsv.setChecked(bool(config.get('hsv', self.hsv.isChecked())))
+        self.hsv_strength.setValue(int(config.get('hsv_strength', self.hsv_strength.value())))
+
+        self.train_split.setValue(int(config.get('train_split', self.train_split.value())))
+        self.val_split.setValue(int(config.get('val_split', self.val_split.value())))
+        self.test_split.setValue(int(config.get('test_split', self.test_split.value())))
+        self.on_split_changed()
+        return True
+
+    def save_current_as_template(self):
+        """将当前页面配置保存为模板。"""
+        template_name, ok = QInputDialog.getText(self, "保存训练模板", "请输入模板名称:")
+        template_name = template_name.strip()
+        if not ok or not template_name:
+            return
+        if template_name == NO_TEMPLATE_OPTION:
+            QMessageBox.warning(self, "模板名称无效", f"“{NO_TEMPLATE_OPTION}”是保留名称，请换一个模板名")
+            return
+
+        if template_name in self.training_templates:
+            reply = QMessageBox.question(
+                self,
+                "覆盖模板",
+                f"模板“{template_name}”已存在，是否覆盖？",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return
+
+        self.training_templates[template_name] = self.collect_training_form_config()
+        self.save_training_templates()
+        self.load_training_templates()
+        self.template_combo.setCurrentText(template_name)
+
+    def update_selected_template(self):
+        """用当前页面参数覆盖当前模板。"""
+        template_name = self.template_combo.currentText()
+        if template_name not in self.training_templates:
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "更新模板",
+            f"确认用当前页面参数覆盖模板“{template_name}”？",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self.training_templates[template_name] = self.collect_training_form_config()
+        self.save_training_templates()
+
+    def delete_selected_template(self):
+        """删除当前选中的模板。"""
+        template_name = self.template_combo.currentText()
+        if template_name not in self.training_templates:
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "删除模板",
+            f"确认删除模板“{template_name}”？",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self.training_templates.pop(template_name, None)
+        self.save_training_templates()
+        self.load_training_templates()
+
+    def apply_selected_template(self):
+        """立即套用当前选中的模板。"""
+        template_name = self.template_combo.currentText()
+        template_config = self.training_templates.get(template_name)
+        if not template_config:
+            return
+        if self.apply_training_form_config(template_config):
+            self.template_combo.setCurrentText(template_name)
+
+    def maybe_confirm_template_before_training(self) -> Optional[dict]:
+        """训练前确认是否使用当前模板。"""
+        template_name = self.template_combo.currentText()
+        if template_name not in self.training_templates:
+            return self.collect_training_form_config()
+
+        message_box = QMessageBox(self)
+        message_box.setIcon(QMessageBox.Icon.Question)
+        message_box.setWindowTitle("使用训练模板")
+        message_box.setText(f"当前已选择训练模板“{template_name}”，本次训练是否使用该模板？")
+        use_template_button = message_box.addButton("使用模板", QMessageBox.ButtonRole.AcceptRole)
+        use_current_button = message_box.addButton("使用当前页面参数", QMessageBox.ButtonRole.DestructiveRole)
+        cancel_button = message_box.addButton("取消", QMessageBox.ButtonRole.RejectRole)
+        message_box.setDefaultButton(use_template_button)
+        message_box.exec()
+
+        clicked = message_box.clickedButton()
+        if clicked == cancel_button:
+            return None
+        if clicked == use_current_button:
+            return self.collect_training_form_config()
+
+        template_config = self.training_templates.get(template_name)
+        if not template_config:
+            return self.collect_training_form_config()
+        if not self.apply_training_form_config(template_config):
+            return None
+        return self.collect_training_form_config()
+
+    def build_training_runtime_config(self, form_config: dict) -> Optional[dict]:
+        """将表单配置转换为训练线程使用的配置。"""
+        version = form_config.get('version')
+        model_size = form_config.get('model_size')
+        task = form_config.get('task')
+
+        if not version or version not in ULTRALYTICS_MODELS or not model_size or not task:
+            return None
+
+        return {
+            'version': version,
+            'model_prefix': ULTRALYTICS_MODELS[version]['prefix'],
+            'model_size': model_size,
+            'task': task,
+            'epochs': form_config['epochs'],
+            'batch_size': form_config['batch_size'],
+            'img_size': form_config['img_size'],
+            'lr': form_config['lr'],
+            'optimizer': form_config['optimizer'],
+            'device': form_config['device'],
+            'workers': form_config['workers'],
+            'mosaic': form_config['mosaic'],
+            'mixup': 0.1 if form_config['mixup'] else 0.0,
+            'flip': form_config['flip'],
+            'rotate': form_config['rotate'],
+            'hsv': form_config['hsv'],
+            'hsv_strength': form_config['hsv_strength'],
+            'train_split': form_config['train_split'],
+            'val_split': form_config['val_split'],
+            'test_split': form_config['test_split'],
+        }
     
     def create_monitor_panel(self) -> QWidget:
         """创建监控面板"""
@@ -1138,53 +1512,30 @@ class TrainPage(QWidget):
     
     def start_training(self):
         """开始训练"""
-        # 检查数据集划分
-        train = self.train_split.value()
-        val = self.val_split.value()
-        test = self.test_split.value()
-        
-        if train + val + test != 100:
-            QMessageBox.warning(self, "配置错误", "数据集划分比例总和必须等于100%")
-            return
-        
         # 检查是否选择了项目
         if not self.current_project_id:
             QMessageBox.warning(self, "错误", "请先选择一个项目")
             return
-        
-        # 获取模型配置
-        version = self.model_version.currentText()
-        model_size = self.model_size.currentData()
-        task = self.task_type.currentData()
-        
-        if not version or not model_size:
-            QMessageBox.warning(self, "错误", "请选择模型版本和型号")
+
+        form_config = self.maybe_confirm_template_before_training()
+        if form_config is None:
             return
-        
-        model_prefix = ULTRALYTICS_MODELS[version]['prefix']
-        
-        # 收集配置
-        config = {
-            'model_prefix': model_prefix,
-            'model_size': model_size,
-            'task': task,
-            'epochs': self.epochs.value(),
-            'batch_size': self.batch_size.value(),
-            'img_size': self.img_size.value(),
-            'lr': self.lr.value(),
-            'optimizer': self.optimizer.currentText(),
-            'device': self.device.currentText(),
-            'workers': self.workers.value(),
-            'mosaic': self.mosaic.isChecked(),
-            'mixup': 0.1 if self.mixup.isChecked() else 0.0,
-            'flip': self.flip.isChecked(),
-            'rotate': self.rotate.isChecked(),
-            'hsv': self.hsv.isChecked(),
-            'hsv_strength': self.hsv_strength.value(),
-            'train_split': train,
-            'val_split': val,
-            'test_split': test,
-        }
+
+        train = form_config['train_split']
+        val = form_config['val_split']
+        test = form_config['test_split']
+        if train + val + test != 100:
+            QMessageBox.warning(self, "配置错误", "数据集划分比例总和必须等于100%")
+            return
+
+        config = self.build_training_runtime_config(form_config)
+        if not config:
+            QMessageBox.warning(self, "错误", "请选择有效的模型版本和型号")
+            return
+
+        version = config['version']
+        model_size = config['model_size']
+        task = config['task']
         
         # 清空历史
         self.training_history = []


### PR DESCRIPTION
## 变更内容

- 修复导入页缩略图加载线程在切项目、删项目、清空列表时的残留回写问题
- 新增导入页手动刷新标注状态按钮
- 修复标注页工具栏布局、绘制工具切换和删除当前图片能力
- 优化标注页样本统计与随机删样本性能
- 训练页增加滚轮防误改
- 训练页增加全局训练模板，并在开始训练前支持模板确认

## 验证

- python -m py_compile gui/pages/import_page.py gui/pages/train_page.py gui/pages/annotate_page.py
- 关键页面可正常实例化
****