### PR TITLE
完善 EzYOLO 全流程界面、任务反馈与跨平台标注交互

### DIFF
--- a/core/import_manager.py
+++ b/core/import_manager.py
@@ -5,6 +5,8 @@
 """
 
 import os
+import math
+import random
 import shutil
 import hashlib
 import threading
@@ -16,6 +18,69 @@ from PIL import Image
 import numpy as np
 
 from models.database import db
+
+# 抽帧方式
+VIDEO_MODE_INTERVAL = 'interval'   # 每 N 帧取 1 张
+VIDEO_MODE_RANDOM = 'random'       # 随机取 N 张
+
+
+def probe_video_metadata(video_path: str) -> Dict:
+    """只读一下视频的元信息，不解码、不导入任何一帧。
+
+    抽帧弹窗要先知道「这段视频有多少帧、多少 fps」才能给出预计张数和建议，
+    但那时候用户还没确认导入——所以这里只开一下文件读几个属性就关掉。
+
+    Returns:
+        {'total_frames': int, 'fps': float, 'duration': float | None}
+        总帧数 / fps 读不到时为 0，duration 相应为 None（不是所有容器都写了这些）。
+    """
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise ValueError(f"无法打开视频: {video_path}")
+
+    try:
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        fps = float(cap.get(cv2.CAP_PROP_FPS))
+    finally:
+        cap.release()
+
+    # 有的视频（尤其是流式录制的）这两个值是 0、负数甚至 nan，一律当「不知道」
+    if total_frames <= 0:
+        total_frames = 0
+    if not math.isfinite(fps) or fps <= 0:
+        fps = 0.0
+
+    duration = (total_frames / fps) if (total_frames and fps) else None
+
+    return {'total_frames': total_frames, 'fps': fps, 'duration': duration}
+
+
+def estimate_interval_frame_count(total_frames: int, frame_interval: int) -> Optional[int]:
+    """固定间隔能抽出多少张。总帧数未知时返回 None。
+
+    向上取整：31 帧、间隔 30，第 0 帧和第 30 帧都会被抽到，是 2 张不是 1 张。
+    """
+    if total_frames <= 0 or frame_interval < 1:
+        return None
+    return (total_frames + frame_interval - 1) // frame_interval
+
+
+def plan_random_frame_indices(total_frames: int, sample_count: int,
+                              rng: Optional[random.Random] = None) -> List[int]:
+    """随机挑 sample_count 个帧号，去重后按升序返回。
+
+    升序是硬要求：抽帧是顺序解码一遍视频、路过选中的帧就存下来，
+    帧号乱序的话就得来回 seek（很多容器 seek 不准），或者把整段视频缓存起来。
+    要几张就是几张（不会重复抽到同一帧），要得比总帧数还多时按总帧数封顶。
+    """
+    if total_frames <= 0:
+        raise ValueError("总帧数未知，无法随机抽取固定张数")
+    if sample_count < 1:
+        raise ValueError("随机抽取的张数至少是 1")
+
+    count = min(sample_count, total_frames)
+    generator = rng if rng is not None else random.Random()
+    return sorted(generator.sample(range(total_frames), count))
 
 
 class ImportManager:
@@ -238,19 +303,36 @@ class ImportManager:
     
     def import_video(self, video_path: str, frame_interval: int = 1,
                     progress_callback: Callable[[int, str], None] = None,
-                    cancel_event: Optional[threading.Event] = None) -> Tuple[int, int]:
+                    cancel_event: Optional[threading.Event] = None,
+                    mode: str = VIDEO_MODE_INTERVAL,
+                    sample_count: Optional[int] = None,
+                    rng: Optional[random.Random] = None) -> Tuple[int, int]:
         """
         从视频中抽取帧导入
 
+        两种抽法：
+            interval —— 每 frame_interval 帧取 1 张（默认，老行为）
+            random   —— 从整段视频里随机取 sample_count 张，帧号不重复
+
+        随机抽取也只顺序解码一遍：先把要的帧号排好序，路过就存，
+        最后一个要的帧存完就收工（后面的帧不再解码）。不 seek——
+        很多容器按帧号 seek 不准，会取到隔壁的帧甚至取不到。
+
         Args:
             video_path: 视频文件路径
-            frame_interval: 抽帧间隔（每隔多少帧抽取一帧）
+            frame_interval: 抽帧间隔（每隔多少帧抽取一帧），仅 interval 模式用
             progress_callback: 进度回调函数；进度为 -1 表示总帧数未知，
                 调用方应显示忙碌态而非具体百分比
             cancel_event: 取消信号，每帧读取后检查一次，最迟在下一帧边界停止
+            mode: VIDEO_MODE_INTERVAL / VIDEO_MODE_RANDOM
+            sample_count: 随机模式要抽的张数
+            rng: 随机源，测试里传一个定种子的 random.Random 就能复现
 
         Returns:
             (成功导入数量, 跳过数量)
+
+        Raises:
+            ValueError: 随机模式但视频读不到总帧数（不知道有多少帧，就没法随机取 N 张）
         """
         video_path = Path(video_path)
         if not video_path.exists():
@@ -268,17 +350,41 @@ class ImportManager:
             raise ValueError(f"无法打开视频: {video_path}")
 
         total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        fps = cap.get(cv2.CAP_PROP_FPS)
+        if total_frames < 0:
+            total_frames = 0
+
+        # 随机模式：先把帧号定下来。定不下来（总帧数未知）就别开始，
+        # 免得解码了半天才发现这活干不了。
+        wanted_frames = None
+        last_wanted = -1
+        target_count = 0
+        if mode == VIDEO_MODE_RANDOM:
+            try:
+                indices = plan_random_frame_indices(total_frames, sample_count or 0, rng)
+            except ValueError:
+                cap.release()
+                raise
+            wanted_frames = set(indices)
+            last_wanted = indices[-1]
+            target_count = len(indices)
 
         if progress_callback:
-            if total_frames > 0:
-                # 向上取整：例如 31 帧、间隔 30，第 0/30 帧都会被抽到，预计 2 张
-                estimated = (total_frames + frame_interval - 1) // frame_interval
+            if wanted_frames is not None:
                 progress_callback(
-                    0, f"视频信息就绪: 共 {total_frames} 帧，间隔 {frame_interval}，预计抽取 {estimated} 张"
+                    0, f"视频信息就绪: 共 {total_frames} 帧，随机抽取 {target_count} 张"
                 )
             else:
-                progress_callback(-1, f"视频总帧数未知，间隔 {frame_interval}，将持续抽帧")
+                estimated = estimate_interval_frame_count(total_frames, frame_interval)
+                if estimated is not None:
+                    progress_callback(
+                        0,
+                        f"视频信息就绪: 共 {total_frames} 帧，按固定间隔 {frame_interval} 抽取，"
+                        f"预计抽取 {estimated} 张",
+                    )
+                else:
+                    progress_callback(
+                        -1, f"视频总帧数未知，按固定间隔 {frame_interval} 抽取，将持续抽帧"
+                    )
 
         imported = 0
         skipped = 0
@@ -288,6 +394,10 @@ class ImportManager:
 
         try:
             while True:
+                # 随机模式：要的帧都过完了就停，别再白解码后面的
+                if wanted_frames is not None and frame_count > last_wanted:
+                    break
+
                 ret, frame = cap.read()
                 if not ret:
                     break
@@ -296,12 +406,24 @@ class ImportManager:
                     cancelled = True
                     break
 
-                # 按间隔抽帧
-                if frame_count % frame_interval == 0:
+                if wanted_frames is not None:
+                    wanted = frame_count in wanted_frames
+                else:
+                    wanted = frame_count % frame_interval == 0
+
+                if wanted:
                     try:
                         # 更新进度
                         if progress_callback:
-                            if total_frames > 0:
+                            if wanted_frames is not None:
+                                progress = int((imported / target_count) * 100)
+                                last_progress = progress
+                                progress_callback(
+                                    progress,
+                                    f"正在抽取第 {frame_count} 帧"
+                                    f"（随机第 {imported + 1}/{target_count} 张）",
+                                )
+                            elif total_frames > 0:
                                 progress = int((frame_count / total_frames) * 100)
                                 last_progress = progress
                                 progress_callback(
@@ -318,8 +440,6 @@ class ImportManager:
                         target_filename = f"{timestamp}_frame_{frame_count:06d}.jpg"
                         target_path = self.images_path / target_filename
 
-                        # 转换颜色空间并保存
-                        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                         cv2.imwrite(str(target_path), frame)
 
                         # 获取图像信息
@@ -352,9 +472,15 @@ class ImportManager:
 
         # 完成进度：取消时保留最后的真实进度，不要显示成 100% 完成
         if progress_callback:
+            if wanted_frames is not None:
+                how = f"随机 {target_count} 张"
+            else:
+                how = f"每 {frame_interval} 帧取 1 张"
             status = "已取消" if cancelled else "视频导入完成"
             final_progress = last_progress if cancelled else 100
-            progress_callback(final_progress, f"{status}: 成功 {imported}, 跳过 {skipped}")
+            progress_callback(
+                final_progress, f"{status}（{how}）: 成功 {imported}, 跳过 {skipped}"
+            )
 
         return imported, skipped
     

--- a/core/import_manager.py
+++ b/core/import_manager.py
@@ -7,6 +7,7 @@
 import os
 import shutil
 import hashlib
+import threading
 from pathlib import Path
 from typing import List, Dict, Tuple, Optional, Callable
 from datetime import datetime
@@ -48,100 +49,132 @@ class ImportManager:
         self.images_path = self.storage_path / "images"
         self.images_path.mkdir(exist_ok=True)
     
-    def import_folder(self, folder_path: str, 
-                     progress_callback: Callable[[int, str], None] = None) -> Tuple[int, int]:
+    def import_folder(self, folder_path: str,
+                     progress_callback: Callable[[int, str], None] = None,
+                     cancel_event: Optional[threading.Event] = None) -> Tuple[int, int]:
         """
         导入文件夹中的所有图像
-        
+
         Args:
             folder_path: 文件夹路径
-            progress_callback: 进度回调函数，参数为(进度百分比, 状态信息)
-            
+            progress_callback: 进度回调函数，参数为(进度百分比, 状态信息)；
+                进度为 -1 表示总量未知/尚在准备，调用方应显示忙碌态而非具体百分比
+            cancel_event: 取消信号，每张图片处理前检查一次，最迟在下一张图片边界停止
+
         Returns:
             (成功导入数量, 跳过数量)
         """
         folder_path = Path(folder_path)
         if not folder_path.exists() or not folder_path.is_dir():
             raise ValueError(f"无效的文件夹路径: {folder_path}")
-        
+
+        if progress_callback:
+            progress_callback(-1, f"正在扫描文件夹: {folder_path.name}")
+
         # 获取所有图像文件
         image_files = []
         for ext in self.SUPPORTED_IMAGE_FORMATS:
             image_files.extend(folder_path.rglob(f"*{ext}"))
             image_files.extend(folder_path.rglob(f"*{ext.upper()}"))
-        
+
         # 去重并排序
         image_files = sorted(set(image_files))
-        
+
         if not image_files:
+            if progress_callback:
+                progress_callback(100, "文件夹中没有找到图片")
             return 0, 0
-        
+
         total = len(image_files)
         imported = 0
         skipped = 0
-        
+        last_progress = 0
+
+        if progress_callback:
+            progress_callback(0, f"共 {total} 张待导入")
+
         for i, image_file in enumerate(image_files):
+            if cancel_event is not None and cancel_event.is_set():
+                break
+
             try:
                 # 更新进度
                 progress = int((i / total) * 100)
+                last_progress = progress
                 if progress_callback:
-                    progress_callback(progress, f"正在导入: {image_file.name}")
-                
+                    progress_callback(progress, f"正在导入: {image_file.name} ({i + 1}/{total})")
+
                 # 导入单张图像
                 result = self.import_single_image(str(image_file))
                 if result:
                     imported += 1
                 else:
                     skipped += 1
-                    
+
             except Exception as e:
                 print(f"导入图像失败 {image_file}: {e}")
                 skipped += 1
-        
-        # 完成进度
+
+        # 完成进度：取消时保留最后的真实进度，不要显示成 100% 完成
         if progress_callback:
-            progress_callback(100, f"导入完成: 成功 {imported}, 跳过 {skipped}")
-        
+            cancelled = cancel_event is not None and cancel_event.is_set()
+            status = "已取消" if cancelled else "导入完成"
+            final_progress = last_progress if cancelled else 100
+            progress_callback(final_progress, f"{status}: 成功 {imported}, 跳过 {skipped}")
+
         return imported, skipped
-    
+
     def import_images(self, file_paths: List[str],
-                     progress_callback: Callable[[int, str], None] = None) -> Tuple[int, int]:
+                     progress_callback: Callable[[int, str], None] = None,
+                     cancel_event: Optional[threading.Event] = None) -> Tuple[int, int]:
         """
         导入多张图像
-        
+
         Args:
             file_paths: 图像文件路径列表
             progress_callback: 进度回调函数
-            
+            cancel_event: 取消信号，每张图片处理前检查一次，最迟在下一张图片边界停止
+
         Returns:
             (成功导入数量, 跳过数量)
         """
         total = len(file_paths)
         imported = 0
         skipped = 0
-        
+        last_progress = 0
+
+        if progress_callback:
+            progress_callback(0, f"正在导入 0/{total} 张图片")
+
         for i, file_path in enumerate(file_paths):
+            if cancel_event is not None and cancel_event.is_set():
+                break
+
             try:
                 # 更新进度
-                progress = int((i / total) * 100)
+                progress = int((i / total) * 100) if total else 100
+                last_progress = progress
                 if progress_callback:
-                    progress_callback(progress, f"正在导入: {Path(file_path).name}")
-                
+                    progress_callback(progress, f"正在导入: {Path(file_path).name} ({i + 1}/{total})")
+
                 # 导入单张图像
                 result = self.import_single_image(file_path)
                 if result:
                     imported += 1
                 else:
                     skipped += 1
-                    
+
             except Exception as e:
                 print(f"导入图像失败 {file_path}: {e}")
                 skipped += 1
-        
-        # 完成进度
+
+        # 完成进度：取消时保留最后的真实进度，不要显示成 100% 完成
         if progress_callback:
-            progress_callback(100, f"导入完成: 成功 {imported}, 跳过 {skipped}")
-        
+            cancelled = cancel_event is not None and cancel_event.is_set()
+            status = "已取消" if cancelled else "导入完成"
+            final_progress = last_progress if cancelled else 100
+            progress_callback(final_progress, f"{status}: 成功 {imported}, 跳过 {skipped}")
+
         return imported, skipped
     
     def import_single_image(self, file_path: str) -> bool:
@@ -204,64 +237,95 @@ class ImportManager:
             return False
     
     def import_video(self, video_path: str, frame_interval: int = 1,
-                    progress_callback: Callable[[int, str], None] = None) -> Tuple[int, int]:
+                    progress_callback: Callable[[int, str], None] = None,
+                    cancel_event: Optional[threading.Event] = None) -> Tuple[int, int]:
         """
         从视频中抽取帧导入
-        
+
         Args:
             video_path: 视频文件路径
             frame_interval: 抽帧间隔（每隔多少帧抽取一帧）
-            progress_callback: 进度回调函数
-            
+            progress_callback: 进度回调函数；进度为 -1 表示总帧数未知，
+                调用方应显示忙碌态而非具体百分比
+            cancel_event: 取消信号，每帧读取后检查一次，最迟在下一帧边界停止
+
         Returns:
             (成功导入数量, 跳过数量)
         """
         video_path = Path(video_path)
         if not video_path.exists():
             raise ValueError(f"视频文件不存在: {video_path}")
-        
+
         if video_path.suffix.lower() not in self.SUPPORTED_VIDEO_FORMATS:
             raise ValueError(f"不支持的视频格式: {video_path.suffix}")
-        
+
+        if progress_callback:
+            progress_callback(-1, f"正在打开视频: {video_path.name}")
+
         # 打开视频
         cap = cv2.VideoCapture(str(video_path))
         if not cap.isOpened():
             raise ValueError(f"无法打开视频: {video_path}")
-        
+
         total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         fps = cap.get(cv2.CAP_PROP_FPS)
-        
+
+        if progress_callback:
+            if total_frames > 0:
+                # 向上取整：例如 31 帧、间隔 30，第 0/30 帧都会被抽到，预计 2 张
+                estimated = (total_frames + frame_interval - 1) // frame_interval
+                progress_callback(
+                    0, f"视频信息就绪: 共 {total_frames} 帧，间隔 {frame_interval}，预计抽取 {estimated} 张"
+                )
+            else:
+                progress_callback(-1, f"视频总帧数未知，间隔 {frame_interval}，将持续抽帧")
+
         imported = 0
         skipped = 0
         frame_count = 0
-        
+        last_progress = 0
+        cancelled = False
+
         try:
             while True:
                 ret, frame = cap.read()
                 if not ret:
                     break
-                
+
+                if cancel_event is not None and cancel_event.is_set():
+                    cancelled = True
+                    break
+
                 # 按间隔抽帧
                 if frame_count % frame_interval == 0:
                     try:
                         # 更新进度
-                        progress = int((frame_count / total_frames) * 100)
                         if progress_callback:
-                            progress_callback(progress, f"正在抽取帧 {frame_count}/{total_frames}")
-                        
+                            if total_frames > 0:
+                                progress = int((frame_count / total_frames) * 100)
+                                last_progress = progress
+                                progress_callback(
+                                    progress,
+                                    f"正在抽取帧 {frame_count}/{total_frames}（已导入 {imported}）",
+                                )
+                            else:
+                                progress_callback(
+                                    -1, f"正在抽取帧 {frame_count}（已导入 {imported}）"
+                                )
+
                         # 保存帧为图像
                         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
                         target_filename = f"{timestamp}_frame_{frame_count:06d}.jpg"
                         target_path = self.images_path / target_filename
-                        
+
                         # 转换颜色空间并保存
                         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                         cv2.imwrite(str(target_path), frame)
-                        
+
                         # 获取图像信息
                         height, width = frame.shape[:2]
                         size = target_path.stat().st_size
-                        
+
                         # 添加到数据库
                         db.add_image(
                             project_id=self.project_id,
@@ -274,22 +338,24 @@ class ImportManager:
                             original_path=str(video_path),
                             group_id=self.group_id,
                         )
-                        
+
                         imported += 1
-                        
+
                     except Exception as e:
                         print(f"保存帧失败 {frame_count}: {e}")
                         skipped += 1
-                
+
                 frame_count += 1
-                
+
         finally:
             cap.release()
-        
-        # 完成进度
+
+        # 完成进度：取消时保留最后的真实进度，不要显示成 100% 完成
         if progress_callback:
-            progress_callback(100, f"视频导入完成: 成功 {imported}, 跳过 {skipped}")
-        
+            status = "已取消" if cancelled else "视频导入完成"
+            final_progress = last_progress if cancelled else 100
+            progress_callback(final_progress, f"{status}: 成功 {imported}, 跳过 {skipped}")
+
         return imported, skipped
     
     def _calculate_file_hash(self, file_path: str) -> str:

--- a/gui/assets/chevron-left.svg
+++ b/gui/assets/chevron-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M7.25 2.75 L4 6 L7.25 9.25" fill="none" stroke="#6E6E73" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron-right.svg
+++ b/gui/assets/chevron-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M4.75 2.75 L8 6 L4.75 9.25" fill="none" stroke="#6E6E73" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron_down.svg
+++ b/gui/assets/chevron_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M2.75 4.5 L6 7.75 L9.25 4.5" fill="none" stroke="#007AFF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron_down_disabled.svg
+++ b/gui/assets/chevron_down_disabled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M2.75 4.5 L6 7.75 L9.25 4.5" fill="none" stroke="#AEAEB2" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron_down_red.svg
+++ b/gui/assets/chevron_down_red.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M2.75 4.5 L6 7.75 L9.25 4.5" fill="none" stroke="#D70015" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron_down_white.svg
+++ b/gui/assets/chevron_down_white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M2.75 4.5 L6 7.75 L9.25 4.5" fill="none" stroke="#FFFFFF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron_up.svg
+++ b/gui/assets/chevron_up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M2.75 7.5 L6 4.25 L9.25 7.5" fill="none" stroke="#007AFF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/chevron_up_disabled.svg
+++ b/gui/assets/chevron_up_disabled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path d="M2.75 7.5 L6 4.25 L9.25 7.5" fill="none" stroke="#AEAEB2" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/gui/assets/lock-closed.svg
+++ b/gui/assets/lock-closed.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M5.25 7.25 V4.75 a2.75 2.75 0 0 1 5.5 0 V7.25" fill="none" stroke="#007AFF" stroke-width="1.4" stroke-linecap="round"/><rect x="4" y="7.25" width="8" height="6.1" rx="1.4" fill="none" stroke="#007AFF" stroke-width="1.4"/></svg>

--- a/gui/assets/lock-open.svg
+++ b/gui/assets/lock-open.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M5.25 7.25 V4.75 a2.75 2.75 0 0 1 5.5 0" fill="none" stroke="#6E6E73" stroke-width="1.4" stroke-linecap="round"/><rect x="2.9" y="7.25" width="8" height="6.1" rx="1.4" fill="none" stroke="#6E6E73" stroke-width="1.4"/></svg>

--- a/gui/display_names.py
+++ b/gui/display_names.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""图片显示名：数据库里存什么还是什么，这里只决定「界面上怎么念它」。
+
+视频抽帧落库的文件名长这样：
+
+    20260712_000602_575947_frame_000223.jpg
+
+时间戳是为了不重名，帧号才是人要看的东西。一屏几十行全是这种名字时，
+前 22 个字符完全一样，用户得横着扫到第 23 位才能分辨两张图——列表再宽也没用。
+所以列表里显示「帧 223」，完整文件名留在 tooltip 里。
+
+普通图片导入时 filename 存的就是用户自己的文件名（时间戳只加在磁盘副本上），
+本来就可读——原样返回，让界面自己去打省略号，不要替用户改写文件名。
+
+只做显示：不改文件名，不动数据库。
+"""
+
+import re
+from collections import defaultdict
+from typing import Dict, List, Optional, Sequence
+
+# 抽帧文件名：<日期>_<时间>_<微秒>_frame_<帧号>.<扩展名>
+# 由 core.import_manager.import_video 生成，格式变了这里会认不出来，
+# 认不出来就原样显示——退化成「难看但正确」，不会显示成错的帧号。
+_FRAME_NAME = re.compile(
+    r"^(?P<date>\d{8})_(?P<time>\d{6})_(?P<micro>\d{6})_frame_(?P<frame>\d+)\.[^.]+$"
+)
+
+
+def parse_frame_name(filename: str) -> Optional[Dict[str, str]]:
+    """认出抽帧生成的文件名，拆出日期 / 时间 / 帧号；不是这种名字就返回 None。"""
+    match = _FRAME_NAME.match((filename or "").strip())
+    return match.groupdict() if match else None
+
+
+def display_name(filename: str) -> str:
+    """一个文件名在界面上显示成什么。
+
+    抽帧名 → 「帧 223」（前导零去掉；全是零就是「帧 0」，别显示成空的）。
+    其余一律原样返回。
+    """
+    parsed = parse_frame_name(filename)
+    if not parsed:
+        return filename or ""
+    return f"帧 {int(parsed['frame'])}"
+
+
+def _discriminator(filename: str, level: str) -> Optional[str]:
+    """重名时用来区分的那一小截，取自文件名里的生成时间。"""
+    parsed = parse_frame_name(filename)
+    if not parsed:
+        return None
+
+    if level == "date":
+        date = parsed["date"]
+        return f"{date[4:6]}-{date[6:8]}"          # 20260712 → 07-12
+
+    time = parsed["time"]
+    return f"{time[0:2]}:{time[2:4]}:{time[4:6]}"  # 000602 → 00:06:02
+
+
+def display_names(filenames: Sequence[str]) -> List[str]:
+    """一整个列表的显示名：重名的补一个最短的区分信息。
+
+    同一段视频里帧号不会重复，重名只发生在「两段视频都抽到了第 223 帧」。
+    这时先用抽帧日期分（多半就够了），同一天的用时间分，同一秒的才退到序号。
+    """
+    aliases = [display_name(name) for name in filenames]
+
+    groups: Dict[str, List[int]] = defaultdict(list)
+    for index, alias in enumerate(aliases):
+        groups[alias].append(index)
+
+    for alias, indexes in groups.items():
+        if len(indexes) < 2:
+            continue
+
+        for level in ("date", "time"):
+            marks = [_discriminator(filenames[i], level) for i in indexes]
+            # 每个都拿得到、且两两不同，这一档才真的能把它们分开
+            if all(marks) and len(set(marks)) == len(indexes):
+                for index, mark in zip(indexes, marks):
+                    aliases[index] = f"{alias} · {mark}"
+                break
+        else:
+            # 时间也分不开（同一秒抽的，或者压根不是抽帧名）：给一个稳定的序号
+            for ordinal, index in enumerate(indexes, start=1):
+                aliases[index] = f"{alias} ({ordinal})"
+
+    return aliases

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,16 +1,26 @@
 # -*- coding: utf-8 -*-
 """
 EzYOLO 主窗口
+
+窗口 = 左边一条固定的流程导航 + 右边「页头 + 当前步骤」。
+项目的选择放在窗口层（侧边栏顶部），所有页面共用同一个当前项目，
+不用在每个页面里再选一次。
 """
 
 from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout,
-    QStackedWidget, QLabel, QPushButton, QFrame
+    QStackedWidget, QLabel, QPushButton, QFrame, QComboBox,
 )
 from PyQt6.QtCore import Qt, QSettings, QSize, QPoint
-from PyQt6.QtGui import QFont, QIcon
 
-from gui.styles import get_full_stylesheet, COLORS
+from gui.styles import get_full_stylesheet
+from gui.workflow import (
+    WORKFLOW_STEPS, STEP_BY_INDEX, PAGE_SETTINGS, PAGE_ABOUT,
+    STEP_IMPORT, STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST,
+    get_project_snapshot, compute_step_states, step_status_text,
+    get_blocker, get_next_action,
+)
+from gui.widgets.workflow_widgets import StepNav, PageHeader, StepGate, NoticeBar
 from gui.pages.import_page import ImportPage
 from gui.pages.annotate_page import AnnotatePage
 from gui.pages.train_page import TrainPage
@@ -20,294 +30,383 @@ from gui.pages.settings_page import SettingsPage
 from gui.pages.about_page import AboutPage
 from models.database import db
 
+GATE_INDEX = 7  # 前置条件说明页在 content_stack 中的位置
+
+AUX_PAGES = {
+    PAGE_SETTINGS: ("设置", "模型路径、自动保存与快捷键。"),
+    PAGE_ABOUT: ("关于 EzYOLO", ""),
+}
+
 
 class MainWindow(QMainWindow):
     """主窗口类"""
-    
+
     def __init__(self):
         super().__init__()
-        
-        # 加载设置
+
         self.settings = QSettings("EzYOLO", "MainWindow")
-        
-        # 初始化UI
+        self.current_project_id = None
+        self.current_index = STEP_IMPORT
+        self.snapshot = get_project_snapshot(None)
+        self.step_states = compute_step_states(self.snapshot)
+        self._bypassed_steps = set()
+
         self.init_ui()
-        
-        # 加载窗口状态
         self.load_window_state()
-    
+
+    # ==================== 界面搭建 ====================
+
     def init_ui(self):
         """初始化界面"""
-        # 设置窗口标题
-        self.setWindowTitle("EzYOLO - 全流程YOLO训练")
-        
-        # 设置最小尺寸
-        self.setMinimumSize(1200, 800)
-        
-        # 加载当前主题设置
-        current_theme = self.settings.value("theme", "深色主题")
-        theme_key = 'light' if current_theme == '浅色主题' else 'dark'
-        
-        # 应用样式表
-        self.setStyleSheet(get_full_stylesheet(theme_key))
-        
-        # 创建中央部件
+        self.setWindowTitle("EzYOLO - 本地YOLO训练全流程")
+        self.setMinimumSize(1100, 720)
+
+        self.setStyleSheet(get_full_stylesheet())
+
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
-        
-        # 主布局
+
         main_layout = QHBoxLayout(central_widget)
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
-        
-        # 创建侧边栏
+
+        # 先建内容区（页面在这里创建），再建侧边栏，侧边栏要连到导入页
+        content = self.create_content_area()
+
         self.sidebar = self.create_sidebar()
         main_layout.addWidget(self.sidebar)
-        
-        # 创建内容区域
-        self.content_stack = self.create_content_area()
-        main_layout.addWidget(self.content_stack)
-        
-        # 连接主题变化信号
+        main_layout.addWidget(content, 1)
+
         self.settings_page.theme_changed.connect(self.on_theme_changed)
-        
+        self.settings_page.auto_label_config_requested.connect(self.open_auto_label_config)
+        self.import_page.projects_changed.connect(self.on_projects_changed)
+        self.import_page.project_data_changed.connect(self.refresh_workflow)
+
         # 启动时同步数据库与真实文件
         self.sync_database_files()
-        
-        # 设置布局比例
-        main_layout.setStretch(0, 0)  # 侧边栏固定宽度
-        main_layout.setStretch(1, 1)  # 内容区域自适应
-    
+
+        self.load_projects()
+        self.switch_page(STEP_IMPORT)
+
     def create_sidebar(self) -> QWidget:
-        """创建侧边栏"""
+        """创建侧边栏：品牌 → 当前项目 → 流程步骤 → 辅助入口"""
         sidebar = QWidget()
         sidebar.setObjectName("sidebar")
-        sidebar.setFixedWidth(200)
-        
+        sidebar.setFixedWidth(216)
+
         layout = QVBoxLayout(sidebar)
-        layout.setContentsMargins(0, 20, 0, 20)
-        layout.setSpacing(4)
-        
-        # 标题
-        title_label = QLabel("EzYOLO")
-        title_label.setObjectName("title")
-        title_label.setFont(QFont("Microsoft YaHei", 18, QFont.Weight.Bold))
-        title_label.setStyleSheet(f"color: {COLORS['primary']}; padding: 0 16px;")
-        layout.addWidget(title_label)
-        
-        # 副标题
-        subtitle_label = QLabel("YOLO训练工具")
-        subtitle_label.setObjectName("subtitle")
-        subtitle_label.setStyleSheet("padding: 0 16px; margin-bottom: 20px;")
-        layout.addWidget(subtitle_label)
-        
-        # 分隔线
-        line = QFrame()
-        line.setFrameShape(QFrame.Shape.HLine)
-        line.setStyleSheet(f"background-color: {COLORS['border']}; max-height: 1px;")
-        layout.addWidget(line)
-        
-        # 导航按钮组
-        self.nav_buttons = []
-        
-        # 导入按钮
-        btn_import = self.create_nav_button("① 导入", 0)
-        layout.addWidget(btn_import)
-        self.nav_buttons.append(btn_import)
-        
-        # 标注按钮
-        btn_annotate = self.create_nav_button("② 标注", 1)
-        layout.addWidget(btn_annotate)
-        self.nav_buttons.append(btn_annotate)
-        
-        # 训练按钮
-        btn_train = self.create_nav_button("③ 训练", 2)
-        layout.addWidget(btn_train)
-        self.nav_buttons.append(btn_train)
-        
-        # 训练结果按钮
-        btn_result = self.create_nav_button("④ 训练结果", 3)
-        layout.addWidget(btn_result)
-        self.nav_buttons.append(btn_result)
-        
-        # 测试按钮
-        btn_test = self.create_nav_button("⑤ 测试", 4)
-        layout.addWidget(btn_test)
-        self.nav_buttons.append(btn_test)
-        
-        # 添加弹性空间
+        layout.setContentsMargins(12, 16, 12, 12)
+        layout.setSpacing(0)
+
+        brand = QLabel("EzYOLO")
+        brand.setObjectName("brand")
+        layout.addWidget(brand)
+
+        layout.addSpacing(16)
+
+        # 当前项目：全窗口共用，切换项目后所有步骤跟着走
+        project_label = QLabel("项目")
+        project_label.setObjectName("nav_section")
+        layout.addWidget(project_label)
+        layout.addSpacing(6)
+
+        self.project_combo = QComboBox()
+        self.project_combo.setToolTip("图片、标注和训练结果都存在当前项目里")
+        # 项目名可以很长，下拉框不能被它撑出侧栏
+        self.project_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        )
+        self.project_combo.setMinimumContentsLength(8)
+        self.project_combo.currentIndexChanged.connect(self.on_project_combo_changed)
+        layout.addWidget(self.project_combo)
+
+        layout.addSpacing(6)
+
+        self.btn_new_project = QPushButton("新建项目")
+        self.btn_new_project.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_new_project.clicked.connect(self.import_page.create_new_project)
+        layout.addWidget(self.btn_new_project)
+
+        layout.addSpacing(18)
+
+        flow_label = QLabel("流程")
+        flow_label.setObjectName("nav_section")
+        layout.addWidget(flow_label)
+        layout.addSpacing(6)
+
+        self.step_nav = StepNav()
+        self.step_nav.step_clicked.connect(self.switch_page)
+        layout.addWidget(self.step_nav)
+
         layout.addStretch()
-        
-        # 底部按钮
-        line2 = QFrame()
-        line2.setFrameShape(QFrame.Shape.HLine)
-        line2.setStyleSheet(f"background-color: {COLORS['border']}; max-height: 1px;")
-        layout.addWidget(line2)
-        
-        btn_settings = self.create_nav_button("⚙ 设置", 5)
-        layout.addWidget(btn_settings)
-        self.nav_buttons.append(btn_settings)
-        
-        btn_about = self.create_nav_button("ⓘ 关于", 6)
-        layout.addWidget(btn_about)
-        self.nav_buttons.append(btn_about)
-        
+
+        divider = QFrame()
+        divider.setObjectName("divider")
+        layout.addWidget(divider)
+        layout.addSpacing(8)
+
+        aux_row = QHBoxLayout()
+        aux_row.setContentsMargins(0, 0, 0, 0)
+        aux_row.setSpacing(6)
+
+        self.btn_settings = QPushButton("设置")
+        self.btn_settings.setObjectName("ghost")
+        self.btn_settings.setCheckable(True)
+        self.btn_settings.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_settings.clicked.connect(lambda: self.switch_page(PAGE_SETTINGS))
+        aux_row.addWidget(self.btn_settings)
+
+        self.btn_about = QPushButton("关于")
+        self.btn_about.setObjectName("ghost")
+        self.btn_about.setCheckable(True)
+        self.btn_about.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_about.clicked.connect(lambda: self.switch_page(PAGE_ABOUT))
+        aux_row.addWidget(self.btn_about)
+
+        layout.addLayout(aux_row)
+
         return sidebar
-    
-    def create_nav_button(self, text: str, index: int) -> QPushButton:
-        """创建导航按钮"""
-        btn = QPushButton(text)
-        btn.setObjectName("nav_button")
-        btn.setCheckable(True)
-        btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        
-        if index >= 0:
-            btn.clicked.connect(lambda checked, idx=index: self.switch_page(idx))
-        
-        return btn
-    
-    def create_content_area(self) -> QStackedWidget:
-        """创建内容区域"""
-        stack = QStackedWidget()
-        
-        # 导入页面
+
+    def create_content_area(self) -> QWidget:
+        """创建内容区：页头 + 页面堆栈"""
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.header = PageHeader()
+        self.header.next_clicked.connect(self.switch_page)
+        layout.addWidget(self.header)
+
+        # 启动自检这类「说一声就行」的消息落在这里，默认不占位
+        self.notice = NoticeBar()
+        layout.addWidget(self.notice)
+
+        self.content_stack = QStackedWidget()
+
         self.import_page = ImportPage()
-        stack.addWidget(self.import_page)
-        
-        # 标注页面
+        self.content_stack.addWidget(self.import_page)          # 0
+
         self.annotate_page = AnnotatePage()
-        stack.addWidget(self.annotate_page)
-        
-        # 训练页面
+        self.content_stack.addWidget(self.annotate_page)        # 1
+
         self.train_page = TrainPage()
-        stack.addWidget(self.train_page)
-        
-        # 训练结果页面
+        self.content_stack.addWidget(self.train_page)           # 2
+
         self.result_page = ResultPage()
-        stack.addWidget(self.result_page)
-        
-        # 测试页面
+        self.content_stack.addWidget(self.result_page)          # 3
+
         self.test_page = TestPage()
-        stack.addWidget(self.test_page)
-        
-        # 设置页面
+        self.content_stack.addWidget(self.test_page)            # 4
+
         self.settings_page = SettingsPage()
-        stack.addWidget(self.settings_page)
-        
-        # 关于页面
+        self.content_stack.addWidget(self.settings_page)        # 5
+
         self.about_page = AboutPage()
-        stack.addWidget(self.about_page)
-        
-        # 默认选中第一个页面
-        self.nav_buttons[0].setChecked(True)
-        
-        return stack
-    
+        self.content_stack.addWidget(self.about_page)           # 6
+
+        self.gate = StepGate()
+        self.gate.goto_requested.connect(self.switch_page)
+        self.gate.bypass_requested.connect(self.on_gate_bypassed)
+        self.content_stack.addWidget(self.gate)                 # 7
+
+        layout.addWidget(self.content_stack, 1)
+        return container
+
+    # ==================== 项目 ====================
+
+    def load_projects(self, select_id: int = None):
+        """把项目列表灌进侧边栏下拉框。"""
+        self.project_combo.blockSignals(True)
+        self.project_combo.clear()
+
+        projects = db.get_all_projects()
+        if projects:
+            self.project_combo.addItem("请选择项目…", None)
+            for project in projects:
+                self.project_combo.addItem(project['name'], project['id'])
+        else:
+            self.project_combo.addItem("还没有项目", None)
+
+        target = select_id if select_id is not None else self.current_project_id
+        index = self.project_combo.findData(target) if target else -1
+        self.project_combo.setCurrentIndex(index if index >= 0 else 0)
+        self.project_combo.blockSignals(False)
+
+        self.set_active_project(self.project_combo.currentData())
+
+    def on_project_combo_changed(self, _index: int):
+        self.set_active_project(self.project_combo.currentData())
+
+    def set_active_project(self, project_id):
+        """切换当前项目：导入页立刻跟着换，其余页面在进入时同步。"""
+        self.current_project_id = project_id
+        self._bypassed_steps.clear()
+        self.import_page.set_project(project_id)
+        self.refresh_workflow()
+        if self.current_index != STEP_IMPORT:
+            self.apply_page_project(self.current_index)
+
+    def on_projects_changed(self, project_id):
+        """导入页新建 / 删除项目后，刷新下拉框。"""
+        self.load_projects(select_id=project_id)
+
+    # ==================== 页面切换 ====================
+
     def switch_page(self, index: int):
-        """切换页面"""
-        # 更新按钮状态
-        for i, btn in enumerate(self.nav_buttons):
-            btn.setChecked(i == index)
-        
-        # 切换页面
-        self.content_stack.setCurrentIndex(index)
-        
-        # 同步项目信息到各页面
-        current_project_id = self.import_page.current_project_id
-        
-        if index == 1:  # 标注页面
-            if current_project_id:
-                self.annotate_page.set_project(current_project_id)
-            else:
-                # 如果没有选择项目，提示用户
-                from PyQt6.QtWidgets import QMessageBox
-                QMessageBox.information(self, "提示", "请先在导入页面选择一个项目")
-        
-        elif index == 2:  # 训练页面
-            if current_project_id:
-                self.train_page.set_project(current_project_id)
-            else:
-                # 如果没有选择项目，提示用户
-                from PyQt6.QtWidgets import QMessageBox
-                QMessageBox.information(self, "提示", "请先在导入页面选择一个项目")
-        
-        elif index == 3:  # 训练结果页面
-            if current_project_id:
-                self.result_page.set_project(current_project_id)
-            else:
-                # 如果没有选择项目，提示用户
-                from PyQt6.QtWidgets import QMessageBox
-                QMessageBox.information(self, "提示", "请先在导入页面选择一个项目")
-        
-        elif index == 4:  # 测试页面
-            if current_project_id:
-                self.test_page.set_project(current_project_id)
-            else:
-                # 如果没有选择项目，提示用户
-                from PyQt6.QtWidgets import QMessageBox
-                QMessageBox.information(self, "提示", "请先在导入页面选择一个项目")
-        
-        elif index == 5:  # 设置页面
-            # 设置页面不需要项目信息
-            pass
-        
-        elif index == 6:  # 关于页面
-            # 关于页面不需要项目信息
-            pass
-    
+        """切换到某一步。前置条件不满足时不再弹窗，而是就地说明原因并给出入口。"""
+        self.refresh_workflow(update_views=False)
+        self.current_index = index
+
+        blocker = None
+        if index not in self._bypassed_steps:
+            blocker = get_blocker(index, self.snapshot)
+
+        if blocker:
+            self.gate.set_blocker(blocker)
+            self.content_stack.setCurrentIndex(GATE_INDEX)
+        else:
+            self.apply_page_project(index)
+            self.content_stack.setCurrentIndex(index)
+
+        self.update_header(index)
+        self.update_nav(index)
+
+    def apply_page_project(self, index: int):
+        """把当前项目同步给将要显示的页面。"""
+        if index == STEP_IMPORT:
+            # 别的步骤可能改过标注状态，回到导入页时对一下
+            self.import_page.refresh_project_images()
+            return
+
+        page_setters = {
+            STEP_ANNOTATE: self.annotate_page.set_project,
+            STEP_TRAIN: self.train_page.set_project,
+            STEP_RESULT: self.result_page.set_project,
+            STEP_TEST: self.test_page.set_project,
+        }
+        setter = page_setters.get(index)
+        if setter and self.current_project_id:
+            setter(self.current_project_id)
+
+    def open_auto_label_config(self, section: str = ""):
+        """设置页点「打开自动标注配置」→ 就在这儿把配置窗口开出来。
+
+        配置窗口是标注页那一个实例（AutoLabelDialog），但用户不用先切到标注页、
+        再去工具栏里找按钮——设置页发信号，窗口层直接开。SAM / LLM 的配置是
+        全局文件，没有项目也能配。关掉之后把设置页显示的状态重新读一遍。
+        """
+        self.annotate_page.open_auto_label_config(section)
+        self.settings_page.refresh_ai_status()
+
+    def on_gate_bypassed(self):
+        """用户选择「我有现成的模型，直接测试」这类跳过。"""
+        self._bypassed_steps.add(self.current_index)
+        self.switch_page(self.current_index)
+
+    # ==================== 流程状态 ====================
+
+    def refresh_workflow(self, update_views: bool = True):
+        """重新读取项目事实（图片数、标注数、训练结果），刷新侧边栏与页头。"""
+        self.snapshot = get_project_snapshot(self.current_project_id)
+        self.step_states = compute_step_states(self.snapshot)
+        if update_views:
+            self.update_nav(self.current_index)
+            self.update_header(self.current_index)
+
+    def update_nav(self, index: int):
+        status_texts = {
+            step['index']: step_status_text(step['index'], self.snapshot, self.step_states)
+            for step in WORKFLOW_STEPS
+        }
+        # 停留在设置/关于时，主流程不高亮任何一步
+        highlight = -1 if index in AUX_PAGES else index
+        self.step_nav.update_states(self.step_states, status_texts, highlight)
+
+        self.btn_settings.setChecked(index == PAGE_SETTINGS)
+        self.btn_about.setChecked(index == PAGE_ABOUT)
+
+    def update_header(self, index: int):
+        if index in AUX_PAGES:
+            title, desc = AUX_PAGES[index]
+            self.header.set_step(index, title, desc)
+            self.header.set_next_action(None)
+            return
+
+        if index not in STEP_BY_INDEX:
+            return
+
+        self.header.set_step(index)
+        self.header.set_next_action(
+            get_next_action(self.snapshot, self.step_states, index)
+        )
+
+    # ==================== 窗口状态 ====================
+
     def load_window_state(self):
         """加载窗口状态"""
-        # 恢复窗口大小
-        size = self.settings.value("size", QSize(1400, 900))
+        size = self.settings.value("size", QSize(1440, 900))
         self.resize(size)
-        
-        # 恢复窗口位置
+
         pos = self.settings.value("pos", QPoint(100, 100))
         self.move(pos)
-        
-        # 恢复窗口状态（最大化等）
+
         state = self.settings.value("windowState")
         if state:
             self.restoreState(state)
-    
+
     def save_window_state(self):
         """保存窗口状态"""
         self.settings.setValue("size", self.size())
         self.settings.setValue("pos", self.pos())
         self.settings.setValue("windowState", self.saveState())
-    
-    def on_theme_changed(self, theme_key):
-        """处理主题变化（固定为深色主题）"""
-        # 始终使用深色主题
-        dark_theme_key = 'dark'
-        # 应用深色主题样式表
-        self.setStyleSheet(get_full_stylesheet(dark_theme_key))
-        
-        # 保存主题设置为深色主题
-        self.settings.setValue("theme", "深色主题")
-    
+
+    def on_theme_changed(self, _theme_key=None):
+        """主题变化（应用只有一套浅色外观，重新套一遍样式表即可）"""
+        self.setStyleSheet(get_full_stylesheet())
+
     def closeEvent(self, event):
-        """关闭事件"""
+        """关闭事件：后台线程先停干净，再让窗口销毁。
+
+        QThread 还在 run() 里时被销毁会直接崩，所以推理和 LLM 批量这两条
+        长任务在这里各自收工（都带超时，不会把退出流程拖住）。
+        """
+        for page in (self.test_page, self.annotate_page):
+            shutdown = getattr(page, 'shutdown', None)
+            if shutdown:
+                shutdown()
+
         self.save_window_state()
         event.accept()
 
     def sync_database_files(self):
-        """同步数据库与真实文件"""
+        """启动自检：只看数据库和磁盘对不对得上，不动任何数据。
+
+        数据层只扫描、只报数（orphan_db_count / orphan_disk_count / issues），
+        删不删由用户自己决定。所以这里也只是「说一声」：
+        对得上就什么都不显示；对不上就在窗口里留一条可关掉的通知，
+        不弹窗、不阻塞启动，更不会替用户删东西。
+        """
         try:
-            # 调用数据库同步方法
-            result = db.sync_files_with_database()
-            
-            deleted_db_count = result.get('deleted_db_count', 0)
-            deleted_file_count = result.get('deleted_file_count', 0)
-            total_deleted = result.get('total_deleted', 0)
-            
-            if total_deleted > 0:
-                print(f"[同步] 删除了 {deleted_db_count} 个数据库中不存在的文件记录")
-                print(f"[同步] 删除了 {deleted_file_count} 个文件夹中不存在于数据库的文件")
-                print(f"[同步] 总共删除了 {total_deleted} 个项目")
-                # 可以在这里添加一个通知，告知用户同步结果
-                # 例如：QMessageBox.information(self, "同步完成", f"删除了 {deleted_file_count} 个不存在于数据库的文件和 {deleted_db_count} 个无效记录")
-            else:
-                print("[同步] 数据库与文件系统一致，无需删除")
-        except Exception as e:
-            print(f"[同步] 同步过程中出现错误: {str(e)}")
+            result = db.sync_files_with_database() or {}
+        except Exception as exc:  # noqa: BLE001  自检失败不该拦住启动
+            print(f"[自检] 跳过：{exc}")
+            return
+
+        orphan_db = result.get('orphan_db_count', 0)
+        orphan_disk = result.get('orphan_disk_count', 0)
+        if not (orphan_db or orphan_disk):
+            return
+
+        parts = []
+        if orphan_db:
+            parts.append(f"{orphan_db} 条记录找不到对应文件")
+        if orphan_disk:
+            parts.append(f"{orphan_disk} 个文件不在数据库里")
+
+        issues = result.get('issues') or []
+        detail = "\n".join(str(item) for item in issues[:20])
+        self.notice.show_message(
+            "数据自检：" + "，".join(parts) + "。未做任何改动。",
+            detail,
+        )

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -21,6 +21,7 @@ from gui.workflow import (
     get_blocker, get_next_action,
 )
 from gui.widgets.workflow_widgets import StepNav, PageHeader, StepGate, NoticeBar
+from gui.widgets.elided_combo import ElidedComboBox
 from gui.pages.import_page import ImportPage
 from gui.pages.annotate_page import AnnotatePage
 from gui.pages.train_page import TrainPage
@@ -31,6 +32,12 @@ from gui.pages.about_page import AboutPage
 from models.database import db
 
 GATE_INDEX = 7  # 前置条件说明页在 content_stack 中的位置
+
+# 导入/标注是业务页：左侧 StepNav 已经承担了流程和下一步导航，PageHeader
+# 整块（标题/序号/说明/下一步按钮）在这两页上是和 StepNav 重复的第二套导航，
+# 隐藏掉、把页面内容往上提。其余页面（含前置条件不满足时显示的 Gate）
+# 仍然显示 PageHeader。
+HIDDEN_HEADER_STEPS = {STEP_IMPORT, STEP_ANNOTATE}
 
 AUX_PAGES = {
     PAGE_SETTINGS: ("设置", "模型路径、自动保存与快捷键。"),
@@ -110,9 +117,10 @@ class MainWindow(QMainWindow):
         layout.addWidget(project_label)
         layout.addSpacing(6)
 
-        self.project_combo = QComboBox()
+        # 项目名可以很长，下拉框不能被它撑出侧栏；装不下时要省略号收尾，
+        # 不能像原生 QComboBox 那样把最后一个中文字切掉一半
+        self.project_combo = ElidedComboBox()
         self.project_combo.setToolTip("图片、标注和训练结果都存在当前项目里")
-        # 项目名可以很长，下拉框不能被它撑出侧栏
         self.project_combo.setSizeAdjustPolicy(
             QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
         )
@@ -225,6 +233,12 @@ class MainWindow(QMainWindow):
             self.project_combo.addItem("请选择项目…", None)
             for project in projects:
                 self.project_combo.addItem(project['name'], project['id'])
+                # 名字长到要省略时，完整名字至少还能在悬停里看到
+                self.project_combo.setItemData(
+                    self.project_combo.count() - 1,
+                    project['name'],
+                    Qt.ItemDataRole.ToolTipRole,
+                )
         else:
             self.project_combo.addItem("还没有项目", None)
 
@@ -294,10 +308,28 @@ class MainWindow(QMainWindow):
 
         配置窗口是标注页那一个实例（AutoLabelDialog），但用户不用先切到标注页、
         再去工具栏里找按钮——设置页发信号，窗口层直接开。SAM / LLM 的配置是
-        全局文件，没有项目也能配。关掉之后把设置页显示的状态重新读一遍。
+        全局文件，没有项目也能配。
+
+        关窗之后回到「打开它的那个页面」，而不是跳去别的步骤：从设置页点开的，
+        保存完还留在设置页，并且就地把 AI 状态刷新成刚存的值 + 给一句「已保存」——
+        否则用户点完保存，窗口一关，界面上没有任何东西变过，跟没保存一样。
         """
-        self.annotate_page.open_auto_label_config(section)
+        origin_index = self.current_index
+
+        saved = self.annotate_page.open_auto_label_config(section)
+
+        # 配置窗口开着的这段时间里页面不该被换掉；真被换了（以后有人加了新逻辑）
+        # 也要回到用户点开配置的那一页，不能把人甩到别的步骤去。
+        if self.current_index != origin_index:
+            self.switch_page(origin_index)
+
         self.settings_page.refresh_ai_status()
+
+        if origin_index == PAGE_SETTINGS:
+            if saved:
+                self.settings_page.set_status("自动标注设置已保存。", 'success')
+            else:
+                self.settings_page.set_status("没有改动自动标注设置。")
 
     def on_gate_bypassed(self):
         """用户选择「我有现成的模型，直接测试」这类跳过。"""
@@ -327,19 +359,22 @@ class MainWindow(QMainWindow):
         self.btn_about.setChecked(index == PAGE_ABOUT)
 
     def update_header(self, index: int):
+        """页头数据永远按「请求的那一步」来算，不受 Gate 遮挡影响；
+        只有显示与否才看 content_stack 实际显示的是业务页还是 Gate。
+        """
         if index in AUX_PAGES:
             title, desc = AUX_PAGES[index]
             self.header.set_step(index, title, desc)
             self.header.set_next_action(None)
+        elif index in STEP_BY_INDEX:
+            self.header.set_step(index)
+            self.header.set_next_action(
+                get_next_action(self.snapshot, self.step_states, index)
+            )
+        else:
             return
 
-        if index not in STEP_BY_INDEX:
-            return
-
-        self.header.set_step(index)
-        self.header.set_next_action(
-            get_next_action(self.snapshot, self.step_states, index)
-        )
+        self.header.setVisible(self.content_stack.currentIndex() not in HIDDEN_HEADER_STEPS)
 
     # ==================== 窗口状态 ====================
 

--- a/gui/pages/about_page.py
+++ b/gui/pages/about_page.py
@@ -1,109 +1,169 @@
 # -*- coding: utf-8 -*-
 """
 关于页面
+
+辅助页：说清楚 EzYOLO 是什么、能做什么、什么版本、遇到问题找谁。
+不堆宣传语，也不重复页头已经写过的标题。
 """
 
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-    QGroupBox, QFormLayout, QTextEdit
+    QWidget, QVBoxLayout, QGridLayout, QLabel,
+    QGroupBox, QScrollArea, QFrame,
 )
 from PyQt6.QtCore import Qt
+
+VERSION = "1.1.0"
+UPDATED = "2026-03-05"
+AUTHOR = "xinchen"
+GITHUB = "https://github.com/lxinchenl"
+EMAIL = "liuxinchen0803@qq.com"
+
+INTRO = "EzYOLO 把 YOLO 的完整流程收进一条固定路线：导入图片 → 标注 → 训练 → 看结果 → 测试。"
+
+# 每一步做什么，对应左侧主流程的五步
+CAPABILITIES = [
+    ("数据导入", "图片/视频/标注文件"),
+    ("数据标注", "手动/SAM/大模型标注"),
+    ("模型训练", "本机训练 YOLO"),
+    ("结果分析", "曲线、指标、导出"),
+    ("模型测试", "验证新数据表现"),
+]
+
+HELP_TEXT = "有问题欢迎发邮件或到 GitHub 提 issue。"
 
 
 class AboutPage(QWidget):
     """关于页面"""
-    
+
     def __init__(self):
         super().__init__()
         self.init_ui()
-    
+
     def init_ui(self):
         """初始化界面"""
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("关于 EzYOLO")
-        title.setObjectName("title")
-        title.setStyleSheet("font-size: 20px; font-weight: bold;")
-        main_layout.addWidget(title)
-        
-        # 作者信息
-        author_group = self.create_author_group()
-        main_layout.addWidget(author_group)
-        
-        # 联系方式
-        contact_group = self.create_contact_group()
-        main_layout.addWidget(contact_group)
-        
-        # 反盗版声明
-        anti_piracy_group = self.create_anti_piracy_group()
-        main_layout.addWidget(anti_piracy_group)
-        
-        # 版本信息
-        version_group = self.create_version_group()
-        main_layout.addWidget(version_group)
-        
-        # 底部
-        main_layout.addStretch()
-    
-    def create_author_group(self) -> QGroupBox:
-        """创建作者信息组"""
-        group = QGroupBox("作者信息")
-        
-        layout = QFormLayout(group)
-        
-        author_label = QLabel("xinchen")
-        author_label.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        layout.addRow("作者:", author_label)
-        
-        return group
-    
-    def create_contact_group(self) -> QGroupBox:
-        """创建联系方式组"""
-        group = QGroupBox("联系方式")
-        
-        layout = QFormLayout(group)
-        
-        # 微信
-        wechat_label = QLabel("https://github.com/lxinchenl")
-        wechat_label.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        layout.addRow("GitHub:", wechat_label)
-        
-        # 邮箱
-        email_label = QLabel("liuxinchen0803@qq.com")
-        email_label.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        layout.addRow("邮箱:", email_label)
-        
-        return group
-    
-    def create_anti_piracy_group(self) -> QGroupBox:
-        """创建反盗版声明组"""
-        group = QGroupBox("声明")
-        
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+
+        body = QWidget()
+        layout = QVBoxLayout(body)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(14)
+
+        # 内容只有几行，铺满宽屏会变成一片空白。固定一列宽度，宽屏时右边留白。
+        column = QWidget()
+        column.setMaximumWidth(680)
+        column_layout = QVBoxLayout(column)
+        column_layout.setContentsMargins(0, 0, 0, 0)
+        column_layout.setSpacing(14)
+        column_layout.addWidget(self.create_intro_group())
+        column_layout.addWidget(self.create_capability_group())
+        column_layout.addWidget(self.create_version_group())
+        column_layout.addWidget(self.create_help_group())
+
+        layout.addWidget(column)
+        layout.addStretch()
+
+        scroll.setWidget(body)
+        outer.addWidget(scroll)
+
+    def create_intro_group(self) -> QGroupBox:
+        """这是什么"""
+        group = QGroupBox("这是什么")
+
         layout = QVBoxLayout(group)
-        
-        anti_piracy_text = QTextEdit()
-        anti_piracy_text.setReadOnly(True)
-        anti_piracy_text.setStyleSheet("background-color: #252526; color: #ffffff; padding: 8px; border-radius: 4px;")
-        anti_piracy_text.setText("欢迎反馈交流\n\n" )
-        layout.addWidget(anti_piracy_text)
-        
+
+        intro = QLabel(INTRO)
+        intro.setObjectName("subtitle")
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
+
         return group
-    
+
+    def create_capability_group(self) -> QGroupBox:
+        """主要能力：就是主流程的五步
+
+        不用 QFormLayout：QMacStyle 下它给换行标签算的行高不可靠，说明文字
+        折行后裁切、和相邻行重叠。显式网格把说明列拉伸到分组框剩余宽度，
+        这些短句一行就装下，不再需要换行。
+        """
+        group = QGroupBox("主要能力")
+
+        grid = QGridLayout(group)
+        grid.setHorizontalSpacing(14)
+        grid.setVerticalSpacing(10)
+        grid.setColumnStretch(1, 1)
+
+        for row, (name, desc) in enumerate(CAPABILITIES):
+            grid.addWidget(QLabel(name), row, 0, Qt.AlignmentFlag.AlignTop)
+
+            desc_label = QLabel(desc)
+            desc_label.setObjectName("subtitle")
+            desc_label.setWordWrap(True)
+            grid.addWidget(desc_label, row, 1)
+
+        return group
+
     def create_version_group(self) -> QGroupBox:
-        """创建版本信息组"""
-        group = QGroupBox("版本信息")
-        
-        layout = QFormLayout(group)
-        
-        version_label = QLabel("1.1.0")
-        version_label.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        layout.addRow("版本:", version_label)
-        
-        update_label = QLabel("2026-03-05")
-        update_label.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        layout.addRow("更新日期:", update_label)
-        
+        """版本信息
+
+        和本页其他分组一样用网格：QFormLayout 在 QMacStyle 下会把整个表单
+        水平居中，夹在几个左对齐的分组中间很突兀。
+        """
+        group = QGroupBox("版本")
+
+        grid = QGridLayout(group)
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(10)
+        grid.setColumnStretch(1, 1)
+
+        for row, (name, value) in enumerate([
+            ("版本:", VERSION),
+            ("更新日期:", UPDATED),
+            ("作者:", AUTHOR),
+        ]):
+            grid.addWidget(QLabel(name), row, 0)
+            grid.addWidget(QLabel(value), row, 1)
+
         return group
+
+    def create_help_group(self) -> QGroupBox:
+        """帮助与反馈
+
+        链接和邮箱走网格 + 列拉伸：QFormLayout 在 QMacStyle 下值列不跟着
+        分组框伸缩，GitHub 链接会被过早截断。
+        """
+        group = QGroupBox("帮助与反馈")
+
+        layout = QVBoxLayout(group)
+        layout.setSpacing(10)
+
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(10)
+        grid.setColumnStretch(1, 1)
+
+        grid.addWidget(QLabel("GitHub:"), 0, 0)
+        grid.addWidget(self.create_selectable_label(GITHUB), 0, 1)
+        grid.addWidget(QLabel("邮箱:"), 1, 0)
+        grid.addWidget(self.create_selectable_label(EMAIL), 1, 1)
+
+        layout.addLayout(grid)
+
+        help_label = QLabel(HELP_TEXT)
+        help_label.setObjectName("caption")
+        help_label.setWordWrap(True)
+        layout.addWidget(help_label)
+
+        return group
+
+    def create_selectable_label(self, text: str) -> QLabel:
+        """联系方式要能复制出去。"""
+        label = QLabel(text)
+        label.setWordWrap(True)
+        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        label.setCursor(Qt.CursorShape.IBeamCursor)
+        return label

--- a/gui/pages/annotate_page.py
+++ b/gui/pages/annotate_page.py
@@ -19,25 +19,53 @@ import math
 # 导入自动标注相关模块
 from gui.pages.auto_label_dialog import AutoLabelDialog
 from gui.pages.batch_process_dialog import BatchProcessDialog
+from gui.pages.settings_page import event_matches_shortcut
 from core.auto_labeler import BatchLabelingManager
 from core.model_manager import ModelManager
-from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize, QPoint, QRect
-from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QKeyEvent, QMouseEvent, QWheelEvent, QAction, QIcon, QPen, QBrush, QShortcut, QKeySequence
+from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize, QPoint, QRect, QEvent
+from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QFontMetrics, QKeyEvent, QMouseEvent, QWheelEvent, QAction, QIcon, QPen, QBrush, QShortcut, QKeySequence
 import cv2
 import numpy as np
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
 import os
 import gc
+import json
 import threading
 import random
 
-from gui.styles import COLORS
+from gui.styles import COLORS, RADIUS_SM, CONTROL_HEIGHT, get_primary_font_family
 from models.database import db
 from gui.widgets.loading_dialog import LoadingOverlay
 
 SAM3_DOWNLOAD_URL = "https://huggingface.co/1038lab/sam3/discussions/1"
 NEGATIVE_SAMPLE_CLASS_ID = -1
+
+
+def _readable_on_light(color: str) -> str:
+    """把类别色压到浅底上读得出来的程度。
+
+    类别色是用户挑给「画在图片上的框」用的，亮黄、亮青这类颜色画在照片上很显眼，
+    但直接拿去当白底上的文字色就糊了。这里只在太亮时压暗，色相保持不变——
+    当前类别的颜色线索还在，字也还看得清。
+    """
+    if not color:
+        return COLORS['text_primary']
+
+    qcolor = QColor(color)
+    if not qcolor.isValid():
+        return COLORS['text_primary']
+
+    # 感知亮度（ITU-R BT.601）：白底上超过这个值的颜色基本没法当正文看
+    luminance = (
+        0.299 * qcolor.red() + 0.587 * qcolor.green() + 0.114 * qcolor.blue()
+    ) / 255
+    while luminance > 0.55:
+        qcolor = qcolor.darker(130)
+        luminance = (
+            0.299 * qcolor.red() + 0.587 * qcolor.green() + 0.114 * qcolor.blue()
+        ) / 255
+    return qcolor.name()
 
 
 class SAMModelManager:
@@ -335,6 +363,119 @@ class SAMInferenceWorker(QThread):
                 self.inference_finished.emit(False, f"推理出错: {str(e)}", None)
 
 
+def redact_secret(text: str, secret: str) -> str:
+    """把 API Key 从要显示/打印的文字里抹掉。
+
+    异常信息里偶尔会带上请求参数；密钥不该进日志、不该进弹窗、更不该进测试输出。
+    """
+    if not secret or not text:
+        return text
+    return text.replace(secret, "***")
+
+
+def llm_detect(config: dict, image_path: str, target: str) -> List[Dict]:
+    """调一次视觉大模型，返回 [{'label', 'bbox'}]。
+
+    只做网络请求和解析，不碰界面也不碰数据库——单张和批量共用同一条路径，
+    调用方负责把它放进后台线程。
+    """
+    import base64
+    import re
+    from openai import OpenAI
+
+    with open(image_path, "rb") as f:
+        img_base64 = base64.b64encode(f.read()).decode("utf-8")
+
+    client = OpenAI(api_key=config['api_key'], base_url=config['base_url'])
+
+    completion = client.chat.completions.create(
+        model=config['model_name'],
+        messages=[
+            {"role": "system", "content": config['system_prompt']},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": config['user_prompt'].format(target=target)},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{img_base64}"}
+                    }
+                ]
+            }
+        ]
+    )
+
+    response_text = completion.choices[0].message.content or ""
+
+    # 约定的返回格式: target,[xmin,ymin,xmax,ymax]
+    detections = []
+    for label, xmin, ymin, xmax, ymax in re.findall(
+        r'([^,\n]+),\[(\d+),(\d+),(\d+),(\d+)\]', response_text
+    ):
+        detections.append({
+            "label": label.strip(),
+            "bbox": [int(xmin), int(ymin), int(xmax), int(ymax)],
+        })
+    return detections
+
+
+class LLMBatchWorker(QThread):
+    """LLM 批量推理：一整批图片的网络请求都在这个线程里跑。
+
+    原来这段是在界面线程里 for 循环逐张发请求，靠 QProgressDialog 撑场面——
+    每张图要等几秒，这几秒里窗口是死的（拖不动、点不了、取消键也要等当前这张
+    回来才轮得到）。搬到后台之后：进度实时、取消立刻生效、失败的图片单独记账。
+
+    线程只负责「发请求 + 解析」；标注写库仍然回到界面线程做（signal 带回结果），
+    数据库的写入路径不多一个并发来源。
+    """
+
+    image_started = pyqtSignal(int, str)     # 第几张（从 1 数）, 文件名
+    image_done = pyqtSignal(int, list, str)  # image_id, 检测结果, 出错原因（''=成功）
+    batch_finished = pyqtSignal(int, int, bool)  # 成功数, 失败数, 是否被取消
+
+    def __init__(self, config: dict, images: List[Dict], target: str):
+        super().__init__()
+        self.config = config
+        self.images = images
+        self.target = target
+        self._cancelled = False
+
+    def cancel(self):
+        """请求取消：只置标志，调用方不阻塞等待。"""
+        self._cancelled = True
+
+    def run(self):
+        succeeded = 0
+        failed = 0
+
+        for i, image_data in enumerate(self.images):
+            if self._cancelled:
+                break
+
+            image_id = image_data['id']
+            self.image_started.emit(i + 1, image_data.get('filename', ''))
+
+            image_path = image_data.get('storage_path', '')
+            if not image_path or not os.path.exists(image_path):
+                failed += 1
+                self.image_done.emit(image_id, [], "图片文件不存在")
+                continue
+
+            try:
+                detections = llm_detect(self.config, image_path, self.target)
+            except Exception as e:  # noqa: BLE001  单张失败不该中断整批
+                failed += 1
+                reason = redact_secret(str(e), self.config.get('api_key', ''))
+                self.image_done.emit(image_id, [], reason or "推理失败")
+                continue
+
+            succeeded += 1
+            self.image_done.emit(image_id, detections, "")
+
+        self.batch_finished.emit(succeeded, failed, self._cancelled)
+
+
 class AnnotateImageLoadWorker(QThread):
     """标注页面图片加载工作线程"""
     
@@ -553,7 +694,10 @@ class AnnotationCanvas(QFrame):
         # SAM记忆模式显示列表
         self.memory_display_points = []  # [{"x": x, "y": y, "obj_id": id}, ...]
         self.memory_display_bboxes = []  # [{"x1": x1, "y1": y1, "x2": x2, "y2": y2, "obj_id": id}, ...]
-        
+
+        # 没有图片时画布中央显示的话，由页面按当前状态填写
+        self.empty_hint = "请选择一张图片开始标注"
+
         self.init_ui()
     
     def init_ui(self):
@@ -672,8 +816,12 @@ class AnnotationCanvas(QFrame):
         if self.current_image is None:
             # 显示提示文字
             painter.setPen(QColor(COLORS['text_secondary']))
-            painter.setFont(QFont("Microsoft YaHei", 14))
-            painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, "请选择一张图片开始标注")
+            painter.setFont(QFont(get_primary_font_family(), 14))
+            painter.drawText(
+                self.rect().adjusted(40, 0, -40, 0),
+                Qt.AlignmentFlag.AlignCenter | Qt.TextFlag.TextWordWrap,
+                self.empty_hint
+            )
             return
         
         # 绘制图像
@@ -750,7 +898,7 @@ class AnnotationCanvas(QFrame):
                 
                 # 绘制ID
                 painter.setPen(QColor(255, 255, 255))
-                painter.setFont(QFont("Microsoft YaHei", 10, QFont.Weight.Bold))
+                painter.setFont(QFont(get_primary_font_family(), 10, QFont.Weight.Bold))
                 painter.drawText(widget_pos.x() + radius + 2, widget_pos.y() - radius, f"ID:{obj_id}")
         
         # 绘制记忆对象的所有框
@@ -790,7 +938,7 @@ class AnnotationCanvas(QFrame):
                 label_rect = QRect(p1.x(), p1.y() - 20, 40, 20)
                 painter.drawRect(label_rect)
                 painter.setPen(QColor(255, 255, 255))
-                painter.setFont(QFont("Microsoft YaHei", 9))
+                painter.setFont(QFont(get_primary_font_family(), 9))
                 painter.drawText(label_rect, Qt.AlignmentFlag.AlignCenter, f"ID:{obj_id}")
         
         # 绘制当前正在添加的点（临时标记）
@@ -802,7 +950,7 @@ class AnnotationCanvas(QFrame):
             painter.drawEllipse(widget_pos, radius, radius)
             # 绘制点编号
             painter.setPen(QColor(255, 255, 255))
-            painter.setFont(QFont("Microsoft YaHei", 10, QFont.Weight.Bold))
+            painter.setFont(QFont(get_primary_font_family(), 10, QFont.Weight.Bold))
             painter.drawText(widget_pos.x() + radius + 2, widget_pos.y() - radius, str(i + 1))
             painter.setPen(QPen(QColor(0, 255, 0), 2))
             painter.setBrush(QBrush(QColor(0, 255, 0)))
@@ -833,7 +981,7 @@ class AnnotationCanvas(QFrame):
             
             # 绘制点编号
             painter.setPen(QColor(255, 255, 255))
-            painter.setFont(QFont("Microsoft YaHei", 10, QFont.Weight.Bold))
+            painter.setFont(QFont(get_primary_font_family(), 10, QFont.Weight.Bold))
             painter.drawText(widget_pos.x() + radius + 2, widget_pos.y() - radius, str(i + 1))
             
             # 恢复绘制样式
@@ -1798,10 +1946,10 @@ class AnnotationCanvas(QFrame):
         
         # 获取快捷键设置
         settings = QSettings("EzYOLO", "Settings")
-        reset_view_key = settings.value("reset_view_shortcut", "R").upper()
+        reset_view_key = str(settings.value("reset_view_shortcut", "R"))
         
         # 重置视图快捷键
-        if event.text().upper() == reset_view_key:
+        if event_matches_shortcut(event, reset_view_key):
             self.reset_view()
             self.update()
             return
@@ -2255,52 +2403,244 @@ class AnnotatePage(QWidget):
         self.auto_label_dialog = None
         self.model_manager = None
         self.batch_labeling_manager = None
+        # 批处理对话框（非模态）。同名属性在 AnnotationCanvas 上也有一份，
+        # 但页面自己这份必须先存在：show_batch_process_dialog 一进来就要读它。
+        self.batch_process_dialog = None
         self.sam_memory_objects = []
         self.sam_memory_dialog = None
         self.prev_image_shortcut = None
         self.next_image_shortcut = None
-        
+
+        # LLM 推理：单张一个线程，批量一个线程；引用留在页面上，别让它跑着就被回收。
+        # 已经收工、但线程还没真正退出的那些，先挪进 _retired_llm_workers 继续持有，
+        # 等 QThread.finished 再销毁——见 _on_llm_worker_finished。
+        self.llm_worker = None
+        self.llm_batch_worker = None
+        self._retired_llm_workers = []
+        self.llm_batch_progress = None
+        self.llm_batch_total = 0
+        self.llm_batch_added = 0
+        self.llm_batch_class_id = 0
+
         self.init_ui()
+
+    def shutdown(self):
+        """关窗前收工：正在跑的 LLM 线程先请它停，再等它退出。
+
+        QThread 对象在 run() 还没结束时被销毁会直接崩；等待给上限，
+        不让一个卡住的网络请求把整个退出流程拖死。
+        """
+        workers = [self.llm_batch_worker, self.llm_worker, *self._retired_llm_workers]
+        for worker in workers:
+            if worker is None or not worker.isRunning():
+                continue
+            if hasattr(worker, 'cancel'):
+                worker.cancel()
+            worker.wait(5000)
+
+    def _track_llm_worker(self, worker):
+        """所有 LLM 线程都从这里登记生命周期。"""
+        worker.finished.connect(self._on_llm_worker_finished)
+
+    def _on_llm_worker_finished(self):
+        """线程真的退出了才销毁它。
+
+        业务信号（image_done / batch_finished）是 run() 里的最后几句，那会儿
+        run() 还没返回；在那里 deleteLater() 或者把最后一个引用丢掉，QThread
+        就会在自己还在跑的时候被销毁——直接崩。QThread.finished 是 run() 返回
+        之后才发的，只有这里放手才安全。
+        """
+        worker = self.sender()
+        if worker is None:
+            return
+        if worker is self.llm_worker:
+            self.llm_worker = None
+        if worker is self.llm_batch_worker:
+            self.llm_batch_worker = None
+        if worker in self._retired_llm_workers:
+            self._retired_llm_workers.remove(worker)
+        worker.deleteLater()
     
     def init_ui(self):
-        """初始化界面"""
+        """初始化界面
+
+        自上而下四层：
+            信息条 —— 现在在哪个项目、标哪张图、标了多少、当前是什么类别
+            主区   —— 左：图片列表 / 中：工具栏 + 画布 + 翻页 / 右：类别、AI、样本、导出
+            状态栏 —— 位置、本图标注数、当前工具（快捷键收进「快捷键」按钮的提示里）
+        """
         self.main_layout = QVBoxLayout(self)
         self.main_layout.setContentsMargins(0, 0, 0, 0)
         self.main_layout.setSpacing(0)
-        
+
+        # 顶部信息条（任务类型选择器在这里创建，中间面板初始化时要读它）
+        self.context_bar = self.create_context_bar()
+        self.main_layout.addWidget(self.context_bar)
+
         # 创建分割器
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        
+        splitter.setChildrenCollapsible(False)
+
         # 左侧：图片列表
         self.left_panel = self.create_left_panel()
         splitter.addWidget(self.left_panel)
-        
+
         # 中间：标注画布
         self.center_panel = self.create_center_panel()
         splitter.addWidget(self.center_panel)
-        
+
         # 右侧：属性面板
         self.right_panel = self.create_right_panel()
         splitter.addWidget(self.right_panel)
-        
-        # 设置分割器比例
-        splitter.setSizes([250, 700, 250])
+
+        # 初始比例要落在三个面板各自的 min/max 区间内（左 175~320 / 中 ≥380 / 右 245~340），
+        # 否则第一次绘制时会被重新夹紧，看起来像「跳」了一下。这里按 1100px 窗口的可用宽度分。
+        # 三栏在 1100 宽窗口下的实际分配（内容区约 884）。右栏要留出足够视口宽度：
+        # 它内部内容的最小宽度是 263px，少 1px 就会冒出一条横向滚动条。
+        splitter.setSizes([215, 385, 285])
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
         splitter.setStretchFactor(2, 0)
-        
-        self.main_layout.addWidget(splitter)
-        
+
+        self.main_layout.addWidget(splitter, 1)
+
         # 底部状态栏
         self.status_bar = self.create_status_bar()
         self.main_layout.addWidget(self.status_bar)
 
         self._init_navigation_shortcuts()
+        self._update_context_bar()
+        self._update_action_availability()
 
     def showEvent(self, event):
         """显示页面时刷新快捷键配置。"""
         self._refresh_navigation_shortcuts()
         super().showEvent(event)
+
+    def resizeEvent(self, event):
+        """窗口变化后重算工具栏高度：出现横向滚动条时别把按钮压掉一截。"""
+        super().resizeEvent(event)
+        self._sync_toolbar_scroll_height()
+
+    def create_context_bar(self) -> QWidget:
+        """顶部信息条：当前项目 / 标注方式 / 当前图片 / 标注进度 / 当前类别。"""
+        bar = QWidget()
+        bar.setObjectName("page_header")
+
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(16, 10, 16, 10)
+        layout.setSpacing(20)
+
+        # 当前项目（项目名可能很长：宽度封顶 + 省略号，完整名字进 tooltip）
+        self.project_name_label = QLabel()
+        self.project_name_label.setObjectName("h2")
+        self.project_name_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        self.project_name_label.setMinimumWidth(110)
+        self.project_name_label.setMaximumWidth(200)
+        self._register_elided_label(self.project_name_label)
+        self._set_elided_text(self.project_name_label, "未选择项目")
+        layout.addLayout(self._context_field("当前项目", self.project_name_label), 1)
+
+        # 标注方式（任务类型）：决定用什么形状标注
+        self.task_combo = QComboBox()
+        self.task_combo.addItems(["detect", "segment", "pose", "classify"])
+        self.task_combo.setFixedWidth(128)
+        self.task_combo.setToolTip(
+            "决定用什么形状标注：\n"
+            "detect 检测 = 画矩形框\n"
+            "segment 分割 = 画多边形\n"
+            "pose 姿态 = 点关键点\n"
+            "classify 分类 = 整张图给一个类别"
+        )
+        self.task_combo.currentTextChanged.connect(self.on_task_changed)
+        layout.addLayout(self._context_field("标注方式", self.task_combo))
+
+        # 当前图片：文件名 + 第几张 + 标没标
+        self.image_name_label = QLabel()
+        self.image_name_label.setObjectName("title")
+        # 窗口变窄时优先压缩这一格，不把右边的进度和类别挤出去；压不下就打省略号，不切半个字
+        self.image_name_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        self.image_name_label.setMinimumWidth(150)
+        self._register_elided_label(self.image_name_label)
+        self._set_elided_text(self.image_name_label, "未选择图片")
+        layout.addLayout(self._context_field("当前图片", self.image_name_label), 2)
+
+        # 标注进度
+        progress_row = QWidget()
+        progress_layout = QHBoxLayout(progress_row)
+        progress_layout.setContentsMargins(0, 0, 0, 0)
+        progress_layout.setSpacing(8)
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setFixedWidth(120)
+        self.progress_bar.setTextVisible(False)
+        progress_layout.addWidget(self.progress_bar)
+        self.progress_label = QLabel("0/0 张已标注")
+        progress_layout.addWidget(self.progress_label)
+        layout.addLayout(self._context_field("标注进度", progress_row))
+
+        # 当前类别：右侧类别列表里选中的那个（类别名可能很长，同样封顶 + 省略号）
+        self.current_class_chip = QLabel()
+        self.current_class_chip.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        self.current_class_chip.setMinimumWidth(90)
+        self.current_class_chip.setMaximumWidth(160)
+        self._register_elided_label(self.current_class_chip)
+        self._set_elided_text(self.current_class_chip, "未选择")
+        layout.addLayout(self._context_field("当前类别", self.current_class_chip), 1)
+
+        return bar
+
+    def _register_elided_label(self, label: QLabel):
+        """登记一个会随宽度打省略号的标签：自己变宽变窄时重算。"""
+        if not hasattr(self, '_elided_labels'):
+            self._elided_labels = []
+        if label not in self._elided_labels:
+            self._elided_labels.append(label)
+            label.installEventFilter(self)
+
+    def _set_elided_text(self, label: QLabel, text: str, tooltip: Optional[str] = None):
+        """给标签设文本：显示时按当前宽度截断，完整内容放进 tooltip。"""
+        label.setProperty('_full_text', text)
+        label.setToolTip(text if tooltip is None else tooltip)
+        self._apply_elide(label)
+
+    def _apply_elide(self, label: QLabel):
+        """按标签当前宽度重新截断，永远不会切在半个字上。"""
+        full = label.property('_full_text')
+        if full is None:
+            return
+        metrics = QFontMetrics(label.font())
+        available = max(label.width(), 32)
+        label.setText(metrics.elidedText(str(full), Qt.TextElideMode.ElideRight, available))
+
+    def eventFilter(self, obj, event):
+        """信息条上的标签一变宽/变窄，就重新算省略号。"""
+        if event.type() == QEvent.Type.Resize and obj in getattr(self, '_elided_labels', ()):
+            self._apply_elide(obj)
+        return super().eventFilter(obj, event)
+
+    def _context_field(self, caption: str, widget: QWidget) -> QVBoxLayout:
+        """信息条里的一格：上面一行小字说明，下面是值。
+
+        每一格从顶上开始排，值占一行统一的高度。不这么钉住的话，放下拉框的那一格
+        （标注方式）比放纯文字的高一截，五个说明文字就会在垂直居中里各自漂移——
+        「标注方式」比旁边的「当前项目」高出 4px，整条信息条看着是歪的。
+        """
+        column = QVBoxLayout()
+        column.setContentsMargins(0, 0, 0, 0)
+        column.setSpacing(3)
+        column.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        label = QLabel(caption)
+        label.setObjectName("caption")
+        # 值有宽度上限时，说明文字也跟着封顶，否则整格会被说明文字撑得比值还宽
+        if widget.maximumWidth() < 16777215:
+            label.setMaximumWidth(widget.maximumWidth())
+        column.addWidget(label)
+
+        # 值这一行统一高度：文字格和控件格的下边缘也要对齐，不只是上边缘
+        widget.setMinimumHeight(CONTROL_HEIGHT)
+        column.addWidget(widget)
+        return column
 
     def _init_navigation_shortcuts(self):
         """初始化翻页快捷键，避免依赖控件焦点。"""
@@ -2314,15 +2654,55 @@ class AnnotatePage(QWidget):
 
         self._refresh_navigation_shortcuts()
 
-    def _refresh_navigation_shortcuts(self):
-        """读取设置中的翻页快捷键。"""
+    def _shortcut_keys(self) -> Dict[str, str]:
+        """当前生效的快捷键，与 keyPressEvent 读的是同一份设置。"""
         from PyQt6.QtCore import QSettings
 
         settings = QSettings("EzYOLO", "Settings")
-        prev_image_key = str(settings.value("prev_image_shortcut", "A")).upper()
-        next_image_key = str(settings.value("next_image_shortcut", "D")).upper()
-        self.prev_image_shortcut.setKey(QKeySequence(prev_image_key))
-        self.next_image_shortcut.setKey(QKeySequence(next_image_key))
+        return {
+            'prev': str(settings.value("prev_image_shortcut", "A")).upper(),
+            'next': str(settings.value("next_image_shortcut", "D")).upper(),
+            'rect': str(settings.value("rect_tool_shortcut", "W")).upper(),
+            'poly': str(settings.value("poly_tool_shortcut", "P")).upper(),
+            'move': str(settings.value("move_tool_shortcut", "V")).upper(),
+            'delete': str(settings.value("delete_shortcut", "DELETE")).upper(),
+        }
+
+    def _refresh_navigation_shortcuts(self):
+        """读取设置中的快捷键，并同步到翻页按钮和各处工具提示。"""
+        keys = self._shortcut_keys()
+        self.prev_image_shortcut.setKey(QKeySequence(keys['prev']))
+        self.next_image_shortcut.setKey(QKeySequence(keys['next']))
+
+        if hasattr(self, 'btn_prev'):
+            self.btn_prev.setText(f"◀ 上一张 ({keys['prev']})")
+            self.btn_next.setText(f"下一张 ({keys['next']}) ▶")
+
+        if hasattr(self, 'btn_move'):
+            self.btn_move.setToolTip(f"拖动画布和已有标注\n快捷键: {keys['move']}")
+        if hasattr(self, 'btn_delete'):
+            self.btn_delete.setToolTip(
+                f"删除当前选中的标注\n快捷键: {keys['delete']}\n下拉菜单里可以删除整张图片"
+            )
+        if hasattr(self, 'btn_draw_tool'):
+            self.refresh_draw_tool_button()
+
+        # 快捷键表不再常驻状态栏（1100px 下会被切断），改挂在「快捷键」按钮的提示里
+        shortcut_text = "\n".join([
+            f"{keys['prev']} / {keys['next']}　上一张 / 下一张",
+            f"{keys['rect']}　矩形",
+            f"{keys['poly']}　多边形",
+            f"{keys['move']}　移动",
+            "1-9　切换类别",
+            f"{keys['delete']}　删除标注",
+            "Ctrl+Z　撤销",
+        ])
+        if hasattr(self, 'btn_shortcut_help'):
+            self.btn_shortcut_help.setToolTip(shortcut_text)
+        if hasattr(self, 'status_bar'):
+            self.status_bar.setToolTip(shortcut_text)
+
+        self._update_canvas_placeholder()
 
     def _should_handle_navigation_shortcut(self) -> bool:
         """在当前焦点状态下是否允许触发翻页快捷键。"""
@@ -2354,89 +2734,72 @@ class AnnotatePage(QWidget):
 
     def create_left_panel(self) -> QWidget:
         """创建左侧面板 - 图片列表"""
-        panel = QFrame()
-        panel.setFrameStyle(QFrame.Shape.StyledPanel)
-        panel.setMaximumWidth(300)
-        panel.setStyleSheet(f"""
-            QFrame {{
-                background-color: {COLORS['panel']};
-                border-right: 1px solid {COLORS['border']};
-            }}
-        """)
-        
+        panel = QWidget()
+        panel.setMinimumWidth(175)
+        panel.setMaximumWidth(320)
+
         layout = QVBoxLayout(panel)
-        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setContentsMargins(10, 10, 6, 10)
         layout.setSpacing(8)
-        
+
         # 标题
-        title = QLabel("图片列表")
-        title.setStyleSheet(f"color: {COLORS['text_primary']}; font-size: 14px; font-weight: bold;")
+        title = QLabel("图片")
+        title.setObjectName("h2")
         layout.addWidget(title)
-        
-        # 任务类型选择器
-        task_layout = QHBoxLayout()
-        task_label = QLabel("任务类型:")
-        task_label.setStyleSheet(f"color: {COLORS['text_secondary']};")
-        task_layout.addWidget(task_label)
-        
-        self.task_combo = QComboBox()
-        self.task_combo.addItems(["detect", "segment", "pose", "classify"])
-        self.task_combo.currentTextChanged.connect(self.on_task_changed)
-        task_layout.addWidget(self.task_combo)
-        layout.addLayout(task_layout)
-        
+
+        # 这个项目里有多少图、标了多少
+        self.image_list_caption = QLabel("还没有图片")
+        self.image_list_caption.setObjectName("caption")
+        self.image_list_caption.setWordWrap(True)
+        layout.addWidget(self.image_list_caption)
+
         # 筛选
         self.image_filter = QComboBox()
         self.image_filter.addItems(["全部", "未标注", "已标注"])
+        self.image_filter.setToolTip("只看还没标的图片，可以避免漏标")
         self.image_filter.currentTextChanged.connect(self.filter_images)
         layout.addWidget(self.image_filter)
-        
-        # 图片列表
+
+        # 图片列表（✓ = 已标注，○ = 还没标）
         self.image_list = QListWidget()
-        self.image_list.setIconSize(QSize(80, 80))
-        self.image_list.setSpacing(4)
+        # 缩略图和文件名共用一行的宽度：80px 的图会把文件名挤成「sho…」，
+        # 64px 刚好让 shot0.jpg 这种长度完整显示
+        self.image_list.setIconSize(QSize(64, 64))
+        self.image_list.setSpacing(2)
+        self.image_list.setToolTip("✓ 已标注　○ 还没标注")
+        # 缩略图占掉大半行宽，文件名再长也只能就地省略：
+        # 让列表横向滚动的话，用户得拖着滚动条才能看全一个文件名，反而更糟
+        self.image_list.setTextElideMode(Qt.TextElideMode.ElideRight)
+        self.image_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.image_list.setWordWrap(False)
         self.image_list.itemClicked.connect(self.on_image_selected)
-        self.image_list.setStyleSheet(f"""
-            QListWidget {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-            }}
-            QListWidget::item {{
-                background-color: {COLORS['panel']};
-                border-radius: 4px;
-                padding: 4px;
-            }}
-            QListWidget::item:selected {{
-                background-color: {COLORS['primary']};
-            }}
-        """)
-        layout.addWidget(self.image_list)
-        
-        # 导航按钮
-        nav_layout = QHBoxLayout()
-        self.btn_prev = QPushButton("◀ 上一张")
-        self.btn_prev.clicked.connect(self.prev_image)
-        self.btn_next = QPushButton("下一张 ▶")
-        self.btn_next.clicked.connect(self.next_image)
-        nav_layout.addWidget(self.btn_prev)
-        nav_layout.addWidget(self.btn_next)
-        layout.addLayout(nav_layout)
-        
+        layout.addWidget(self.image_list, 1)
+
         return panel
-    
+
     def create_center_panel(self) -> QWidget:
-        """创建中间面板 - 标注画布"""
+        """创建中间面板 - 工具栏 + 标注画布 + 翻页"""
         panel = QWidget()
-        panel.setMinimumWidth(620)
+        # 左 175 + 中 380 + 右 245 + 手柄，1100px 窗口下还留得出余量
+        panel.setMinimumWidth(380)
         layout = QVBoxLayout(panel)
-        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setContentsMargins(6, 10, 6, 10)
         layout.setSpacing(8)
-        
-        # 工具栏
+
+        # 工具栏：放进横向滚动区。窗口够宽时看不出区别；窗口很窄时工具栏自己滚，
+        # 而不是把「删除」这类按钮挤出屏幕，也不会把整页的最小宽度拉大。
         toolbar = self.create_toolbar()
-        layout.addWidget(toolbar)
-        
+        toolbar_scroll = QScrollArea()
+        toolbar_scroll.setWidgetResizable(True)
+        toolbar_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        toolbar_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        toolbar_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        toolbar_scroll.setWidget(toolbar)
+        toolbar_scroll.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self.toolbar_scroll = toolbar_scroll
+        self._sync_toolbar_scroll_height()
+        layout.addWidget(toolbar_scroll)
+
         # 标注画布
         self.canvas = AnnotationCanvas()
         self.canvas.annotation_created.connect(self.on_annotation_created)
@@ -2444,32 +2807,72 @@ class AnnotatePage(QWidget):
         self.canvas.annotation_modified.connect(self.on_annotation_modified)
         self.canvas.annotation_deleted.connect(self.on_annotation_deleted)
         layout.addWidget(self.canvas, stretch=1)
-        
+
+        # 翻页：这一页最主要的下一步动作就是「下一张」
+        layout.addWidget(self.create_navigation_bar())
+
         # 初始化时根据当前任务类型调整工具按钮的可见性
         current_task = self.task_combo.currentText()
         self.adjust_tool_visibility(current_task)
-        
+
         return panel
+
+    def _sync_toolbar_scroll_height(self):
+        """工具栏高度跟着实际内容走：按钮换行更高、或者出现横向滚动条时，都不会被悄悄切掉。"""
+        scroll = getattr(self, 'toolbar_scroll', None)
+        if scroll is None:
+            return
+
+        content = scroll.widget()
+        if content is None:
+            return
+
+        height = content.sizeHint().height() + 12
+        scrollbar = scroll.horizontalScrollBar()
+        if scrollbar is not None and scrollbar.isVisible():
+            height += scrollbar.sizeHint().height()
+
+        if scroll.minimumHeight() != height:
+            scroll.setMinimumHeight(height)
+            scroll.setMaximumHeight(height)
+
+    def create_navigation_bar(self) -> QWidget:
+        """画布下方的翻页条：上一张 / 下一张（主操作）。"""
+        bar = QWidget()
+        bar.setToolTip("标注自动保存，不需要手动保存")
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        self.btn_prev = QPushButton("◀ 上一张")
+        self.btn_prev.setMinimumHeight(34)
+        self.btn_prev.clicked.connect(self.prev_image)
+        layout.addWidget(self.btn_prev)
+
+        layout.addStretch(1)
+
+        self.btn_next = QPushButton("下一张 ▶")
+        self.btn_next.setObjectName("primary")
+        self.btn_next.setMinimumHeight(34)
+        self.btn_next.setMinimumWidth(130)
+        self.btn_next.clicked.connect(self.next_image)
+        layout.addWidget(self.btn_next)
+
+        return bar
     
     def create_toolbar(self) -> QWidget:
-        """创建工具栏"""
+        """创建工具栏：只放画标注和改标注的动作，AI 相关的入口在右侧面板。"""
         toolbar = QFrame()
-        toolbar.setStyleSheet(f"""
-            QFrame {{
-                background-color: {COLORS['panel']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-            }}
-        """)
+        toolbar.setObjectName("toolbar")
         toolbar_layout = QHBoxLayout(toolbar)
-        toolbar_layout.setContentsMargins(6, 3, 6, 3)
-        toolbar_layout.setSpacing(14)
+        toolbar_layout.setContentsMargins(8, 6, 8, 6)
+        toolbar_layout.setSpacing(8)
         base_tool_button_style = self._toolbar_chip_style('tool')
-        
+
         # 工具按钮组
         self.tool_group = QButtonGroup(self)
         self.tool_group.setExclusive(True)
-        
+
         # 绘制工具（矩形/多边形合并）
         self.btn_draw_tool = QToolButton()
         self.btn_draw_tool.setCheckable(True)
@@ -2485,16 +2888,16 @@ class AnnotatePage(QWidget):
         self.btn_draw_tool.setMenu(self.draw_tool_menu)
         self.btn_draw_tool.hide()  # 默认隐藏
         self.tool_group.addButton(self.btn_draw_tool)
-        
+
         # 关键点工具
-        self.btn_keypoint = QPushButton("📍 关键点")
-        self.btn_keypoint.setToolTip("关键点工具")
+        self.btn_keypoint = QPushButton("关键点")
+        self.btn_keypoint.setToolTip("在目标上依次点关键点（姿态任务）")
         self.btn_keypoint.setCheckable(True)
         self.btn_keypoint.clicked.connect(lambda: self.set_tool('keypoint'))
         self.btn_keypoint.setStyleSheet(base_tool_button_style)
         self.btn_keypoint.hide()  # 默认隐藏
         self.tool_group.addButton(self.btn_keypoint)
-        
+
         # # OBB工具
         # self.btn_obb = QPushButton("🔲 旋转矩形 (O)")
         # self.btn_obb.setCheckable(True)
@@ -2502,19 +2905,23 @@ class AnnotatePage(QWidget):
         # toolbar.addWidget(self.btn_obb)
         # self.btn_obb.hide()  # 默认隐藏
         # self.tool_group.addButton(self.btn_obb)
-        
+
         # 移动工具
-        self.btn_move = QPushButton("✋ 移动")
-        self.btn_move.setToolTip("移动视图")
+        self.btn_move = QPushButton("移动")
+        self.btn_move.setToolTip("拖动画布和已有标注")
         self.btn_move.setCheckable(True)
         self.btn_move.clicked.connect(lambda: self.set_tool('move'))
         self.btn_move.setStyleSheet(base_tool_button_style)
         self.tool_group.addButton(self.btn_move)
 
+        # 撤销按钮
+        self.btn_undo = QPushButton("撤销")
+        self.btn_undo.setToolTip("撤销上一步\n快捷键: Ctrl+Z")
+        self.btn_undo.clicked.connect(self.undo)
+
         # 删除按钮（主动作删标注，下拉菜单删图片）
         self.btn_delete = QToolButton()
-        self.btn_delete.setText("🗑️ 删除")
-        self.btn_delete.setToolTip("删除当前选中标注\n快捷键: D")
+        self.btn_delete.setText("删除")
         self.btn_delete.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         self.btn_delete.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
         self.btn_delete.setStyleSheet(self._toolbar_chip_style('danger'))
@@ -2524,144 +2931,126 @@ class AnnotatePage(QWidget):
         self.action_delete_current_image.triggered.connect(self.delete_current_image)
         self.delete_menu.aboutToShow.connect(self.update_delete_menu_state)
         self.btn_delete.setMenu(self.delete_menu)
-        
-        # 撤销按钮
-        self.btn_undo = QPushButton("↶ 撤销")
-        self.btn_undo.setToolTip("撤销上一步\n快捷键: Ctrl+Z")
-        self.btn_undo.clicked.connect(self.undo)
-        self.btn_undo.setStyleSheet(base_tool_button_style)
-        
-        # 自动标注按钮
-        self.btn_auto_label = QPushButton("🤖 自动标注")
-        self.btn_auto_label.setMenu(self.create_auto_label_menu())
-        self.btn_auto_label.setStyleSheet(self._toolbar_menu_button_style('ai_blue'))
-        
-        # SAM自动标注按钮
-        self.btn_sam = QPushButton("🎯 SAM")
-        self.btn_sam.setToolTip("使用SAM进行交互式分割标注")
-        self.btn_sam.setStyleSheet(self._toolbar_menu_button_style('ai_green'))
-        self.apply_sam_button_mode()
-        
-        # LLM自动标注按钮
-        self.btn_llm_label = QPushButton("🧠 LLM")
-        self.btn_llm_label.setToolTip("使用多模态大模型进行自动标注")
-        self.btn_llm_label.setMenu(self.create_llm_menu())
-        self.btn_llm_label.setStyleSheet(self._toolbar_menu_button_style('ai_gold'))
-        
-        # 批量处理按钮
-        self.btn_batch_process = QPushButton("📋 批处理")
-        self.btn_batch_process.clicked.connect(self.show_batch_process_dialog)
-        self.btn_batch_process.setToolTip("批量处理工具")
-        self.btn_batch_process.setStyleSheet(self._toolbar_chip_style('ai_olive'))
 
         self.toolbar_draw_buttons = [self.btn_draw_tool, self.btn_keypoint, self.btn_move]
-        self.toolbar_edit_buttons = [self.btn_delete, self.btn_undo]
-        self.toolbar_ai_buttons = [self.btn_auto_label, self.btn_sam, self.btn_llm_label, self.btn_batch_process]
-        self.toolbar_draw_group = self._create_toolbar_button_group(self.toolbar_draw_buttons)
-        self.toolbar_edit_group = self._create_toolbar_button_group(self.toolbar_edit_buttons)
-        self.toolbar_ai_group = self._create_toolbar_button_group(self.toolbar_ai_buttons)
+        self.toolbar_edit_buttons = [self.btn_undo, self.btn_delete]
+        self.toolbar_draw_group = self._create_toolbar_button_group("标注工具", self.toolbar_draw_buttons)
+        self.toolbar_edit_group = self._create_toolbar_button_group("修改", self.toolbar_edit_buttons)
         self.toolbar_groups = [
             (self.toolbar_draw_group, self.toolbar_draw_buttons),
             (self.toolbar_edit_group, self.toolbar_edit_buttons),
-            (self.toolbar_ai_group, self.toolbar_ai_buttons),
         ]
 
         toolbar_layout.addWidget(self.toolbar_draw_group)
+        toolbar_layout.addWidget(self._toolbar_separator())
         toolbar_layout.addWidget(self.toolbar_edit_group)
-        toolbar_layout.addWidget(self.toolbar_ai_group)
         toolbar_layout.addStretch(1)
 
         self.refresh_draw_tool_button()
         self.refresh_toolbar_button_layout()
-        
+
         return toolbar
 
-    def _create_toolbar_button_group(self, buttons) -> QWidget:
-        """创建工具栏按钮组，显式控制组内间距。"""
+    def _create_toolbar_button_group(self, caption: str, buttons) -> QWidget:
+        """创建工具栏按钮组：上面一行小字说明这组是干什么的。"""
         group_widget = QWidget()
-        layout = QHBoxLayout(group_widget)
+        layout = QVBoxLayout(group_widget)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        layout.setSpacing(2)
+
+        label = QLabel(caption)
+        label.setObjectName("caption")
+        layout.addWidget(label)
+
+        button_row = QHBoxLayout()
+        button_row.setContentsMargins(0, 0, 0, 0)
+        button_row.setSpacing(8)
         for button in buttons:
-            layout.addWidget(button)
+            button_row.addWidget(button)
+        layout.addLayout(button_row)
         return group_widget
 
+    def _toolbar_separator(self) -> QFrame:
+        """工具栏里的竖直分隔线。"""
+        line = QFrame()
+        line.setFixedWidth(1)
+        line.setStyleSheet(
+            f"background-color: {COLORS['border']}; border: none; border-radius: 0px;"
+        )
+        return line
+
     def _toolbar_chip_style(self, role: str) -> str:
-        """生成顶部工具栏按钮样式。"""
+        """工具栏按钮样式。
+
+        选中的工具 = 实心蓝（就是它在生效），未选中 = 描边；
+        删除是破坏性动作，单独用红色描边，不和普通工具混在一起。
+        """
         palette_map = {
             'tool': {
-                'bg': '#154B78',
-                'hover': '#1D629B',
-                'active': COLORS['primary'],
-                'border': '#2871A8',
-                'text': '#F7FBFF',
+                'text': COLORS['text_primary'],
+                'border': COLORS['border_strong'],
+                'hover_border': COLORS['primary_hover'],
+                'checked': COLORS['primary'],
+                'checked_hover': COLORS['primary_hover'],
             },
             'danger': {
-                'bg': '#154B78',
-                'hover': '#1D629B',
-                'active': COLORS['primary'],
-                'border': '#2871A8',
-                'text': '#F7FBFF',
-            },
-            'ai_blue': {
-                'bg': '#154B78',
-                'hover': '#1D629B',
-                'active': COLORS['primary'],
-                'border': '#2871A8',
-                'text': '#F7FBFF',
-            },
-            'ai_green': {
-                'bg': '#154B78',
-                'hover': '#1D629B',
-                'active': COLORS['primary'],
-                'border': '#2871A8',
-                'text': '#F7FBFF',
-            },
-            'ai_gold': {
-                'bg': '#154B78',
-                'hover': '#1D629B',
-                'active': COLORS['primary'],
-                'border': '#2871A8',
-                'text': '#F7FBFF',
-            },
-            'ai_olive': {
-                'bg': '#154B78',
-                'hover': '#1D629B',
-                'active': COLORS['primary'],
-                'border': '#2871A8',
-                'text': '#F7FBFF',
+                'text': COLORS['error'],
+                'border': COLORS['border_strong'],
+                'hover_border': COLORS['error'],
+                'checked': COLORS['error'],
+                'checked_hover': COLORS['error'],
             },
         }
         palette = palette_map[role]
         return f"""
             QPushButton, QToolButton {{
-                background-color: {palette['bg']};
+                background-color: {COLORS['panel']};
                 color: {palette['text']};
                 border: 1px solid {palette['border']};
-                border-radius: 6px;
+                border-radius: {RADIUS_SM}px;
                 padding: 4px 10px;
                 font-weight: 600;
             }}
             QPushButton:hover, QToolButton:hover {{
-                background-color: {palette['hover']};
-                border-color: {palette['active']};
+                background-color: {COLORS['hover']};
+                border-color: {palette['hover_border']};
             }}
             QPushButton:checked, QToolButton:checked {{
-                background-color: {palette['active']};
-                color: white;
-                border-color: {palette['active']};
+                background-color: {palette['checked']};
+                color: #FFFFFF;
+                border-color: {palette['checked']};
+            }}
+            QPushButton:disabled, QToolButton:disabled {{
+                background-color: {COLORS['panel']};
+                color: {COLORS['text_disabled']};
+                border-color: {COLORS['border']};
             }}
             QToolButton::menu-button {{
                 subcontrol-origin: padding;
                 subcontrol-position: right center;
                 width: 16px;
-                background-color: rgba(255, 255, 255, 0.08);
-                border-left: 1px solid rgba(255, 255, 255, 0.14);
-                border-top-right-radius: 6px;
-                border-bottom-right-radius: 6px;
+                background-color: {COLORS['panel']};
+                border-left: 1px solid {COLORS['border']};
+                border-top-right-radius: {RADIUS_SM}px;
+                border-bottom-right-radius: {RADIUS_SM}px;
             }}
             QToolButton::menu-button:hover {{
-                background-color: rgba(255, 255, 255, 0.14);
+                background-color: {COLORS['hover']};
+            }}
+            /* 子控件要写在伪状态前面。写成 QToolButton:checked::menu-button，
+               Qt 认不出子控件，会把这条的底色刷满整个按钮——没选中的「删除」
+               也会变成一整块实心红。 */
+            QToolButton::menu-button:checked {{
+                background-color: {palette['checked']};
+                border-left: 1px solid {COLORS['panel']};
+            }}
+            QToolButton::menu-button:checked:hover {{
+                background-color: {palette['checked_hover']};
+                border-left: 1px solid {COLORS['panel']};
+            }}
+            QToolButton::menu-button:disabled {{
+                background-color: {COLORS['panel']};
+                border-left: 1px solid {COLORS['border']};
             }}
             QToolButton::menu-arrow {{
                 width: 10px;
@@ -2673,53 +3062,53 @@ class AnnotatePage(QWidget):
             }}
         """
 
-    def _toolbar_menu_button_style(self, role: str) -> str:
-        """菜单按钮样式：保留下拉菜单能力，但隐藏倒三角指示器。"""
-        base_style = self._toolbar_chip_style(role)
-        return base_style + """
-            QPushButton::menu-indicator {
-                image: none;
-                width: 0px;
-                subcontrol-origin: padding;
-                subcontrol-position: right center;
-            }
-        """
-
     def _get_toolbar_button_width(self, button) -> int:
         """计算按钮建议宽度，菜单按钮额外预留箭头空间。"""
         text_width = button.fontMetrics().horizontalAdvance(button.text())
-        extra_padding = 40
+        extra_padding = 24
         if isinstance(button, QToolButton) and button.menu() is not None:
-            extra_padding += 18
+            extra_padding += 16
         return text_width + extra_padding
 
     def refresh_toolbar_button_layout(self):
-        """按分组统一顶部按钮尺寸。"""
+        """统一顶部按钮高度，宽度按各自文字走。
+
+        以前是按分组统一宽度（都撑到组里最宽的那个），工具栏因此要 577px，
+        窗口一小就把删除按钮挤出可视区。这里只保证高度一致和一个最小宽度。
+        """
         button_height = 32
+        min_button_width = 78
         for group_widget, group in getattr(self, 'toolbar_groups', []):
             visible_buttons = [
                 button for button in group
                 if button is not None and not button.isHidden()
             ]
             group_widget.setVisible(bool(visible_buttons))
-            if not visible_buttons:
-                continue
-            group_width = max(self._get_toolbar_button_width(button) for button in visible_buttons)
             for button in visible_buttons:
                 button.setFixedHeight(button_height)
-                button.setFixedWidth(group_width)
+                button.setMinimumWidth(
+                    max(min_button_width, self._get_toolbar_button_width(button))
+                )
+
+        # 按钮显隐/文字变了，工具栏本身可能变高，容器高度要跟上
+        self._sync_toolbar_scroll_height()
 
     def refresh_draw_tool_button(self):
         """刷新绘制工具按钮文本与选项状态。"""
         if not hasattr(self, 'btn_draw_tool'):
             return
 
+        keys = self._shortcut_keys()
         if self.default_draw_tool == 'polygon':
-            self.btn_draw_tool.setText("🛑 绘制")
-            self.btn_draw_tool.setToolTip("当前默认绘制模式: 多边形\n点击主按钮直接进入多边形绘制")
+            self.btn_draw_tool.setText("画多边形")
+            self.btn_draw_tool.setToolTip(
+                f"沿目标轮廓依次点，回到起点闭合\n快捷键: {keys['poly']}\n点右侧箭头可换成矩形"
+            )
         else:
-            self.btn_draw_tool.setText("🟦 绘制")
-            self.btn_draw_tool.setToolTip("当前默认绘制模式: 矩形\n点击主按钮直接进入矩形绘制")
+            self.btn_draw_tool.setText("画方框")
+            self.btn_draw_tool.setToolTip(
+                f"按住左键拖出一个框\n快捷键: {keys['rect']}\n点右侧箭头可换成多边形"
+            )
 
         if hasattr(self, 'action_draw_rectangle'):
             self.action_draw_rectangle.setCheckable(True)
@@ -2764,12 +3153,17 @@ class AnnotatePage(QWidget):
         usage_mode = sam_config.get("usage_mode", "normal")
 
         if usage_mode == "memory" and sam_type in ("SAM2", "SAM3"):
-            self.btn_sam.setText("🎯 SAM记忆")
-            self.btn_sam.setToolTip("SAM记忆标注：更新记忆/清空记忆/单张推理/批量推理")
+            self.btn_sam.setText("SAM 记忆标注")
+            self.btn_sam.setToolTip(
+                "先教它认一次目标（更新记忆），之后就能自动标同类目标\n"
+                "菜单：更新记忆 / 清空记忆 / 单张推理 / 批量推理"
+            )
             self.btn_sam.setMenu(self.create_sam_memory_menu())
         else:
-            self.btn_sam.setText("🎯 SAM")
-            self.btn_sam.setToolTip("使用SAM进行交互式分割标注")
+            self.btn_sam.setText("SAM 交互分割")
+            self.btn_sam.setToolTip(
+                "在目标上点一下，SAM 自动分割出它的轮廓\n需要先在「用已有模型标注 → 设置」里配好 SAM 模型"
+            )
             self.btn_sam.clicked.connect(self.start_sam_annotation)
         self.refresh_toolbar_button_layout()
 
@@ -2791,204 +3185,217 @@ class AnnotatePage(QWidget):
         return menu
     
     def create_right_panel(self) -> QWidget:
-        """创建右侧面板 - 属性面板"""
-        panel = QFrame()
-        panel.setFrameStyle(QFrame.Shape.StyledPanel)
-        panel.setMaximumWidth(300)
-        panel.setStyleSheet(f"""
-            QFrame {{
-                background-color: {COLORS['panel']};
-                border-left: 1px solid {COLORS['border']};
-            }}
-        """)
-        
-        layout = QVBoxLayout(panel)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(8)
-        
-        # 类别列表
-        class_group = QGroupBox("类别列表")
-        class_group.setStyleSheet(f"""
-            QGroupBox {{
-                color: {COLORS['text_primary']};
-                font-weight: bold;
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                margin-top: 8px;
-                padding-top: 8px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 8px;
-                padding: 0 4px;
-            }}
-        """)
+        """创建右侧面板 - 类别、AI 自动标注、样本管理、导出
+
+        整块可以滚动：窗口再矮也不会把下面的按钮压没。
+        """
+        panel = QWidget()
+        panel.setMinimumWidth(245)
+        panel.setMaximumWidth(340)
+
+        outer = QVBoxLayout(panel)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        # 横向滚动条平时不会出现；万一字体更宽把内容撑出去，也是能滚到而不是被切掉
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+
+        content = QWidget()
+        layout = QVBoxLayout(content)
+        layout.setContentsMargins(0, 8, 0, 8)
+        layout.setSpacing(10)
+
+        layout.addWidget(self._create_class_group())
+        layout.addWidget(self._create_ai_group())
+        layout.addWidget(self._create_sample_group())
+        layout.addWidget(self._create_export_group())
+        layout.addStretch()
+
+        scroll.setWidget(content)
+        outer.addWidget(scroll)
+
+        return panel
+
+    def _create_class_group(self) -> QGroupBox:
+        """类别：标注的第一步——先说清楚要画的是什么。"""
+        class_group = QGroupBox("类别")
         class_layout = QVBoxLayout(class_group)
-        
+        class_layout.setSpacing(8)
+
         self.class_list = QListWidget()
-        self.class_list.setStyleSheet(f"""
-            QListWidget {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-            }}
-            QListWidget::item {{
-                padding: 6px 8px;
-                min-height: 24px;
-            }}
-            QListWidget::item:selected {{
-                background-color: {COLORS['primary']};
-            }}
-        """)
+        self.class_list.setMinimumHeight(120)
         self.class_list.setSpacing(2)
+        self.class_list.setToolTip("数字键 1-9 切换类别；右键类别可改名或删除")
         self.class_list.itemClicked.connect(self.on_class_selected)
         self.class_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.class_list.customContextMenuRequested.connect(self.show_class_context_menu)
         class_layout.addWidget(self.class_list)
-        
-        compact_action_button_height = 24
-        compact_action_button_style = f"""
-            QPushButton {{
-                min-height: {compact_action_button_height}px;
-                max-height: {compact_action_button_height}px;
-                padding: 0 10px;
-            }}
-        """
 
-        # 添加类别按钮
+        # 隐藏的类别下拉：仍然承担「选中标注 → 改类别」的数据流，不再占版面
+        self.attr_class = QComboBox(class_group)
+        self.attr_class.currentIndexChanged.connect(self.on_attr_class_changed)
+        self.attr_class.hide()
+
         self.btn_add_class = QPushButton("+ 添加类别")
         self.btn_add_class.clicked.connect(self.add_class)
-        self.btn_add_class.setFixedHeight(compact_action_button_height)
         self.btn_add_class.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        self.btn_add_class.setStyleSheet(compact_action_button_style)
-        self.btn_apply_attr = QPushButton("应用修改")
+
+        # 只有「选中了一个标注、且选的类别和它现在的不一样」时才可点
+        self.btn_apply_attr = QPushButton("改为选中类别")
+        self.btn_apply_attr.setToolTip("把画布上选中的那个标注，改成当前选中的类别")
         self.btn_apply_attr.clicked.connect(self.apply_annotation_changes)
-        self.btn_apply_attr.setFixedHeight(compact_action_button_height)
         self.btn_apply_attr.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        self.btn_apply_attr.setStyleSheet(compact_action_button_style)
         self.btn_apply_attr.setEnabled(False)
+
         class_button_row = QHBoxLayout()
         class_button_row.setContentsMargins(0, 0, 0, 0)
         class_button_row.setSpacing(8)
         class_button_row.addWidget(self.btn_add_class, 1)
         class_button_row.addWidget(self.btn_apply_attr, 1)
         class_layout.addLayout(class_button_row)
-        
-        layout.addWidget(class_group)
-        
-        # 标注属性 / 样本调节
-        attr_group = QGroupBox("标注属性")
-        attr_group.setStyleSheet(class_group.styleSheet())
-        attr_layout = QFormLayout(attr_group)
-        attr_layout.setLabelAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
-        attr_layout.setFormAlignment(Qt.AlignmentFlag.AlignTop)
-        attr_layout.setVerticalSpacing(8)
-        attr_layout.setHorizontalSpacing(10)
 
-        field_style = f"""
-            QComboBox, QSpinBox {{
-                min-height: 32px;
-                padding: 3px 8px;
-                color: {COLORS['text_primary']};
-            }}
-        """
-        # 当前标注类别
-        self.attr_class = QComboBox()
-        self.attr_class.currentIndexChanged.connect(self.on_attr_class_changed)
-        self.attr_class.hide()
-        
-        # 当前目标标签的样本数
+        return class_group
+
+    def _create_ai_group(self) -> QGroupBox:
+        """AI 自动标注：让模型先画一遍，人只做检查和微调。"""
+        ai_group = QGroupBox("AI 自动标注")
+        ai_group.setToolTip("模型先标一遍，你只做检查和微调")
+        ai_layout = QVBoxLayout(ai_group)
+        ai_layout.setSpacing(8)
+
+        # 已有 YOLO 权重 → 自动画框
+        self.btn_auto_label = QPushButton("用已有模型标注")
+        self.btn_auto_label.setToolTip("用一个已经训练好的 .pt 模型自动标注\n菜单：设置 / 单张推理 / 批量推理")
+        self.btn_auto_label.setMenu(self.create_auto_label_menu())
+
+        # SAM：点一下就分割（文本和菜单由 apply_sam_button_mode 按设置决定）
+        self.btn_sam = QPushButton("SAM")
+
+        # 多模态大模型
+        self.btn_llm_label = QPushButton("大模型标注")
+        self.btn_llm_label.setToolTip("用多模态大模型识别图片里的目标\n菜单：单张推理 / 批量推理")
+        self.btn_llm_label.setMenu(self.create_llm_menu())
+
+        self.btn_batch_process = QPushButton("批处理")
+        self.btn_batch_process.setToolTip("按选中的像素点批量处理图片")
+        self.btn_batch_process.clicked.connect(self.show_batch_process_dialog)
+
+        self.ai_action_buttons = [
+            self.btn_auto_label, self.btn_sam, self.btn_llm_label, self.btn_batch_process
+        ]
+        for button in self.ai_action_buttons:
+            button.setMinimumHeight(32)
+            button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            ai_layout.addWidget(button)
+
+        self.apply_sam_button_mode()
+
+        return ai_group
+
+    def _create_sample_group(self) -> QGroupBox:
+        """样本管理：负样本标记 + 按类别随机删图，用来平衡数据。"""
+        sample_group = QGroupBox("样本管理（进阶）")
+        sample_group.setToolTip("按整张图片随机删除，用来平衡类别；负样本 = 已标注但没有任何框的图片")
+        sample_layout = QVBoxLayout(sample_group)
+        sample_layout.setSpacing(8)
+
+        self.btn_mark_negative_sample = QPushButton("把当前图片标为负样本")
+        self.btn_mark_negative_sample.setToolTip("这张图里没有任何目标，也是有用的学习材料")
+        self.btn_mark_negative_sample.clicked.connect(self.mark_current_image_as_negative_sample)
+        self.btn_mark_negative_sample.setMinimumHeight(30)
+        self.btn_mark_negative_sample.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sample_layout.addWidget(self.btn_mark_negative_sample)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        form.setFormAlignment(Qt.AlignmentFlag.AlignTop)
+        form.setVerticalSpacing(8)
+        form.setHorizontalSpacing(10)
+        form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+        # 面板窄的时候标签自动换到字段上一行，而不是把面板顶宽
+        form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
+
         self.sample_target_class = QComboBox()
+        self.sample_target_class.setMinimumWidth(90)
         self.sample_target_class.currentIndexChanged.connect(self.on_sample_target_changed)
-        self.sample_target_class.setStyleSheet(field_style)
-        attr_layout.addRow("删样标签:", self.sample_target_class)
+        form.addRow("删哪个类别:", self.sample_target_class)
 
         self.sample_count_label = QLabel("0")
-        self.sample_count_label.setMinimumHeight(32)
+        self.sample_count_label.setMinimumHeight(30)
         self.sample_count_label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft)
         self.sample_count_label.setStyleSheet(f"""
             QLabel {{
                 color: {COLORS['text_primary']};
-                padding: 6px 8px;
+                padding: 6px 10px;
                 border: 1px solid {COLORS['border']};
-                background-color: {COLORS['sidebar']};
-                border-radius: 4px;
+                background-color: {COLORS['inset']};
+                border-radius: {RADIUS_SM}px;
             }}
         """)
-        attr_layout.addRow("标签个数:", self.sample_count_label)
+        form.addRow("现有图片数:", self.sample_count_label)
 
         self.sample_delete_count = QSpinBox()
         self.sample_delete_count.setRange(0, 0)
-        self.sample_delete_count.setStyleSheet(field_style)
-        attr_layout.addRow("随机删去:", self.sample_delete_count)
+        self.sample_delete_count.setMinimumWidth(90)
+        form.addRow("随机删去:", self.sample_delete_count)
 
-        self.sample_hint = QLabel("按整张图片随机删除；负样本指已标注但无任何框的图片。")
-        self.sample_hint.setWordWrap(True)
-        self.sample_hint.setStyleSheet(f"color: {COLORS['text_secondary']}; padding: 2px 0;")
-        attr_layout.addRow(self.sample_hint)
-
-        self.btn_mark_negative_sample = QPushButton("标注为负样本")
-        self.btn_mark_negative_sample.clicked.connect(self.mark_current_image_as_negative_sample)
-        self.btn_mark_negative_sample.setFixedHeight(compact_action_button_height)
-        self.btn_mark_negative_sample.setStyleSheet(compact_action_button_style)
-        self.btn_mark_negative_sample.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sample_layout.addLayout(form)
 
         self.btn_delete_random_samples = QPushButton("随机删除样本")
+        self.btn_delete_random_samples.setObjectName("danger")
+        self.btn_delete_random_samples.setToolTip("按整张图片随机删除，会连图片文件一起删掉，不可恢复")
         self.btn_delete_random_samples.clicked.connect(self.delete_random_samples_for_target)
-        self.btn_delete_random_samples.setFixedHeight(compact_action_button_height)
-        self.btn_delete_random_samples.setStyleSheet(compact_action_button_style)
+        self.btn_delete_random_samples.setMinimumHeight(30)
         self.btn_delete_random_samples.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sample_layout.addWidget(self.btn_delete_random_samples)
 
-        action_button_widget = QWidget()
-        action_button_layout = QHBoxLayout(action_button_widget)
-        action_button_layout.setContentsMargins(0, 0, 0, 0)
-        action_button_layout.setSpacing(8)
-        action_button_layout.addWidget(self.btn_mark_negative_sample, 1)
-        action_button_layout.addWidget(self.btn_delete_random_samples, 1)
-        attr_layout.addRow(action_button_widget)
-        
-        layout.addWidget(attr_group)
-        
-        # 导出功能
-        export_group = QGroupBox("数据导出")
-        export_group.setStyleSheet(class_group.styleSheet())
+        return sample_group
+
+    def _create_export_group(self) -> QGroupBox:
+        """导出：训练不需要手动导出，这里是给外部工具用的。"""
+        export_group = QGroupBox("数据导出（可选）")
+        export_group.setToolTip("训练会直接读标注，不用先导出；只有要把数据给别的工具用时才需要")
         export_layout = QVBoxLayout(export_group)
-        
-        # 导出格式选择
+        export_layout.setSpacing(8)
+
         format_layout = QFormLayout()
+        format_layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+        format_layout.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
         self.export_format = QComboBox()
         self.export_format.addItems(["YOLO格式", "COCO格式"])
+        self.export_format.setMinimumWidth(90)
         format_layout.addRow("导出格式:", self.export_format)
         export_layout.addLayout(format_layout)
-        
-        # 导出按钮
-        self.btn_export_annotations = QPushButton("📤 导出标注文件")
+
+        self.btn_export_annotations = QPushButton("导出标注文件")
         self.btn_export_annotations.clicked.connect(self.export_annotations)
+        self.btn_export_annotations.setMinimumHeight(30)
         export_layout.addWidget(self.btn_export_annotations)
-        
-        self.btn_export_dataset = QPushButton("📦 导出完整数据集")
+
+        self.btn_export_dataset = QPushButton("导出完整数据集")
+        self.btn_export_dataset.setToolTip("图片 + 标注 + 训练用的 data.yaml")
         self.btn_export_dataset.clicked.connect(self.export_dataset)
+        self.btn_export_dataset.setMinimumHeight(30)
         export_layout.addWidget(self.btn_export_dataset)
-        
-        layout.addWidget(export_group)
-        
-        layout.addStretch()
-        
-        return panel
+
+        return export_group
     
     def create_auto_label_menu(self) -> QMenu:
         """创建自动标注下拉菜单"""
         menu = QMenu()
         
         # 设置选项
-        action_settings = menu.addAction("⚙️ 设置")
+        action_settings = menu.addAction("设置")
         action_settings.triggered.connect(self.show_auto_label_settings)
-        
+
         # 单张推理选项
-        action_single = menu.addAction("🔍 单张推理")
+        action_single = menu.addAction("单张推理")
         action_single.triggered.connect(self.run_single_inference)
-        
+
         # 批量推理选项
-        action_batch = menu.addAction("📋 批量推理")
+        action_batch = menu.addAction("批量推理")
         action_batch.triggered.connect(self.run_batch_inference)
         
         return menu
@@ -2998,54 +3405,196 @@ class AnnotatePage(QWidget):
         menu = QMenu()
         
         # 单张推理选项
-        action_single = menu.addAction("🔍 单张推理")
+        action_single = menu.addAction("单张推理")
         action_single.triggered.connect(self.run_llm_single_inference)
-        
+
         # 批量推理选项
-        action_batch = menu.addAction("📋 批量推理")
+        action_batch = menu.addAction("批量推理")
         action_batch.triggered.connect(self.run_llm_batch_inference)
         
         return menu
     
     def create_status_bar(self) -> QFrame:
-        """创建状态栏"""
+        """创建状态栏：位置、本图标注数、当前工具；快捷键收进右侧按钮的提示里。"""
         status_bar = QFrame()
-        status_bar.setFrameStyle(QFrame.Shape.StyledPanel)
-        status_bar.setMaximumHeight(40)
+        # 固定高度会在字体放大时把文字切掉，这里只给下限
+        status_bar.setMinimumHeight(34)
         status_bar.setStyleSheet(f"""
             QFrame {{
                 background-color: {COLORS['panel']};
+                border: none;
                 border-top: 1px solid {COLORS['border']};
+                border-radius: 0px;
             }}
             QLabel {{
                 color: {COLORS['text_secondary']};
                 font-size: 12px;
-                padding: 4px 12px;
             }}
         """)
-        
+
         layout = QHBoxLayout(status_bar)
-        layout.setContentsMargins(8, 4, 8, 4)
-        
+        layout.setContentsMargins(16, 4, 16, 4)
+        layout.setSpacing(12)
+
         self.status_image = QLabel("当前: 0/0")
         layout.addWidget(self.status_image)
-        
+
         layout.addWidget(QLabel("|"))
-        
-        self.status_annotation = QLabel("标注: 0")
+
+        self.status_annotation = QLabel("本图标注: 0")
         layout.addWidget(self.status_annotation)
-        
+
         layout.addWidget(QLabel("|"))
-        
-        self.status_position = QLabel("位置: --")
-        layout.addWidget(self.status_position)
-        
-        layout.addStretch()
-        
+
         self.status_tool = QLabel("工具: 矩形")
         layout.addWidget(self.status_tool)
-        
+
+        # 临时进度用（批量自动标注时显示正在处理哪张图），平时为空
+        self.status_position = QLabel("")
+        layout.addWidget(self.status_position, 1)
+
+        # 快捷键表以前是一整条常驻文字，窗口一窄就被切断；现在收进这个按钮的提示里
+        self.btn_shortcut_help = QPushButton("快捷键")
+        self.btn_shortcut_help.setObjectName("ghost")
+        self.btn_shortcut_help.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.btn_shortcut_help.setStyleSheet(
+            "QPushButton#ghost { padding: 1px 8px; min-height: 0px; font-size: 12px; }"
+        )
+        self.btn_shortcut_help.setFixedHeight(24)
+        self.btn_shortcut_help.clicked.connect(self._show_shortcut_help)
+        layout.addWidget(self.btn_shortcut_help)
+
         return status_bar
+
+    def _show_shortcut_help(self):
+        """点「快捷键」直接把提示弹出来，不用非得悬停等。"""
+        from PyQt6.QtWidgets import QToolTip
+
+        QToolTip.showText(
+            self.btn_shortcut_help.mapToGlobal(QPoint(0, 0)),
+            self.btn_shortcut_help.toolTip(),
+            self.btn_shortcut_help
+        )
+
+    def _current_image_index(self) -> int:
+        """当前图片在列表中的位置，没有则 -1。"""
+        if not self.current_image_id:
+            return -1
+        return next(
+            (i for i, img in enumerate(self.images) if img['id'] == self.current_image_id),
+            -1
+        )
+
+    def _update_context_bar(self):
+        """刷新顶部信息条和左侧图片计数。"""
+        if not hasattr(self, 'image_name_label'):
+            return
+
+        total = len(self.images)
+        annotated = sum(1 for img in self.images if img.get('status') == 'annotated')
+        index = self._current_image_index()
+
+        if not self.current_project_id:
+            self._set_elided_text(self.image_name_label, "未选择项目")
+        elif not self.images:
+            self._set_elided_text(self.image_name_label, "这个项目还没有图片")
+        elif index < 0:
+            self._set_elided_text(self.image_name_label, "未选择图片")
+        else:
+            image = self.images[index]
+            filename = image.get('filename', '')
+            status = "已标注" if image.get('status') == 'annotated' else "还没标注"
+            self._set_elided_text(
+                self.image_name_label,
+                f"{filename} · 第 {index + 1}/{total} 张 · {status}",
+                tooltip=filename
+            )
+
+        self.progress_bar.setMaximum(max(total, 1))
+        self.progress_bar.setValue(annotated)
+        self.progress_label.setText(f"{annotated}/{total} 张已标注" if total else "还没有图片")
+
+        if hasattr(self, 'image_list_caption'):
+            if total:
+                self.image_list_caption.setText(
+                    f"共 {total} 张 · 已标注 {annotated} · 还剩 {total - annotated}"
+                )
+            else:
+                self.image_list_caption.setText("还没有图片，请回到「数据导入」")
+
+        self._update_current_class_chip()
+        self._update_canvas_placeholder()
+
+    def _update_current_class_chip(self):
+        """信息条上的「当前类别」：画上去的就是它。"""
+        if not hasattr(self, 'current_class_chip'):
+            return
+
+        current = next((cls for cls in self.classes if cls['id'] == self.current_class_id), None)
+        if current is None:
+            self.current_class_chip.setStyleSheet(f"color: {COLORS['text_secondary']};")
+            self._set_elided_text(
+                self.current_class_chip, "未选择",
+                tooltip="画上去的标注算哪个类别，在右侧「类别」里换"
+            )
+            return
+
+        self.current_class_chip.setStyleSheet(
+            f"color: {_readable_on_light(current.get('color'))}; font-weight: 600;"
+        )
+        self._set_elided_text(
+            self.current_class_chip, f"■ {current['name']}",
+            tooltip=f"当前类别：{current['name']}\n在右侧「类别」里切换"
+        )
+
+    def _update_canvas_placeholder(self):
+        """画布空着的时候，告诉用户下一步该做什么。"""
+        if not hasattr(self, 'canvas'):
+            return
+
+        if not self.current_project_id:
+            hint = "还没有选择项目"
+        elif not self.images:
+            hint = "这个项目里还没有图片"
+        else:
+            hint = "从左边选一张图片开始"
+
+        if self.canvas.empty_hint != hint:
+            self.canvas.empty_hint = hint
+            if self.canvas.current_image is None:
+                self.canvas.update()
+
+    def _update_action_availability(self):
+        """没有项目/图片时就把对应的按钮关掉，别让人点了没反应。"""
+        has_project = bool(self.current_project_id)
+        has_image = bool(self.current_image_id)
+        index = self._current_image_index()
+
+        if hasattr(self, 'btn_prev'):
+            self.btn_prev.setEnabled(index > 0)
+            self.btn_next.setEnabled(0 <= index < len(self.images) - 1)
+
+        for name in ('btn_draw_tool', 'btn_keypoint', 'btn_move', 'btn_delete'):
+            button = getattr(self, name, None)
+            if button is not None:
+                button.setEnabled(has_image)
+
+        if hasattr(self, 'btn_undo'):
+            self.btn_undo.setEnabled(has_image and self.history_index >= 0)
+
+        # AI 入口只要求有项目：它们的菜单里还有「设置」和「批量推理」，
+        # 没选图片也该点得开；只对当前图片生效的那些，处理函数自己会提示先选图片。
+        for button in getattr(self, 'ai_action_buttons', []):
+            button.setEnabled(has_project)
+
+        if hasattr(self, 'btn_add_class'):
+            self.btn_add_class.setEnabled(has_project)
+        if hasattr(self, 'btn_mark_negative_sample'):
+            self.btn_mark_negative_sample.setEnabled(has_image)
+        for name in ('btn_delete_random_samples', 'btn_export_annotations', 'btn_export_dataset'):
+            button = getattr(self, name, None)
+            if button is not None:
+                button.setEnabled(has_project)
     
     def set_project(self, project_id: int):
         """设置当前项目"""
@@ -3115,16 +3664,23 @@ class AnnotatePage(QWidget):
         # 保存图片数据
         self.images = data.get('images', [])
         
-        # 设置任务类型选择器
+        # 设置项目名和任务类型选择器
         if self.current_project_id:
             project = db.get_project(self.current_project_id)
-            if project and project.get('type'):
-                task_type = project['type']
+            if project:
+                self._set_elided_text(
+                    self.project_name_label,
+                    project.get('name') or f"项目 {self.current_project_id}"
+                )
+
+                task_type = project.get('type')
                 if task_type in ['detect', 'segment', 'pose', 'classify', 'obb']:
                     index = self.task_combo.findText(task_type)
                     if index >= 0:
                         self.task_combo.setCurrentIndex(index)
-        
+        else:
+            self._set_elided_text(self.project_name_label, "未选择项目")
+
         # 开始加载图片列表（使用多线程加载缩略图）
         self.load_image_list()
     
@@ -3207,7 +3763,10 @@ class AnnotatePage(QWidget):
                     # 更新显示文本
                     status_text = "✓" if image_data.get('status') == 'annotated' else "○"
                     item.setText(f"{status_text} {image_data['filename']}")
-    
+
+            # 图片的已标注状态变了，进度也要跟着变
+            self.update_status_bar()
+
     def update_class_list(self):
         """更新类别列表"""
         current_attr_class = self.attr_class.currentData()
@@ -3258,7 +3817,8 @@ class AnnotatePage(QWidget):
             self.sample_target_class.setCurrentIndex(0)
         self.sample_target_class.blockSignals(False)
         self.update_sample_control_panel(class_sample_counts, negative_sample_count)
-        
+        self._update_current_class_chip()
+
         # 默认选中第一个类别
         if self.class_list.count() > 0:
             selected_row = next(
@@ -3344,6 +3904,7 @@ class AnnotatePage(QWidget):
 
         self._sync_attr_class_combo_from_list()
         self._refresh_annotation_class_controls()
+        self._update_current_class_chip()
 
     def _sync_attr_class_combo_from_list(self):
         """将类别列表当前选择同步到属性下拉框。"""
@@ -3487,42 +4048,105 @@ class AnnotatePage(QWidget):
         if hasattr(self, 'loading_label'):
             self.loading_label.hide()
     
-    def show_auto_label_settings(self):
-        """显示自动标注设置对话框"""
+    # 配置窗口里的三页：设置页和「去配置」入口按名字点进去，不让用户自己找
+    AUTO_LABEL_TABS = {'yolo': 0, 'sam': 1, 'llm': 2}
+
+    def open_auto_label_config(self, section: str = "") -> bool:
+        """打开自动标注配置窗口，可指定直接落在哪一页。
+
+        设置页和各处「去配置」入口都走这里——配置文件（SAM / LLM）是全局的，
+        没有项目也能配，只是类别映射没东西可写，这时不碰数据库。
+
+        返回用户有没有点保存。
+        """
         self.init_auto_label_components()
         self.auto_label_dialog.set_classes(self.classes)
-        
-        # 显示对话框
-        if self.auto_label_dialog.exec() == QDialog.DialogCode.Accepted:
-            # 获取任务类型
-            model_task = self.auto_label_dialog.get_model_task()
-            
-            # 保存设置
-            self.auto_label_settings = {
-                'model_path': self.auto_label_dialog.get_model_path(),
-                'model_task': model_task,  # 保存任务类型
-                'conf_threshold': self.auto_label_dialog.sb_conf_threshold.value(),
-                'iou_threshold': self.auto_label_dialog.sb_iou_threshold.value(),
-                'class_mapping': self.auto_label_dialog.get_class_mappings(),
-                'only_unlabeled': self.auto_label_dialog.chk_only_unlabeled.isChecked(),
-                'overwrite_labels': self.auto_label_dialog.chk_overwrite.isChecked()
-            }
-            
-            # 输出调试信息
 
-            
-            # 更新标注页面的类别列表
-            if hasattr(self.auto_label_dialog, 'project_classes'):
-                new_classes = self.auto_label_dialog.project_classes
-                if new_classes != self.classes:
-                    self.classes = new_classes
-                    # 更新数据库
-                    db.update_project(self.current_project_id, classes=self.classes)
-                    # 更新界面
-                    self.update_class_list()
-                    QMessageBox.information(self, "成功", "类别列表已更新")
-            self.apply_sam_button_mode()
-    
+        tab_index = self.AUTO_LABEL_TABS.get(section)
+        if tab_index is not None:
+            self.auto_label_dialog.tab_widget.setCurrentIndex(tab_index)
+
+        if self.auto_label_dialog.exec() != QDialog.DialogCode.Accepted:
+            return False
+
+        # 保存 YOLO 预标注的参数（SAM / LLM 的配置由对话框自己写进 config/*.json）
+        self.auto_label_settings = {
+            'model_path': self.auto_label_dialog.get_model_path(),
+            'model_task': self.auto_label_dialog.get_model_task(),
+            'conf_threshold': self.auto_label_dialog.sb_conf_threshold.value(),
+            'iou_threshold': self.auto_label_dialog.sb_iou_threshold.value(),
+            'class_mapping': self.auto_label_dialog.get_class_mappings(),
+            'only_unlabeled': self.auto_label_dialog.chk_only_unlabeled.isChecked(),
+            'overwrite_labels': self.auto_label_dialog.chk_overwrite.isChecked(),
+        }
+
+        # 类别是项目的东西：没有项目就没有类别可写，这时一个字都不往数据库里落
+        new_classes = getattr(self.auto_label_dialog, 'project_classes', None)
+        if self.current_project_id and new_classes is not None and new_classes != self.classes:
+            self.classes = new_classes
+            db.update_project(self.current_project_id, classes=self.classes)
+            self.update_class_list()
+            QMessageBox.information(self, "成功", "类别列表已更新")
+
+        self.apply_sam_button_mode()
+        return True
+
+    def _offer_auto_label_config(self, title: str, message: str, section: str) -> bool:
+        """缺配置时不只是「告诉用户去哪配」，而是给一个真能点开配置的按钮。
+
+        用户点「去配置」→ 直接开配置窗口的对应页；点了保存就返回 True，
+        调用方可以就地重读配置继续干活，不用再走一遍菜单。
+        """
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle(title)
+        box.setText(message)
+        config_btn = box.addButton("去配置", QMessageBox.ButtonRole.AcceptRole)
+        box.addButton("取消", QMessageBox.ButtonRole.RejectRole)
+        box.exec()
+
+        if box.clickedButton() is not config_btn:
+            return False
+        return self.open_auto_label_config(section)
+
+    @staticmethod
+    def _load_llm_config() -> dict:
+        """读 LLM 配置：默认值 + 用户存过的那份。"""
+        from gui.pages.auto_label_dialog import LLM_CONFIG_FILE, DEFAULT_LLM_CONFIG
+
+        llm_config = DEFAULT_LLM_CONFIG.copy()
+        if os.path.exists(LLM_CONFIG_FILE):
+            try:
+                with open(LLM_CONFIG_FILE, 'r', encoding='utf-8') as f:
+                    llm_config.update(json.load(f))
+            except Exception as e:
+                print(f"加载LLM配置失败: {e}")
+        return llm_config
+
+    def _require_llm_config(self) -> Optional[dict]:
+        """拿到能用的 LLM 配置；没填 API Key 就当场给一个能点开的配置入口。"""
+        llm_config = self._load_llm_config()
+        if llm_config.get('api_key'):
+            return llm_config
+
+        if not self._offer_auto_label_config(
+            "还没填 API Key",
+            "用大模型标注要先在 LLM 视觉里填好 API Key 和模型名。",
+            'llm',
+        ):
+            return None
+
+        llm_config = self._load_llm_config()
+        if not llm_config.get('api_key'):
+            QMessageBox.warning(self, "提示", "还是没有 API Key，填好之后再试。")
+            return None
+        return llm_config
+
+    def show_auto_label_settings(self):
+        """显示自动标注设置对话框（工具栏「自动标注 → 设置」）"""
+        self.open_auto_label_config()
+
+
     def start_sam_annotation(self):
         """开始SAM交互式标注"""
         if not self.current_project_id:
@@ -3551,11 +4175,21 @@ class AnnotatePage(QWidget):
         
         # 获取已保存的SAM配置（避免临时弹窗回落到默认值）
         sam_config = AutoLabelDialog.get_saved_sam_config()
-        
+
         if not sam_config or not sam_config.get('model_file'):
-            QMessageBox.warning(self, "提示", "请先配置SAM模型\n点击: 自动标注 → 设置 → SAM自动标注")
-            return
-        
+            # 配完就地继续，不用再点一遍「自动标注 → 设置」
+            if not self._offer_auto_label_config(
+                "还没配置 SAM 模型",
+                "SAM 交互分割要先选好分割模型和权重文件。",
+                'sam',
+            ):
+                return
+            sam_config = AutoLabelDialog.get_saved_sam_config()
+            if not sam_config or not sam_config.get('model_file'):
+                QMessageBox.warning(self, "提示", "还是没有可用的 SAM 权重，先配好再来。")
+                return
+
+
         # 获取项目类型
         project = db.get_project(self.current_project_id)
         project_type = project.get('type', 'detect') if isinstance(project, dict) else 'detect'
@@ -3598,8 +4232,16 @@ class AnnotatePage(QWidget):
             return None, None
         sam_config = AutoLabelDialog.get_saved_sam_config()
         if sam_config.get("usage_mode") != "memory" or sam_config.get("sam_type") not in ("SAM2", "SAM3"):
-            QMessageBox.warning(self, "提示", "当前SAM设置不是记忆标注模式（仅SAM2/SAM3支持）")
-            return None, None
+            if not self._offer_auto_label_config(
+                "当前不是记忆标注模式",
+                "记忆标注需要把 SAM 设成 SAM2 或 SAM3，并把用法选成「记忆」。",
+                'sam',
+            ):
+                return None, None
+            sam_config = AutoLabelDialog.get_saved_sam_config()
+            if sam_config.get("usage_mode") != "memory" or sam_config.get("sam_type") not in ("SAM2", "SAM3"):
+                QMessageBox.warning(self, "提示", "SAM 设置仍然不是记忆标注模式（仅 SAM2/SAM3 支持）。")
+                return None, None
         return sam_config, image_path
 
     def start_sam_memory_update(self):
@@ -4020,36 +4662,59 @@ class AnnotatePage(QWidget):
                     })
         return annotations
     
+    def _exit_batch_process_mode(self):
+        """退出批处理点选模式。
+
+        幂等：确认执行、点取消、直接关窗三条路径都走这里，重复调用没有副作用。
+        以前只有「确认执行」会清理，用户一取消就卡在点选模式里——画布上每点一下
+        还在继续加点，而且是加给一个已经关掉的对话框。
+        """
+        canvas = getattr(self, 'canvas', None)
+        if canvas is not None:
+            canvas.batch_process_mode = False
+            canvas.batch_process_points = []
+            canvas.batch_process_dialog = None
+            canvas.update()
+        self.batch_process_dialog = None
+
     def show_batch_process_dialog(self):
         """显示批量处理标注对话框"""
         if not self.current_project_id:
             QMessageBox.warning(self, "提示", "请先选择一个项目")
             return
-        
+
         if not self.images:
             QMessageBox.warning(self, "提示", "项目中没有图片")
             return
-        
+
+        # 上一次的对话框可能还开着，先收干净再开新的
+        previous = self.batch_process_dialog
+        self._exit_batch_process_mode()
+        if previous is not None:
+            previous.close()
+            previous.deleteLater()
+
         # 创建对话框
         dialog = BatchProcessDialog(self, self.classes, len(self.images))
         dialog.process_requested.connect(self.on_batch_process_requested)
-        
+        # 接受 / 取消 / 直接关窗都会触发 finished，统一在这里退出点选模式
+        dialog.finished.connect(lambda _result: self._exit_batch_process_mode())
+
         # 进入像素点选择模式
         self.batch_process_dialog = dialog
         self.canvas.batch_process_mode = True
         self.canvas.batch_process_points = []
         self.canvas.batch_process_dialog = dialog
-        
+        self.canvas.update()
+
         # 显示对话框（非模态，允许在图片上点击）
         dialog.show()
-    
+
     def on_batch_process_requested(self, config):
         """处理批量处理请求"""
         # 退出像素点选择模式
-        self.canvas.batch_process_mode = False
-        self.canvas.batch_process_points = []
-        self.canvas.batch_process_dialog = None
-        
+        self._exit_batch_process_mode()
+
         # 执行批量处理
         self.execute_batch_process(config)
     
@@ -4528,6 +5193,7 @@ class AnnotatePage(QWidget):
             self.canvas.current_class_id = self.current_class_id
             self._sync_attr_class_combo_from_list()
         self._refresh_annotation_class_controls()
+        self._update_current_class_chip()
     
     def filter_images(self, filter_text: str):
         """筛选图片"""
@@ -5311,14 +5977,13 @@ class AnnotatePage(QWidget):
         self.update_sample_control_panel()
     
     def update_status_bar(self):
-        """更新状态栏"""
+        """更新状态栏，并顺带刷新顶部信息条和按钮可用性。"""
         total = len(self.images)
-        current = 0
-        if self.current_image_id:
-            current = next((i for i, img in enumerate(self.images) if img['id'] == self.current_image_id), 0) + 1
-        
+        index = self._current_image_index()
+        current = index + 1 if index >= 0 else 0
+
         self.status_image.setText(f"当前: {current}/{total}")
-        self.status_annotation.setText(f"标注: {len(self.annotations)}")
+        self.status_annotation.setText(f"本图标注: {len(self.annotations)}")
         tool_names = {
             'rectangle': '矩形',
             'polygon': '多边形',
@@ -5327,31 +5992,36 @@ class AnnotatePage(QWidget):
             'obb': '旋转矩形'
         }
         self.status_tool.setText(f"工具: {tool_names.get(self.canvas.current_tool, self.canvas.current_tool)}")
-    
+        # 批量任务留下的临时进度文字到这里就该清掉
+        self.status_position.setText("")
+
+        self._update_context_bar()
+        self._update_action_availability()
+
     def keyPressEvent(self, event: QKeyEvent):
         """键盘事件"""
         from PyQt6.QtCore import QSettings
         
         # 获取快捷键设置
         settings = QSettings("EzYOLO", "Settings")
-        rect_tool_key = settings.value("rect_tool_shortcut", "W").upper()
-        poly_tool_key = settings.value("poly_tool_shortcut", "P").upper()
-        move_tool_key = settings.value("move_tool_shortcut", "V").upper()
-        delete_key = settings.value("delete_shortcut", "DELETE").upper()
+        rect_tool_key = str(settings.value("rect_tool_shortcut", "W"))
+        poly_tool_key = str(settings.value("poly_tool_shortcut", "P"))
+        move_tool_key = str(settings.value("move_tool_shortcut", "V"))
+        delete_key = str(settings.value("delete_shortcut", "DELETE"))
         
-        # 处理工具快捷键
+        # 处理工具快捷键（按键码比对，DELETE/SPACE/方向键这些没有字符的键才认得出来）
         key_text = event.text().upper()
-        if key_text == rect_tool_key:
+        if event_matches_shortcut(event, rect_tool_key):
             self.select_draw_tool('rectangle')
             return
-        elif key_text == poly_tool_key:
+        elif event_matches_shortcut(event, poly_tool_key):
             self.select_draw_tool('polygon')
             return
-        elif key_text == move_tool_key:
+        elif event_matches_shortcut(event, move_tool_key):
             self.btn_move.setChecked(True)
             self.set_tool('move')
             return
-        elif key_text == delete_key:
+        elif event_matches_shortcut(event, delete_key):
             self.delete_selected_annotation()
         elif event.modifiers() == Qt.KeyboardModifier.ControlModifier and event.key() == Qt.Key.Key_Z:
             self.undo()
@@ -5607,111 +6277,40 @@ class AnnotatePage(QWidget):
             return
         
         target_class = self.classes[self.current_class_id]['name']
-        
-        # 获取LLM配置
-        from gui.pages.auto_label_dialog import AutoLabelDialog, LLM_CONFIG_FILE, DEFAULT_LLM_CONFIG
-        import json
-        
-        # 加载LLM配置
-        llm_config = DEFAULT_LLM_CONFIG.copy()
-        if os.path.exists(LLM_CONFIG_FILE):
-            try:
-                with open(LLM_CONFIG_FILE, 'r', encoding='utf-8') as f:
-                    saved_config = json.load(f)
-                    llm_config.update(saved_config)
-            except Exception as e:
-                print(f"加载LLM配置失败: {e}")
-        
-        # 检查API Key
-        if not llm_config.get('api_key'):
-            QMessageBox.warning(self, "提示", "请先配置LLM API Key\n点击: 自动标注 → 设置 → LLM自动标注")
+
+        # 缺 API Key 时这里会给出「去配置」入口，配完直接往下走
+        llm_config = self._require_llm_config()
+        if not llm_config:
             return
-        
+
         # 显示进度对话框
         from PyQt6.QtWidgets import QProgressDialog
         progress = QProgressDialog("正在使用LLM进行目标检测...", "取消", 0, 0, self)
         progress.setWindowModality(Qt.WindowModality.WindowModal)
         progress.setCancelButton(None)
         progress.show()
-        
-        # 在后台线程中运行LLM推理
-        from PyQt6.QtCore import QThread, pyqtSignal
-        
-        class LLMInferenceWorker(QThread):
-            """LLM推理工作线程"""
-            inference_finished = pyqtSignal(bool, str, list)  # 成功, 消息, 检测结果
-            
-            def __init__(self, config, image_path, target):
-                super().__init__()
-                self.config = config
-                self.image_path = image_path
-                self.target = target
-            
-            def run(self):
-                try:
-                    import base64
-                    import re
-                    from openai import OpenAI
-                    
-                    # 读取图片
-                    with open(self.image_path, "rb") as f:
-                        img_base64 = base64.b64encode(f.read()).decode("utf-8")
-                    
-                    # 创建客户端
-                    client = OpenAI(
-                        api_key=self.config['api_key'],
-                        base_url=self.config['base_url']
-                    )
-                    
-                    # 格式化提示词
-                    system_prompt = self.config['system_prompt']
-                    user_prompt = self.config['user_prompt'].format(target=self.target)
-                    
-                    # 调用API
-                    completion = client.chat.completions.create(
-                        model=self.config['model_name'],
-                        messages=[
-                            {"role": "system", "content": system_prompt},
-                            {
-                                "role": "user",
-                                "content": [
-                                    {"type": "text", "text": user_prompt},
-                                    {
-                                        "type": "image_url",
-                                        "image_url": {"url": f"data:image/jpeg;base64,{img_base64}"}
-                                    }
-                                ]
-                            }
-                        ]
-                    )
-                    
-                    response_text = completion.choices[0].message.content
-                    print(f"LLM返回:\n{response_text}")
-                    
-                    # 解析返回的文本格式: target,[xmin,ymin,xmax,ymax]
-                    detections = []
-                    pattern = r'([^,\n]+),\[(\d+),(\d+),(\d+),(\d+)\]'
-                    matches = re.findall(pattern, response_text)
-                    
-                    for match in matches:
-                        label, xmin, ymin, xmax, ymax = match
-                        detections.append({
-                            "label": label.strip(),
-                            "bbox": [int(xmin), int(ymin), int(xmax), int(ymax)]
-                        })
-                    
-                    self.inference_finished.emit(True, f"检测到 {len(detections)} 个目标", detections)
-                    
-                except Exception as e:
-                    self.inference_finished.emit(False, f"推理出错: {str(e)}", [])
-        
-        # 创建并启动工作线程
-        self.llm_worker = LLMInferenceWorker(llm_config, image_path, target_class)
-        self.llm_worker.inference_finished.connect(
-            lambda success, msg, detections: self.on_llm_inference_finished(success, msg, detections, progress)
+
+        # 单张也走后台线程：请求要等几秒，界面不能在这几秒里僵着。
+        # 上一张还在跑就不再起新的：直接改写 self.llm_worker 会把最后一个引用丢掉，
+        # 那个还在 run() 里的 QThread 当场被回收——直接崩。
+        if self.llm_worker is not None and self.llm_worker.isRunning():
+            progress.close()
+            QMessageBox.information(self, "提示", "上一张还在跑，等它出结果再试。")
+            return
+
+        self.llm_worker = LLMBatchWorker(llm_config, [current_image], target_class)
+        self._track_llm_worker(self.llm_worker)
+        self.llm_worker.image_done.connect(
+            lambda _image_id, detections, error:
+                self.on_llm_inference_finished(
+                    not error,
+                    f"推理出错: {error}" if error else f"检测到 {len(detections)} 个目标",
+                    detections, progress,
+                )
         )
         self.llm_worker.start()
-    
+
+
     def on_llm_inference_finished(self, success, message, detections, progress_dialog):
         """LLM推理完成回调"""
         progress_dialog.close()
@@ -5796,27 +6395,18 @@ class AnnotatePage(QWidget):
             QMessageBox.warning(self, "提示", "请先选择一个类别")
             return
         
-        target_class = self.classes[self.current_class_id]['name']
-        
-        # 获取LLM配置
-        from gui.pages.auto_label_dialog import LLM_CONFIG_FILE, DEFAULT_LLM_CONFIG
-        import json
-        
-        # 加载LLM配置
-        llm_config = DEFAULT_LLM_CONFIG.copy()
-        if os.path.exists(LLM_CONFIG_FILE):
-            try:
-                with open(LLM_CONFIG_FILE, 'r', encoding='utf-8') as f:
-                    saved_config = json.load(f)
-                    llm_config.update(saved_config)
-            except Exception as e:
-                print(f"加载LLM配置失败: {e}")
-        
-        # 检查API Key
-        if not llm_config.get('api_key'):
-            QMessageBox.warning(self, "提示", "请先配置LLM API Key\n点击: 自动标注 → 设置 → LLM自动标注")
+        # 已经在跑就别再起一批：两批同时写标注，谁都说不清结果
+        if self.llm_batch_worker is not None and self.llm_batch_worker.isRunning():
+            QMessageBox.information(self, "提示", "上一批还在跑，等它结束或者先取消。")
             return
-        
+
+        target_class = self.classes[self.current_class_id]['name']
+
+        # 缺 API Key 时给「去配置」入口，配完继续
+        llm_config = self._require_llm_config()
+        if not llm_config:
+            return
+
         # 选择图片范围
         from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QSpinBox, QHBoxLayout, QPushButton
         
@@ -5869,132 +6459,106 @@ class AnnotatePage(QWidget):
             QMessageBox.warning(self, "提示", "没有选择要处理的图片")
             return
         
-        # 显示进度对话框
+        # 进度条：取消是「请求取消」，当前这张跑完就停，界面不等
         from PyQt6.QtWidgets import QProgressDialog
-        progress = QProgressDialog("正在使用LLM进行批量检测...", "取消", 0, len(images_to_process), self)
-        progress.setWindowModality(Qt.WindowModality.WindowModal)
-        progress.show()
-        
-        # 批量处理
-        total_added = 0
-        processed_count = 0
-        
-        import base64
-        import re
-        from openai import OpenAI
-        
-        for i, image_data in enumerate(images_to_process):
-            if progress.wasCanceled():
-                break
-            
-            progress.setValue(i)
-            progress.setLabelText(f"正在处理: {image_data.get('filename', '')} ({i+1}/{len(images_to_process)})")
-            
-            image_path = image_data.get('storage_path', '')
-            if not image_path or not os.path.exists(image_path):
-                continue
-            
-            try:
-                # 读取图片
-                with open(image_path, "rb") as f:
-                    img_base64 = base64.b64encode(f.read()).decode("utf-8")
-                
-                # 创建客户端
-                client = OpenAI(
-                    api_key=llm_config['api_key'],
-                    base_url=llm_config['base_url']
-                )
-                
-                # 格式化提示词
-                system_prompt = llm_config['system_prompt']
-                user_prompt = llm_config['user_prompt'].format(target=target_class)
-                
-                # 调用API
-                completion = client.chat.completions.create(
-                    model=llm_config['model_name'],
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "text": user_prompt},
-                                {
-                                    "type": "image_url",
-                                    "image_url": {"url": f"data:image/jpeg;base64,{img_base64}"}
-                                }
-                            ]
-                        }
-                    ]
-                )
-                
-                response_text = completion.choices[0].message.content
-                
-                # 解析返回的文本格式
-                detections = []
-                pattern = r'([^,\n]+),\[(\d+),(\d+),(\d+),(\d+)\]'
-                matches = re.findall(pattern, response_text)
-                
-                for match in matches:
-                    label, xmin, ymin, xmax, ymax = match
-                    detections.append({
-                        "label": label.strip(),
-                        "bbox": [int(xmin), int(ymin), int(xmax), int(ymax)]
-                    })
-                
-                # 添加检测结果为标注
-                image_id = image_data['id']
-                class_id = self.current_class_id
-                added_count = 0
-                
-                for det in detections:
-                    bbox = det.get("bbox", [0, 0, 0, 0])
-                    xmin, ymin, xmax, ymax = bbox
-                    
-                    # 创建标注数据
-                    annotation_data = {
-                        'x': float(xmin),
-                        'y': float(ymin),
-                        'width': float(xmax - xmin),
-                        'height': float(ymax - ymin)
-                    }
-                    
-                    # 保存到数据库
-                    class_name = self.classes[class_id]['name'] if class_id < len(self.classes) else 'unknown'
-                    ann_id = db.add_annotation(
-                        image_id=image_id,
-                        project_id=self.current_project_id,
-                        class_id=class_id,
-                        class_name=class_name,
-                        annotation_type='bbox',
-                        data=annotation_data
-                    )
-                    
-                    if ann_id:
-                        added_count += 1
-                
-                if added_count > 0:
-                    db.update_image_status(image_id, 'annotated')
-                    total_added += added_count
-                
-                processed_count += 1
-                
-            except Exception as e:
-                print(f"处理图片 {image_data.get('filename', '')} 时出错: {e}")
-                continue
-        
-        progress.setValue(len(images_to_process))
-        
-        # 重新加载标注
+        self.llm_batch_progress = QProgressDialog(
+            "正在使用LLM进行批量检测...", "取消", 0, len(images_to_process), self
+        )
+        self.llm_batch_progress.setWindowTitle("LLM 批量推理")
+        self.llm_batch_progress.setWindowModality(Qt.WindowModality.WindowModal)
+        self.llm_batch_progress.setAutoClose(False)
+        self.llm_batch_progress.setAutoReset(False)
+        self.llm_batch_progress.setValue(0)
+
+        self.llm_batch_total = len(images_to_process)
+        self.llm_batch_added = 0
+        self.llm_batch_class_id = self.current_class_id
+
+        self.llm_batch_worker = LLMBatchWorker(llm_config, images_to_process, target_class)
+        self.llm_batch_progress.canceled.connect(self.llm_batch_worker.cancel)
+        self.llm_batch_worker.image_started.connect(self.on_llm_batch_image_started)
+        self.llm_batch_worker.image_done.connect(self.on_llm_batch_image_done)
+        self.llm_batch_worker.batch_finished.connect(self.on_llm_batch_finished)
+        self._track_llm_worker(self.llm_batch_worker)
+
+        self.btn_llm_label.setEnabled(False)
+        self.llm_batch_progress.show()
+        self.llm_batch_worker.start()
+
+    def on_llm_batch_image_started(self, position: int, filename: str):
+        """第几张、哪一张，写在进度条上。"""
+        if not self.llm_batch_progress:
+            return
+        self.llm_batch_progress.setLabelText(
+            f"正在处理第 {position}/{self.llm_batch_total} 张：{filename}"
+        )
+
+    def on_llm_batch_image_done(self, image_id: int, detections: list, error: str):
+        """一张图片跑完：标注写库在界面线程做，进度往前走一格。"""
+        if self.llm_batch_progress:
+            self.llm_batch_progress.setValue(self.llm_batch_progress.value() + 1)
+
+        if error:
+            # 失败的图片只记账，不打断整批；错误里的密钥已经在线程里抹掉了
+            print(f"[LLM批量] 图片 {image_id} 处理失败: {error}")
+            return
+
+        class_id = self.llm_batch_class_id
+        class_name = self.classes[class_id]['name'] if class_id < len(self.classes) else 'unknown'
+        added = 0
+
+        for det in detections:
+            xmin, ymin, xmax, ymax = det.get("bbox", [0, 0, 0, 0])
+            ann_id = db.add_annotation(
+                image_id=image_id,
+                project_id=self.current_project_id,
+                class_id=class_id,
+                class_name=class_name,
+                annotation_type='bbox',
+                data={
+                    'x': float(xmin),
+                    'y': float(ymin),
+                    'width': float(xmax - xmin),
+                    'height': float(ymax - ymin),
+                },
+            )
+            if ann_id:
+                added += 1
+
+        if added:
+            db.update_image_status(image_id, 'annotated')
+            self.llm_batch_added += added
+
+    def on_llm_batch_finished(self, succeeded: int, failed: int, cancelled: bool):
+        """整批结束：收尾、刷新界面、把成绩单一次说清楚。"""
+        if self.llm_batch_progress:
+            self.llm_batch_progress.close()
+            self.llm_batch_progress = None
+
+        # 这里不销毁线程：batch_finished 是 run() 的最后一句，run() 还没返回，
+        # 一销毁就是「QThread: Destroyed while thread is still running」。
+        # 先挪到「等它退出」的列表里继续持有，_on_llm_worker_finished 再放手。
+        worker = self.llm_batch_worker
+        self.llm_batch_worker = None
+        if worker is not None and worker not in self._retired_llm_workers:
+            self._retired_llm_workers.append(worker)
+
+        self.btn_llm_label.setEnabled(True)
+
         self.load_annotations()
         self.update_image_list_display()
         self._invalidate_sample_stats_cache()
         self.update_sample_control_panel()
-        
-        QMessageBox.information(self, "完成", 
-            f"批量推理完成!\n"
-            f"处理了 {processed_count} 张图片\n"
-            f"共添加 {total_added} 个标注")
-    
+
+        headline = "批量推理已取消。" if cancelled else "批量推理完成！"
+        QMessageBox.information(
+            self, "完成",
+            f"{headline}\n"
+            f"成功 {succeeded} 张，失败 {failed} 张，共 {self.llm_batch_total} 张\n"
+            f"新增 {self.llm_batch_added} 个标注"
+        )
+
+
     def export_dataset(self):
         """导出完整数据集"""
         import shutil

--- a/gui/pages/annotate_page.py
+++ b/gui/pages/annotate_page.py
@@ -6,7 +6,7 @@
 
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QScrollArea, QGridLayout, QFrame, QFileDialog, QProgressBar,
+    QScrollArea, QGridLayout, QFrame, QFileDialog,
     QMenu, QMessageBox, QComboBox, QLineEdit, QSplitter,
     QListWidget, QListWidgetItem, QButtonGroup,
     QRadioButton, QSpinBox, QDoubleSpinBox, QFormLayout,
@@ -33,13 +33,31 @@ import gc
 import json
 import threading
 import random
+import sys
 
-from gui.styles import COLORS, RADIUS_SM, CONTROL_HEIGHT, get_primary_font_family
+from gui.styles import COLORS, RADIUS_SM, get_primary_font_family, set_menu_indicator
+from gui.display_names import display_name, display_names
+from gui.widgets.collapsible_section import CollapsibleSection
 from models.database import db
 from gui.widgets.loading_dialog import LoadingOverlay
+from gui.view_zoom import (
+    ZOOM_MAX, ZOOM_MIN, native_zoom_factor, pinch_zoom_factor,
+    wheel_zoom_factor, zoom_at,
+)
 
 SAM3_DOWNLOAD_URL = "https://huggingface.co/1038lab/sam3/discussions/1"
 NEGATIVE_SAMPLE_CLASS_ID = -1
+
+_ASSETS_DIR = Path(__file__).parent.parent / "assets"
+
+
+def _asset_icon(name: str) -> QIcon:
+    """gui/assets 下的 SVG 图标。"""
+    return QIcon(str(_ASSETS_DIR / name))
+
+# 工具栏按钮基础高度：实际高度还会按当前字体和 sizeHint 动态向上增长。
+# QToolButton（带下拉箭头）和 QPushButton 的默认高度不一致，所以需要统一下限。
+TOOLBAR_BUTTON_HEIGHT = 32
 
 
 def _readable_on_light(color: str) -> str:
@@ -622,7 +640,11 @@ class AnnotationCanvas(QFrame):
         self.current_image_path = None
         self.image_scale = 1.0
         self.image_offset = QPoint(0, 0)
-        
+
+        # 视图锁：锁上之后切换图片不再重新适配窗口，保持当前缩放和位置
+        self.view_locked = False
+        self.lock_button = None
+
         # 标注数据
         self.annotations = []  # 当前图像的所有标注
         self.selected_annotation_id = None
@@ -713,29 +735,137 @@ class AnnotationCanvas(QFrame):
         # 设置鼠标追踪
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-    
+
+        # macOS 的 Cocoa ZoomNativeGesture 已经是原生捏合输入；再让 Qt 合成
+        # PinchGesture 会把同一次手势缩放两遍。其他平台保留 Qt Pinch 作为入口。
+        self.pinch_gesture_registered = sys.platform != 'darwin'
+        if self.pinch_gesture_registered:
+            self.setAttribute(Qt.WidgetAttribute.WA_AcceptTouchEvents, True)
+            self.grabGesture(Qt.GestureType.PinchGesture)
+
+        # 视图锁按钮：浮在画布右上角
+        self.lock_button = QToolButton(self)
+        self.lock_button.setCheckable(True)
+        self.lock_button.setFixedSize(28, 28)
+        self.lock_button.setIconSize(QSize(16, 16))
+        self.lock_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.lock_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.lock_button.toggled.connect(self._on_view_lock_toggled)
+        self.lock_button.hide()
+        self._refresh_lock_button()
+
+    def _refresh_lock_button(self):
+        """锁按钮的图标、提示、配色跟着锁的状态走。"""
+        if self.lock_button is None:
+            return
+
+        locked = self.lock_button.isChecked()
+        self.lock_button.setIcon(
+            _asset_icon('lock-closed.svg' if locked else 'lock-open.svg')
+        )
+        self.lock_button.setToolTip(
+            "已锁定：切换图片保持缩放和位置" if locked else "锁定视图"
+        )
+        background = COLORS['selected'] if locked else COLORS['panel']
+        border = COLORS['primary'] if locked else COLORS['border']
+        # padding 必须显式清零：全局 QToolButton 给了 5px 10px，28px 的方按钮会把
+        # 图标压成一个小点
+        self.lock_button.setStyleSheet(f"""
+            QToolButton {{
+                background-color: {background};
+                border: 1px solid {border};
+                border-radius: {RADIUS_SM}px;
+                padding: 0px;
+            }}
+            QToolButton:hover {{
+                border-color: {COLORS['primary']};
+            }}
+        """)
+
+    def _on_view_lock_toggled(self, checked: bool):
+        """只改锁的状态，不动当前视图——锁上是为了保住现在看到的画面。"""
+        self.view_locked = checked
+        self._refresh_lock_button()
+
+    def _position_lock_button(self):
+        """右上角，距离右边和上边各 8px。"""
+        if self.lock_button is None:
+            return
+        self.lock_button.move(self.width() - self.lock_button.width() - 8, 8)
+        self.lock_button.raise_()
+
+    def _sync_lock_button(self):
+        """没有图片就没有视图可锁，按钮跟着藏起来。"""
+        if self.lock_button is None:
+            return
+        self.lock_button.setVisible(self.current_image is not None)
+        self._position_lock_button()
+
+    def _capture_locked_view(self) -> Optional[Tuple[float, float, float]]:
+        """锁定时记下缩放，以及视口中心落在当前图上的归一化位置（0~1）。"""
+        if not self.view_locked or self.current_image is None or self.image_scale <= 0:
+            return None
+
+        center = self.rect().center()
+        img_x, img_y = self.widget_to_image(center.x(), center.y())
+        return (
+            self.image_scale,
+            img_x / max(self.current_image.width(), 1),
+            img_y / max(self.current_image.height(), 1),
+        )
+
+    def _apply_locked_view(self, view: Tuple[float, float, float]):
+        """把上一张图的缩放和归一化中心搬到新图上：同尺寸时等于原样保留。"""
+        scale, norm_x, norm_y = view
+        self.image_scale = scale
+
+        width = self.current_image.width()
+        height = self.current_image.height()
+        center = self.rect().center()
+        self.image_offset = QPoint(
+            self._clamp_offset(center.x() - norm_x * width * scale, width * scale, self.width()),
+            self._clamp_offset(center.y() - norm_y * height * scale, height * scale, self.height()),
+        )
+
+    @staticmethod
+    def _clamp_offset(offset: float, scaled_length: float, viewport_length: int) -> int:
+        """新旧图尺寸差得离谱时，别让图整个滑出画布——至少留一条边在视口里。"""
+        overlap = min(40.0, scaled_length)
+        low = overlap - scaled_length
+        high = viewport_length - overlap
+        return int(round(min(max(offset, low), high)))
+
     def load_image(self, image_path: str):
         """加载图像"""
         if not image_path or not os.path.exists(image_path):
             self.current_image = None
             self.current_image_path = None
+            self._sync_lock_button()
             self.update()
             return
-        
+
         # 使用OpenCV加载图像
         img = cv2.imread(image_path)
         if img is not None:
+            # 换图之前先问上一张：锁着就把它的缩放和视口中心留下来
+            locked_view = self._capture_locked_view()
+
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
             h, w, ch = img.shape
             bytes_per_line = ch * w
             qt_image = QImage(img.data, w, h, bytes_per_line, QImage.Format.Format_RGB888)
             self.current_image = QPixmap.fromImage(qt_image)
             self.current_image_path = image_path
-            
-            # 重置视图
-            self.reset_view()
+
+            if locked_view is None:
+                # 没锁（或上一张压根没图）：照旧适配窗口
+                self.reset_view()
+            else:
+                self._apply_locked_view(locked_view)
+
+            self._sync_lock_button()
             self.update()
-    
+
     def reset_view(self):
         """重置视图"""
         if self.current_image is None:
@@ -1913,32 +2043,65 @@ class AnnotationCanvas(QFrame):
     
     def wheelEvent(self, event: QWheelEvent):
         """鼠标滚轮事件 - 缩放"""
-        if self.current_image is None:
-            return
-        
-        # 获取鼠标位置
-        mouse_pos = event.position().toPoint()
-        
-        # 计算缩放前鼠标对应的图像坐标
-        img_x_before = (mouse_pos.x() - self.image_offset.x()) / self.image_scale
-        img_y_before = (mouse_pos.y() - self.image_offset.y()) / self.image_scale
-        
-        # 计算缩放因子
         delta = event.angleDelta().y()
-        zoom_factor = 1.1 if delta > 0 else 0.9
-        
-        # 应用缩放
-        new_scale = self.image_scale * zoom_factor
-        new_scale = max(0.1, min(5.0, new_scale))  # 限制缩放范围
-        
-        # 调整偏移量，使鼠标位置对应的图像点保持不变
-        self.image_offset = QPoint(
-            int(mouse_pos.x() - img_x_before * new_scale),
-            int(mouse_pos.y() - img_y_before * new_scale)
+        if delta == 0:
+            delta = event.pixelDelta().y()
+        self._zoom_by_factor(wheel_zoom_factor(delta), event.position())
+        event.accept()
+
+    def event(self, event):
+        """统一接住原生捏合和 Qt PinchGesture，避免平台分支各自算缩放。"""
+        event_type = event.type()
+        if event_type == QEvent.Type.NativeGesture:
+            gesture_type = event.gestureType()
+            if gesture_type in (
+                Qt.NativeGestureType.BeginNativeGesture,
+                Qt.NativeGestureType.EndNativeGesture,
+            ):
+                event.accept()
+                return True
+            if gesture_type == Qt.NativeGestureType.ZoomNativeGesture:
+                self._zoom_by_factor(native_zoom_factor(event.value()), event.position())
+                event.accept()
+                return True
+            return super().event(event)
+
+        if event_type == QEvent.Type.Gesture:
+            pinch = event.gesture(Qt.GestureType.PinchGesture)
+            if pinch is None:
+                return super().event(event)
+
+            anchor = self.mapFromGlobal(pinch.centerPoint().toPoint())
+            if not self.rect().contains(anchor):
+                anchor = self.rect().center()
+            self._zoom_by_factor(pinch_zoom_factor(pinch.scaleFactor()), anchor)
+            event.accept(pinch)
+            return True
+
+        return super().event(event)
+
+    def _zoom_by_factor(self, factor: float, anchor) -> bool:
+        """所有缩放入口共用这里；只在最终落到像素坐标时取整，并至多刷新一次。"""
+        if self.current_image is None:
+            return False
+
+        new_scale, offset_x, offset_y = zoom_at(
+            self.image_scale,
+            self.image_offset.x(),
+            self.image_offset.y(),
+            anchor.x(),
+            anchor.y(),
+            factor,
+            (ZOOM_MIN, ZOOM_MAX),
         )
+        new_offset = QPoint(int(round(offset_x)), int(round(offset_y)))
+        if new_scale == self.image_scale and new_offset == self.image_offset:
+            return False
+
         self.image_scale = new_scale
-        
+        self.image_offset = new_offset
         self.update()
+        return True
     
     def keyPressEvent(self, event: QKeyEvent):
         """键盘事件"""
@@ -2372,7 +2535,9 @@ class AnnotationCanvas(QFrame):
     def resizeEvent(self, event):
         """窗口大小改变"""
         super().resizeEvent(event)
-        if self.current_image:
+        self._position_lock_button()
+        # 锁定时不重新适配：用户锁的就是当前这个缩放和位置
+        if self.current_image and not self.view_locked:
             self.reset_view()
 
 
@@ -2398,7 +2563,9 @@ class AnnotatePage(QWidget):
         self._negative_sample_count_cache = 0
         self._sample_stats_dirty = True
         self.default_draw_tool = 'rectangle'
-        
+        # 图片栏收起前的三栏宽度，展开时照着还回去；初值和 init_ui 里的初始比例一致
+        self._splitter_sizes = [205, 412, 247]
+
         # 自动标注相关属性
         self.auto_label_dialog = None
         self.model_manager = None
@@ -2480,6 +2647,7 @@ class AnnotatePage(QWidget):
         # 创建分割器
         splitter = QSplitter(Qt.Orientation.Horizontal)
         splitter.setChildrenCollapsible(False)
+        self.splitter = splitter
 
         # 左侧：图片列表
         self.left_panel = self.create_left_panel()
@@ -2493,11 +2661,10 @@ class AnnotatePage(QWidget):
         self.right_panel = self.create_right_panel()
         splitter.addWidget(self.right_panel)
 
-        # 初始比例要落在三个面板各自的 min/max 区间内（左 175~320 / 中 ≥380 / 右 245~340），
-        # 否则第一次绘制时会被重新夹紧，看起来像「跳」了一下。这里按 1100px 窗口的可用宽度分。
-        # 三栏在 1100 宽窗口下的实际分配（内容区约 884）。右栏要留出足够视口宽度：
-        # 它内部内容的最小宽度是 263px，少 1px 就会冒出一条横向滚动条。
-        splitter.setSizes([215, 385, 285])
+        # 初始比例要落在三个面板各自的 min/max 区间内（左 175~320 / 中 ≥412 / 右 232~280），
+        # 否则第一次绘制时会被重新夹紧，看起来像「跳」了一下。这里按 1100px 窗口的可用宽度分
+        # （内容区约 884）：中栏先拿够画布要的 412，剩下的给图片栏和属性栏。
+        splitter.setSizes([205, 412, 247])
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
         splitter.setStretchFactor(2, 0)
@@ -2509,6 +2676,7 @@ class AnnotatePage(QWidget):
         self.main_layout.addWidget(self.status_bar)
 
         self._init_navigation_shortcuts()
+        self._restore_image_list_collapsed()
         self._update_context_bar()
         self._update_action_availability()
 
@@ -2517,34 +2685,38 @@ class AnnotatePage(QWidget):
         self._refresh_navigation_shortcuts()
         super().showEvent(event)
 
-    def resizeEvent(self, event):
-        """窗口变化后重算工具栏高度：出现横向滚动条时别把按钮压掉一截。"""
-        super().resizeEvent(event)
-        self._sync_toolbar_scroll_height()
-
     def create_context_bar(self) -> QWidget:
-        """顶部信息条：当前项目 / 标注方式 / 当前图片 / 标注进度 / 当前类别。"""
+        """顶部信息条：当前图片 / 工具 / 标注方式。
+
+        这里不再放「当前项目」——左侧流程栏一直显示着当前项目，同一屏写两遍
+        不会让人更清楚自己在哪，只是把宽度从「当前图片」那一格里抠走。
+
+        「标注方式」留着并放在最右：它决定工具栏给的是方框、多边形还是关键点，
+        不是纯展示，撤掉的话用户就没有地方换标注形状了。
+        """
         bar = QWidget()
         bar.setObjectName("page_header")
 
-        layout = QHBoxLayout(bar)
-        layout.setContentsMargins(16, 10, 16, 10)
-        layout.setSpacing(20)
+        layout = QGridLayout(bar)
+        layout.setContentsMargins(16, 6, 16, 6)
+        layout.setHorizontalSpacing(12)
+        layout.setVerticalSpacing(2)
 
-        # 当前项目（项目名可能很长：宽度封顶 + 省略号，完整名字进 tooltip）
-        self.project_name_label = QLabel()
-        self.project_name_label.setObjectName("h2")
-        self.project_name_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
-        self.project_name_label.setMinimumWidth(110)
-        self.project_name_label.setMaximumWidth(200)
-        self._register_elided_label(self.project_name_label)
-        self._set_elided_text(self.project_name_label, "未选择项目")
-        layout.addLayout(self._context_field("当前项目", self.project_name_label), 1)
+        # 当前图片：第几张 + 是哪张 + 标没标。文件名可省略，但不会挤动工具。
+        self.image_name_label = QLabel()
+        self.image_name_label.setObjectName("title")
+        self.image_name_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        self.image_name_label.setMinimumWidth(240)
+        self.image_name_label.setMaximumWidth(320)
+        self.image_name_label.setMinimumHeight(TOOLBAR_BUTTON_HEIGHT)
+        self._register_elided_label(self.image_name_label)
+        self._set_elided_text(self.image_name_label, "未选择图片")
 
-        # 标注方式（任务类型）：决定用什么形状标注
+        # 标注方式（任务类型）：决定用什么形状标注。
         self.task_combo = QComboBox()
         self.task_combo.addItems(["detect", "segment", "pose", "classify"])
         self.task_combo.setFixedWidth(128)
+        self.task_combo.setMinimumHeight(TOOLBAR_BUTTON_HEIGHT)
         self.task_combo.setToolTip(
             "决定用什么形状标注：\n"
             "detect 检测 = 画矩形框\n"
@@ -2553,39 +2725,21 @@ class AnnotatePage(QWidget):
             "classify 分类 = 整张图给一个类别"
         )
         self.task_combo.currentTextChanged.connect(self.on_task_changed)
-        layout.addLayout(self._context_field("标注方式", self.task_combo))
 
-        # 当前图片：文件名 + 第几张 + 标没标
-        self.image_name_label = QLabel()
-        self.image_name_label.setObjectName("title")
-        # 窗口变窄时优先压缩这一格，不把右边的进度和类别挤出去；压不下就打省略号，不切半个字
-        self.image_name_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
-        self.image_name_label.setMinimumWidth(150)
-        self._register_elided_label(self.image_name_label)
-        self._set_elided_text(self.image_name_label, "未选择图片")
-        layout.addLayout(self._context_field("当前图片", self.image_name_label), 2)
+        # 工具栏直接落在顶栏的值行，不再占画布上方的一整行。
+        # 高度不钉死；赋值完成后再刷新一次，这时 refresh 方法才能拿到
+        # self.toolbar，并把按钮按字体算出的共同最小高度同步给容器。
+        self.toolbar = self.create_toolbar()
+        self.refresh_toolbar_button_layout()
 
-        # 标注进度
-        progress_row = QWidget()
-        progress_layout = QHBoxLayout(progress_row)
-        progress_layout.setContentsMargins(0, 0, 0, 0)
-        progress_layout.setSpacing(8)
-        self.progress_bar = QProgressBar()
-        self.progress_bar.setFixedWidth(120)
-        self.progress_bar.setTextVisible(False)
-        progress_layout.addWidget(self.progress_bar)
-        self.progress_label = QLabel("0/0 张已标注")
-        progress_layout.addWidget(self.progress_label)
-        layout.addLayout(self._context_field("标注进度", progress_row))
-
-        # 当前类别：右侧类别列表里选中的那个（类别名可能很长，同样封顶 + 省略号）
-        self.current_class_chip = QLabel()
-        self.current_class_chip.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
-        self.current_class_chip.setMinimumWidth(90)
-        self.current_class_chip.setMaximumWidth(160)
-        self._register_elided_label(self.current_class_chip)
-        self._set_elided_text(self.current_class_chip, "未选择")
-        layout.addLayout(self._context_field("当前类别", self.current_class_chip), 1)
+        for column, caption in ((0, "当前图片"), (1, "工具"), (3, "标注方式")):
+            label = QLabel(caption)
+            label.setObjectName("caption")
+            layout.addWidget(label, 0, column)
+        layout.addWidget(self.image_name_label, 1, 0)
+        layout.addWidget(self.toolbar, 1, 1)
+        layout.setColumnStretch(2, 1)
+        layout.addWidget(self.task_combo, 1, 3)
 
         return bar
 
@@ -2617,30 +2771,6 @@ class AnnotatePage(QWidget):
         if event.type() == QEvent.Type.Resize and obj in getattr(self, '_elided_labels', ()):
             self._apply_elide(obj)
         return super().eventFilter(obj, event)
-
-    def _context_field(self, caption: str, widget: QWidget) -> QVBoxLayout:
-        """信息条里的一格：上面一行小字说明，下面是值。
-
-        每一格从顶上开始排，值占一行统一的高度。不这么钉住的话，放下拉框的那一格
-        （标注方式）比放纯文字的高一截，五个说明文字就会在垂直居中里各自漂移——
-        「标注方式」比旁边的「当前项目」高出 4px，整条信息条看着是歪的。
-        """
-        column = QVBoxLayout()
-        column.setContentsMargins(0, 0, 0, 0)
-        column.setSpacing(3)
-        column.setAlignment(Qt.AlignmentFlag.AlignTop)
-
-        label = QLabel(caption)
-        label.setObjectName("caption")
-        # 值有宽度上限时，说明文字也跟着封顶，否则整格会被说明文字撑得比值还宽
-        if widget.maximumWidth() < 16777215:
-            label.setMaximumWidth(widget.maximumWidth())
-        column.addWidget(label)
-
-        # 值这一行统一高度：文字格和控件格的下边缘也要对齐，不只是上边缘
-        widget.setMinimumHeight(CONTROL_HEIGHT)
-        column.addWidget(widget)
-        return column
 
     def _init_navigation_shortcuts(self):
         """初始化翻页快捷键，避免依赖控件焦点。"""
@@ -2677,6 +2807,7 @@ class AnnotatePage(QWidget):
         if hasattr(self, 'btn_prev'):
             self.btn_prev.setText(f"◀ 上一张 ({keys['prev']})")
             self.btn_next.setText(f"下一张 ({keys['next']}) ▶")
+            self._sync_navigation_button_sizes()
 
         if hasattr(self, 'btn_move'):
             self.btn_move.setToolTip(f"拖动画布和已有标注\n快捷键: {keys['move']}")
@@ -2742,10 +2873,25 @@ class AnnotatePage(QWidget):
         layout.setContentsMargins(10, 10, 6, 10)
         layout.setSpacing(8)
 
-        # 标题
-        title = QLabel("图片")
-        title.setObjectName("h2")
-        layout.addWidget(title)
+        # 标题行：「图片 · 张数」+ 收起按钮。收起后这一整栏的宽度让给画布。
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(6)
+
+        self.image_list_title = QLabel("图片")
+        self.image_list_title.setObjectName("h2")
+        title_row.addWidget(self.image_list_title)
+        title_row.addStretch(1)
+
+        self.btn_collapse_image_list = self._ghost_icon_button(
+            'chevron-left.svg', 24, "收起图片列表"
+        )
+        self.btn_collapse_image_list.clicked.connect(
+            lambda: self._set_image_list_collapsed(True)
+        )
+        title_row.addWidget(self.btn_collapse_image_list)
+
+        layout.addLayout(title_row)
 
         # 这个项目里有多少图、标了多少
         self.image_list_caption = QLabel("还没有图片")
@@ -2777,28 +2923,66 @@ class AnnotatePage(QWidget):
 
         return panel
 
-    def create_center_panel(self) -> QWidget:
-        """创建中间面板 - 工具栏 + 标注画布 + 翻页"""
-        panel = QWidget()
-        # 左 175 + 中 380 + 右 245 + 手柄，1100px 窗口下还留得出余量
-        panel.setMinimumWidth(380)
-        layout = QVBoxLayout(panel)
-        layout.setContentsMargins(6, 10, 6, 10)
-        layout.setSpacing(8)
+    def _ghost_icon_button(self, icon_name: str, size: int, tooltip: str) -> QToolButton:
+        """只有图标、没有底色的小按钮：收起 / 展开图片栏用。"""
+        button = QToolButton()
+        button.setIcon(_asset_icon(icon_name))
+        button.setIconSize(QSize(12, 12))
+        button.setFixedSize(size, size)
+        button.setToolTip(tooltip)
+        button.setCursor(Qt.CursorShape.PointingHandCursor)
+        button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        # padding 显式清零：全局 QToolButton 有 5px 10px，会把这么小的按钮里的图标压没
+        button.setStyleSheet(f"""
+            QToolButton {{
+                background-color: transparent;
+                border: none;
+                border-radius: {RADIUS_SM}px;
+                padding: 0px;
+            }}
+            QToolButton:hover {{
+                background-color: {COLORS['hover']};
+            }}
+        """)
+        return button
 
-        # 工具栏：放进横向滚动区。窗口够宽时看不出区别；窗口很窄时工具栏自己滚，
-        # 而不是把「删除」这类按钮挤出屏幕，也不会把整页的最小宽度拉大。
-        toolbar = self.create_toolbar()
-        toolbar_scroll = QScrollArea()
-        toolbar_scroll.setWidgetResizable(True)
-        toolbar_scroll.setFrameShape(QFrame.Shape.NoFrame)
-        toolbar_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        toolbar_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        toolbar_scroll.setWidget(toolbar)
-        toolbar_scroll.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
-        self.toolbar_scroll = toolbar_scroll
-        self._sync_toolbar_scroll_height()
-        layout.addWidget(toolbar_scroll)
+    def _set_image_list_collapsed(self, collapsed: bool, persist: bool = True):
+        """收起 / 展开左侧图片栏。
+
+        收起前先记下三栏当前宽度：QSplitter 把左栏让出来的空间分给中栏，
+        展开时再按记下的宽度还回去（受窗口约束可能有几个像素出入）。
+        """
+        if collapsed and self.left_panel.isVisible():
+            self._splitter_sizes = self.splitter.sizes()
+
+        self.left_panel.setVisible(not collapsed)
+        self.btn_expand_image_list.setVisible(collapsed)
+
+        if not collapsed and self._splitter_sizes:
+            self.splitter.setSizes(self._splitter_sizes)
+
+        if persist:
+            from PyQt6.QtCore import QSettings
+            settings = QSettings("EzYOLO", "Settings")
+            settings.setValue("annotate_image_list_collapsed", collapsed)
+
+    def _restore_image_list_collapsed(self):
+        """按上次退出时的状态决定图片栏是收着还是开着。"""
+        from PyQt6.QtCore import QSettings
+        settings = QSettings("EzYOLO", "Settings")
+        collapsed = str(settings.value("annotate_image_list_collapsed", False)).lower() in ('true', '1')
+        self._set_image_list_collapsed(collapsed, persist=False)
+
+    def create_center_panel(self) -> QWidget:
+        """创建中间面板 - 标注画布 + 翻页"""
+        panel = QWidget()
+        # 画布自己的最小宽度就是 400，加上左右各 6px 边距，这一栏少于 412 就会把画布
+        # 的右缘（以及贴在右上角的视图锁）裁掉。左 175 + 中 412 + 右 232 + 手柄，
+        # 1100px 窗口下仍然放得下。
+        panel.setMinimumWidth(412)
+        layout = QVBoxLayout(panel)
+        layout.setContentsMargins(6, 6, 6, 10)
+        layout.setSpacing(8)
 
         # 标注画布
         self.canvas = AnnotationCanvas()
@@ -2816,25 +3000,6 @@ class AnnotatePage(QWidget):
         self.adjust_tool_visibility(current_task)
 
         return panel
-
-    def _sync_toolbar_scroll_height(self):
-        """工具栏高度跟着实际内容走：按钮换行更高、或者出现横向滚动条时，都不会被悄悄切掉。"""
-        scroll = getattr(self, 'toolbar_scroll', None)
-        if scroll is None:
-            return
-
-        content = scroll.widget()
-        if content is None:
-            return
-
-        height = content.sizeHint().height() + 12
-        scrollbar = scroll.horizontalScrollBar()
-        if scrollbar is not None and scrollbar.isVisible():
-            height += scrollbar.sizeHint().height()
-
-        if scroll.minimumHeight() != height:
-            scroll.setMinimumHeight(height)
-            scroll.setMaximumHeight(height)
 
     def create_navigation_bar(self) -> QWidget:
         """画布下方的翻页条：上一张 / 下一张（主操作）。"""
@@ -2854,20 +3019,53 @@ class AnnotatePage(QWidget):
         self.btn_next = QPushButton("下一张 ▶")
         self.btn_next.setObjectName("primary")
         self.btn_next.setMinimumHeight(34)
-        self.btn_next.setMinimumWidth(130)
         self.btn_next.clicked.connect(self.next_image)
         layout.addWidget(self.btn_next)
 
+        self._sync_navigation_button_sizes()
+
         return bar
+
+    def _sync_navigation_button_sizes(self):
+        """翻页按钮始终取两者所需的较大尺寸，避免左右一大一小。"""
+        buttons = (self.btn_prev, self.btn_next)
+        for button in buttons:
+            button.setMinimumSize(0, 0)
+            button.setMaximumSize(16777215, 16777215)
+
+        width = max(button.sizeHint().width() for button in buttons)
+        height = max(34, *(button.sizeHint().height() for button in buttons))
+        for button in buttons:
+            button.setFixedSize(width, height)
     
     def create_toolbar(self) -> QWidget:
-        """创建工具栏：只放画标注和改标注的动作，AI 相关的入口在右侧面板。"""
-        toolbar = QFrame()
-        toolbar.setObjectName("toolbar")
+        """创建工具栏：一行安静的控件条，只放画标注和改标注的动作。
+
+        以前这里是一张带边框的卡片，还给每组按钮顶了一行小标题（「标注工具」「修改」）。
+        三五个按钮不需要目录：标题多占一行高度，边框把它框成一个和画布平起平坐的区块，
+        画布因此矮了一截——而画布才是这一页真正要看的东西。
+        现在只留按钮本身，中间一根竖线把「画」和「改/删」分开。
+        """
+        toolbar = QWidget()
+        toolbar.setObjectName("annotate_toolbar")
+        # 卡片底色和边框都不要：它是浮在画布上方的一条控件，不是又一张卡片
+        toolbar.setStyleSheet(
+            "QWidget#annotate_toolbar { background-color: transparent; border: none; }"
+        )
         toolbar_layout = QHBoxLayout(toolbar)
-        toolbar_layout.setContentsMargins(8, 6, 8, 6)
-        toolbar_layout.setSpacing(8)
+        toolbar_layout.setContentsMargins(0, 0, 0, 0)
+        toolbar_layout.setSpacing(6)
         base_tool_button_style = self._toolbar_chip_style('tool')
+
+        # 图片栏收起时，这里是把它叫回来的唯一入口；平时不占位
+        self.btn_expand_image_list = self._ghost_icon_button(
+            'chevron-right.svg', 28, "展开图片列表"
+        )
+        self.btn_expand_image_list.clicked.connect(
+            lambda: self._set_image_list_collapsed(False)
+        )
+        self.btn_expand_image_list.hide()
+        toolbar_layout.addWidget(self.btn_expand_image_list)
 
         # 工具按钮组
         self.tool_group = QButtonGroup(self)
@@ -2914,9 +3112,10 @@ class AnnotatePage(QWidget):
         self.btn_move.setStyleSheet(base_tool_button_style)
         self.tool_group.addButton(self.btn_move)
 
-        # 撤销按钮
+        # 撤销按钮（和左边几个工具用同一套尺寸，一行排开时高度、内边距才对得齐）
         self.btn_undo = QPushButton("撤销")
         self.btn_undo.setToolTip("撤销上一步\n快捷键: Ctrl+Z")
+        self.btn_undo.setStyleSheet(base_tool_button_style)
         self.btn_undo.clicked.connect(self.undo)
 
         # 删除按钮（主动作删标注，下拉菜单删图片）
@@ -2932,18 +3131,18 @@ class AnnotatePage(QWidget):
         self.delete_menu.aboutToShow.connect(self.update_delete_menu_state)
         self.btn_delete.setMenu(self.delete_menu)
 
+        # 画的工具 | 改和删。一行排开，中间一根细线分开——
+        # 「删除」离「画方框」远一点，手滑的代价小一点。
         self.toolbar_draw_buttons = [self.btn_draw_tool, self.btn_keypoint, self.btn_move]
         self.toolbar_edit_buttons = [self.btn_undo, self.btn_delete]
-        self.toolbar_draw_group = self._create_toolbar_button_group("标注工具", self.toolbar_draw_buttons)
-        self.toolbar_edit_group = self._create_toolbar_button_group("修改", self.toolbar_edit_buttons)
-        self.toolbar_groups = [
-            (self.toolbar_draw_group, self.toolbar_draw_buttons),
-            (self.toolbar_edit_group, self.toolbar_edit_buttons),
-        ]
+        self.toolbar_buttons = self.toolbar_draw_buttons + self.toolbar_edit_buttons
 
-        toolbar_layout.addWidget(self.toolbar_draw_group)
-        toolbar_layout.addWidget(self._toolbar_separator())
-        toolbar_layout.addWidget(self.toolbar_edit_group)
+        for button in self.toolbar_draw_buttons:
+            toolbar_layout.addWidget(button)
+        self.toolbar_separator = self._toolbar_separator()
+        toolbar_layout.addWidget(self.toolbar_separator)
+        for button in self.toolbar_edit_buttons:
+            toolbar_layout.addWidget(button)
         toolbar_layout.addStretch(1)
 
         self.refresh_draw_tool_button()
@@ -2951,29 +3150,11 @@ class AnnotatePage(QWidget):
 
         return toolbar
 
-    def _create_toolbar_button_group(self, caption: str, buttons) -> QWidget:
-        """创建工具栏按钮组：上面一行小字说明这组是干什么的。"""
-        group_widget = QWidget()
-        layout = QVBoxLayout(group_widget)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(2)
-
-        label = QLabel(caption)
-        label.setObjectName("caption")
-        layout.addWidget(label)
-
-        button_row = QHBoxLayout()
-        button_row.setContentsMargins(0, 0, 0, 0)
-        button_row.setSpacing(8)
-        for button in buttons:
-            button_row.addWidget(button)
-        layout.addLayout(button_row)
-        return group_widget
-
     def _toolbar_separator(self) -> QFrame:
         """工具栏里的竖直分隔线。"""
         line = QFrame()
         line.setFixedWidth(1)
+        line.setMinimumHeight(TOOLBAR_BUTTON_HEIGHT - 8)
         line.setStyleSheet(
             f"background-color: {COLORS['border']}; border: none; border-radius: 0px;"
         )
@@ -3002,14 +3183,26 @@ class AnnotatePage(QWidget):
             },
         }
         palette = palette_map[role]
+        arrow_name = 'chevron_down.svg' if role == 'tool' else 'chevron_down_red.svg'
+        arrow_url = (_ASSETS_DIR / arrow_name).as_posix()
+        disabled_arrow_url = (_ASSETS_DIR / 'chevron_down_disabled.svg').as_posix()
+        checked_menu_background = COLORS['panel'] if role == 'tool' else palette['checked']
+        checked_menu_border = COLORS['border'] if role == 'tool' else COLORS['panel']
         return f"""
             QPushButton, QToolButton {{
                 background-color: {COLORS['panel']};
                 color: {palette['text']};
                 border: 1px solid {palette['border']};
                 border-radius: {RADIUS_SM}px;
-                padding: 4px 10px;
                 font-weight: 600;
+            }}
+            QPushButton {{
+                padding: 4px 10px;
+            }}
+            /* QToolButton 在这里永远带菜单：右边留 36px 给 24px 宽的 menu-button
+               子控件（+ 一点呼吸空间），文字才不会被压进箭头区。 */
+            QToolButton {{
+                padding: 4px 36px 4px 10px;
             }}
             QPushButton:hover, QToolButton:hover {{
                 background-color: {COLORS['hover']};
@@ -3028,7 +3221,7 @@ class AnnotatePage(QWidget):
             QToolButton::menu-button {{
                 subcontrol-origin: padding;
                 subcontrol-position: right center;
-                width: 16px;
+                width: 24px;
                 background-color: {COLORS['panel']};
                 border-left: 1px solid {COLORS['border']};
                 border-top-right-radius: {RADIUS_SM}px;
@@ -3041,57 +3234,74 @@ class AnnotatePage(QWidget):
                Qt 认不出子控件，会把这条的底色刷满整个按钮——没选中的「删除」
                也会变成一整块实心红。 */
             QToolButton::menu-button:checked {{
-                background-color: {palette['checked']};
-                border-left: 1px solid {COLORS['panel']};
+                background-color: {checked_menu_background};
+                border-left: 1px solid {checked_menu_border};
             }}
             QToolButton::menu-button:checked:hover {{
-                background-color: {palette['checked_hover']};
-                border-left: 1px solid {COLORS['panel']};
+                background-color: {checked_menu_background if role == 'tool' else palette['checked_hover']};
+                border-left: 1px solid {checked_menu_border};
             }}
             QToolButton::menu-button:disabled {{
                 background-color: {COLORS['panel']};
                 border-left: 1px solid {COLORS['border']};
             }}
-            QToolButton::menu-arrow {{
-                width: 10px;
-                height: 10px;
-            }}
+            QToolButton::menu-arrow,
             QToolButton::menu-indicator {{
-                width: 10px;
-                height: 10px;
+                image: url({arrow_url});
+                width: 12px;
+                height: 12px;
+            }}
+            QToolButton::menu-arrow:disabled,
+            QToolButton::menu-indicator:disabled {{
+                image: url({disabled_arrow_url});
             }}
         """
 
     def _get_toolbar_button_width(self, button) -> int:
-        """计算按钮建议宽度，菜单按钮额外预留箭头空间。"""
+        """计算按钮建议宽度，菜单按钮额外预留箭头空间。
+
+        菜单按钮不能信 QToolButton 原生的 minimumSizeHint——它不知道我们把
+        menu-button 子控件挤宽到了多少，算出来的宽度会比实际需要的窄，文字
+        就被顶进箭头区。这里按实际的内边距（左 10 + 右 36）和双边框（2px）
+        自己算，再留 6px 安全边，最后跟 sizeHint 取较大值兜底。
+        """
         text_width = button.fontMetrics().horizontalAdvance(button.text())
-        extra_padding = 24
         if isinstance(button, QToolButton) and button.menu() is not None:
-            extra_padding += 16
-        return text_width + extra_padding
+            width = text_width + 10 + 36 + 2 + 6
+            return max(width, button.sizeHint().width())
+        return text_width + 24
 
     def refresh_toolbar_button_layout(self):
-        """统一顶部按钮高度，宽度按各自文字走。
+        """统一工具栏按钮高度，宽度按各自文字走。
 
         以前是按分组统一宽度（都撑到组里最宽的那个），工具栏因此要 577px，
         窗口一小就把删除按钮挤出可视区。这里只保证高度一致和一个最小宽度。
-        """
-        button_height = 32
-        min_button_width = 78
-        for group_widget, group in getattr(self, 'toolbar_groups', []):
-            visible_buttons = [
-                button for button in group
-                if button is not None and not button.isHidden()
-            ]
-            group_widget.setVisible(bool(visible_buttons))
-            for button in visible_buttons:
-                button.setFixedHeight(button_height)
-                button.setMinimumWidth(
-                    max(min_button_width, self._get_toolbar_button_width(button))
-                )
 
-        # 按钮显隐/文字变了，工具栏本身可能变高，容器高度要跟上
-        self._sync_toolbar_scroll_height()
+        高度对所有按钮一视同仁——带下拉箭头的 QToolButton（画方框、删除）和
+        普通 QPushButton（撤销）默认的 sizeHint 不一样，不钉住的话一行排开就是
+        参差不齐的。高度不再写死成 TOOLBAR_BUTTON_HEIGHT：换一套更高的系统字体时，
+        固定高度会把文字压扁，这里改成按实际按钮取需要的最大高度，再用
+        minimumHeight 兜底，长得下的字体可以自己撑高。
+        """
+        min_button_width = 78
+        visible_buttons = [
+            button for button in getattr(self, 'toolbar_buttons', [])
+            if button is not None and not button.isHidden()
+        ]
+        toolbar_height = max(
+            [TOOLBAR_BUTTON_HEIGHT]
+            + [button.sizeHint().height() for button in visible_buttons]
+            + [button.fontMetrics().height() + 12 for button in visible_buttons]
+        )
+        for button in visible_buttons:
+            button.setMinimumHeight(toolbar_height)
+            button.setMinimumWidth(
+                max(min_button_width, self._get_toolbar_button_width(button))
+            )
+        if hasattr(self, 'toolbar'):
+            self.toolbar.setMinimumHeight(toolbar_height)
+        if hasattr(self, 'toolbar_separator'):
+            self.toolbar_separator.setFixedHeight(max(1, toolbar_height - 8))
 
     def refresh_draw_tool_button(self):
         """刷新绘制工具按钮文本与选项状态。"""
@@ -3147,6 +3357,7 @@ class AnnotatePage(QWidget):
         except Exception:
             pass
         self.btn_sam.setMenu(None)
+        set_menu_indicator(self.btn_sam, False)
 
         sam_config = AutoLabelDialog.get_saved_sam_config()
         sam_type = sam_config.get("sam_type", "SAM")
@@ -3159,6 +3370,7 @@ class AnnotatePage(QWidget):
                 "菜单：更新记忆 / 清空记忆 / 单张推理 / 批量推理"
             )
             self.btn_sam.setMenu(self.create_sam_memory_menu())
+            set_menu_indicator(self.btn_sam, True)
         else:
             self.btn_sam.setText("SAM 交互分割")
             self.btn_sam.setToolTip(
@@ -3190,8 +3402,8 @@ class AnnotatePage(QWidget):
         整块可以滚动：窗口再矮也不会把下面的按钮压没。
         """
         panel = QWidget()
-        panel.setMinimumWidth(245)
-        panel.setMaximumWidth(340)
+        panel.setMinimumWidth(232)
+        panel.setMaximumWidth(280)
 
         outer = QVBoxLayout(panel)
         outer.setContentsMargins(0, 0, 0, 0)
@@ -3221,11 +3433,13 @@ class AnnotatePage(QWidget):
     def _create_class_group(self) -> QGroupBox:
         """类别：标注的第一步——先说清楚要画的是什么。"""
         class_group = QGroupBox("类别")
+        class_group.setObjectName("annotate_class_group")
+        class_group.setStyleSheet(self._compact_group_style("annotate_class_group"))
         class_layout = QVBoxLayout(class_group)
         class_layout.setSpacing(8)
 
         self.class_list = QListWidget()
-        self.class_list.setMinimumHeight(120)
+        self.class_list.setMinimumHeight(96)
         self.class_list.setSpacing(2)
         self.class_list.setToolTip("数字键 1-9 切换类别；右键类别可改名或删除")
         self.class_list.itemClicked.connect(self.on_class_selected)
@@ -3240,27 +3454,54 @@ class AnnotatePage(QWidget):
 
         self.btn_add_class = QPushButton("+ 添加类别")
         self.btn_add_class.clicked.connect(self.add_class)
-        self.btn_add_class.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         # 只有「选中了一个标注、且选的类别和它现在的不一样」时才可点
         self.btn_apply_attr = QPushButton("改为选中类别")
         self.btn_apply_attr.setToolTip("把画布上选中的那个标注，改成当前选中的类别")
         self.btn_apply_attr.clicked.connect(self.apply_annotation_changes)
-        self.btn_apply_attr.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.btn_apply_attr.setEnabled(False)
 
-        class_button_row = QHBoxLayout()
+        # 两个按钮真 1:1 等宽：QHBoxLayout 的 stretch 只分「多出来的」空间，
+        # 文字长的那个起点就更宽，最后还是不等。栅格按列分宽度，才真的一样宽。
+        class_button_row = QGridLayout()
         class_button_row.setContentsMargins(0, 0, 0, 0)
-        class_button_row.setSpacing(8)
-        class_button_row.addWidget(self.btn_add_class, 1)
-        class_button_row.addWidget(self.btn_apply_attr, 1)
+        class_button_row.setHorizontalSpacing(8)
+        class_button_row.setColumnStretch(0, 1)
+        class_button_row.setColumnStretch(1, 1)
+        for column, button in enumerate((self.btn_add_class, self.btn_apply_attr)):
+            # 最小宽度放到 10：窄栏里由栅格来分宽度，按钮自己不许把列撑开
+            button.setMinimumWidth(10)
+            button.setMinimumHeight(28)
+            button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            class_button_row.addWidget(button, 0, column)
         class_layout.addLayout(class_button_row)
 
         return class_group
 
+    def _compact_group_style(self, object_name: str) -> str:
+        """只给这一页的某个分组用的紧凑内边距（全局 QGroupBox / QPushButton 不动）。
+
+        组里的按钮也一并收紧左右内边距：右栏窄，全局那份 padding 会让「改为选中类别」
+        这种六个字的按钮在 1100px 窗口下切字。
+        """
+        return f"""
+            QGroupBox#{object_name} {{
+                margin-top: 20px;
+                padding: 10px 12px 12px 12px;
+            }}
+            QGroupBox#{object_name} QPushButton {{
+                padding: 5px 6px;
+            }}
+            QGroupBox#{object_name} QPushButton[menuIndicator="true"] {{
+                padding-right: 30px;
+            }}
+        """
+
     def _create_ai_group(self) -> QGroupBox:
         """AI 自动标注：让模型先画一遍，人只做检查和微调。"""
         ai_group = QGroupBox("AI 自动标注")
+        ai_group.setObjectName("annotate_ai_group")
+        ai_group.setStyleSheet(self._compact_group_style("annotate_ai_group"))
         ai_group.setToolTip("模型先标一遍，你只做检查和微调")
         ai_layout = QVBoxLayout(ai_group)
         ai_layout.setSpacing(8)
@@ -3269,6 +3510,7 @@ class AnnotatePage(QWidget):
         self.btn_auto_label = QPushButton("用已有模型标注")
         self.btn_auto_label.setToolTip("用一个已经训练好的 .pt 模型自动标注\n菜单：设置 / 单张推理 / 批量推理")
         self.btn_auto_label.setMenu(self.create_auto_label_menu())
+        set_menu_indicator(self.btn_auto_label)
 
         # SAM：点一下就分割（文本和菜单由 apply_sam_button_mode 按设置决定）
         self.btn_sam = QPushButton("SAM")
@@ -3277,14 +3519,11 @@ class AnnotatePage(QWidget):
         self.btn_llm_label = QPushButton("大模型标注")
         self.btn_llm_label.setToolTip("用多模态大模型识别图片里的目标\n菜单：单张推理 / 批量推理")
         self.btn_llm_label.setMenu(self.create_llm_menu())
+        set_menu_indicator(self.btn_llm_label)
 
-        self.btn_batch_process = QPushButton("批处理")
-        self.btn_batch_process.setToolTip("按选中的像素点批量处理图片")
-        self.btn_batch_process.clicked.connect(self.show_batch_process_dialog)
-
-        self.ai_action_buttons = [
-            self.btn_auto_label, self.btn_sam, self.btn_llm_label, self.btn_batch_process
-        ]
+        # 批处理不在这里：它不是「让模型帮你标」，是按像素点批量改图，
+        # 归到下面的样本管理（进阶）里，见 _create_sample_group
+        self.ai_action_buttons = [self.btn_auto_label, self.btn_sam, self.btn_llm_label]
         for button in self.ai_action_buttons:
             button.setMinimumHeight(32)
             button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
@@ -3294,12 +3533,22 @@ class AnnotatePage(QWidget):
 
         return ai_group
 
-    def _create_sample_group(self) -> QGroupBox:
-        """样本管理：负样本标记 + 按类别随机删图，用来平衡数据。"""
-        sample_group = QGroupBox("样本管理（进阶）")
+    def _create_sample_group(self) -> CollapsibleSection:
+        """样本管理：批处理 + 负样本标记 + 按类别随机删图，用来平衡数据。
+
+        默认收起：这几件事不是每天都干，但里面有一个会真删图片文件的按钮——
+        既不该常驻占掉类别和 AI 入口的位置，也不该藏进菜单里让人找不到。
+        """
+        sample_group = CollapsibleSection("样本管理（进阶）")
         sample_group.setToolTip("按整张图片随机删除，用来平衡类别；负样本 = 已标注但没有任何框的图片")
-        sample_layout = QVBoxLayout(sample_group)
-        sample_layout.setSpacing(8)
+        sample_layout = sample_group.content_layout()
+
+        self.btn_batch_process = QPushButton("批处理")
+        self.btn_batch_process.setToolTip("按选中的像素点批量处理图片")
+        self.btn_batch_process.clicked.connect(self.show_batch_process_dialog)
+        self.btn_batch_process.setMinimumHeight(30)
+        self.btn_batch_process.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sample_layout.addWidget(self.btn_batch_process)
 
         self.btn_mark_negative_sample = QPushButton("把当前图片标为负样本")
         self.btn_mark_negative_sample.setToolTip("这张图里没有任何目标，也是有用的学习材料")
@@ -3353,12 +3602,11 @@ class AnnotatePage(QWidget):
 
         return sample_group
 
-    def _create_export_group(self) -> QGroupBox:
-        """导出：训练不需要手动导出，这里是给外部工具用的。"""
-        export_group = QGroupBox("数据导出（可选）")
+    def _create_export_group(self) -> CollapsibleSection:
+        """导出：训练不需要手动导出，这里是给外部工具用的。默认收起。"""
+        export_group = CollapsibleSection("数据导出（可选）")
         export_group.setToolTip("训练会直接读标注，不用先导出；只有要把数据给别的工具用时才需要")
-        export_layout = QVBoxLayout(export_group)
-        export_layout.setSpacing(8)
+        export_layout = export_group.content_layout()
 
         format_layout = QFormLayout()
         format_layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
@@ -3415,7 +3663,7 @@ class AnnotatePage(QWidget):
         return menu
     
     def create_status_bar(self) -> QFrame:
-        """创建状态栏：位置、本图标注数、当前工具；快捷键收进右侧按钮的提示里。"""
+        """创建状态栏：图片、进度、类别、工具和临时批处理状态。"""
         status_bar = QFrame()
         # 固定高度会在字体放大时把文字切掉，这里只给下限
         status_bar.setMinimumHeight(34)
@@ -3433,11 +3681,29 @@ class AnnotatePage(QWidget):
         """)
 
         layout = QHBoxLayout(status_bar)
-        layout.setContentsMargins(16, 4, 16, 4)
-        layout.setSpacing(12)
+        layout.setContentsMargins(12, 4, 12, 4)
+        layout.setSpacing(8)
 
         self.status_image = QLabel("当前: 0/0")
         layout.addWidget(self.status_image)
+
+        layout.addWidget(QLabel("|"))
+
+        self.status_progress = QLabel("标注: 0/0")
+        layout.addWidget(self.status_progress)
+
+        layout.addWidget(QLabel("|"))
+
+        # 不能用 Ignored：布局会把它按近零宽度排，随后控件又被 minimumWidth 撑开，
+        # 造成与右侧分隔符重叠。Preferred 让布局按实际可见宽度为它留出位置。
+        # 当前类别仍保留颜色方块；长名称省略，完整名称放在 tooltip。
+        self.current_class_chip = QLabel()
+        self.current_class_chip.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        self.current_class_chip.setMinimumWidth(120)
+        self.current_class_chip.setMaximumWidth(150)
+        self._register_elided_label(self.current_class_chip)
+        self._set_elided_text(self.current_class_chip, "类别: 未选择")
+        layout.addWidget(self.current_class_chip)
 
         layout.addWidget(QLabel("|"))
 
@@ -3449,9 +3715,11 @@ class AnnotatePage(QWidget):
         self.status_tool = QLabel("工具: 矩形")
         layout.addWidget(self.status_tool)
 
-        # 临时进度用（批量自动标注时显示正在处理哪张图），平时为空
-        self.status_position = QLabel("")
-        layout.addWidget(self.status_position, 1)
+        # 临时进度用（批量自动标注时显示正在处理哪张图），平时为空。
+        self.status_batch = QLabel("")
+        self.status_batch.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        self._register_elided_label(self.status_batch)
+        layout.addWidget(self.status_batch, 1)
 
         # 快捷键表以前是一整条常驻文字，窗口一窄就被切断；现在收进这个按钮的提示里
         self.btn_shortcut_help = QPushButton("快捷键")
@@ -3502,17 +3770,17 @@ class AnnotatePage(QWidget):
             self._set_elided_text(self.image_name_label, "未选择图片")
         else:
             image = self.images[index]
-            filename = image.get('filename', '')
             status = "已标注" if image.get('status') == 'annotated' else "还没标注"
+            # 位置和状态在前：它们每张图都有、长度稳定，窗口再窄也看得见。
+            # 名字放最后，压不下时省略掉的是它——不是「第几张」和「标没标」。
             self._set_elided_text(
                 self.image_name_label,
-                f"{filename} · 第 {index + 1}/{total} 张 · {status}",
-                tooltip=filename
+                f"第 {index + 1}/{total} 张 · {self._image_display_name(image)} · {status}",
+                tooltip=self._image_tooltip(image)
             )
 
-        self.progress_bar.setMaximum(max(total, 1))
-        self.progress_bar.setValue(annotated)
-        self.progress_label.setText(f"{annotated}/{total} 张已标注" if total else "还没有图片")
+        if hasattr(self, 'image_list_title'):
+            self.image_list_title.setText(f"图片 · {total}" if total else "图片")
 
         if hasattr(self, 'image_list_caption'):
             if total:
@@ -3526,7 +3794,7 @@ class AnnotatePage(QWidget):
         self._update_canvas_placeholder()
 
     def _update_current_class_chip(self):
-        """信息条上的「当前类别」：画上去的就是它。"""
+        """状态栏上的「当前类别」：画上去的就是它。"""
         if not hasattr(self, 'current_class_chip'):
             return
 
@@ -3534,7 +3802,7 @@ class AnnotatePage(QWidget):
         if current is None:
             self.current_class_chip.setStyleSheet(f"color: {COLORS['text_secondary']};")
             self._set_elided_text(
-                self.current_class_chip, "未选择",
+                self.current_class_chip, "类别: 未选择",
                 tooltip="画上去的标注算哪个类别，在右侧「类别」里换"
             )
             return
@@ -3543,7 +3811,7 @@ class AnnotatePage(QWidget):
             f"color: {_readable_on_light(current.get('color'))}; font-weight: 600;"
         )
         self._set_elided_text(
-            self.current_class_chip, f"■ {current['name']}",
+            self.current_class_chip, f"类别: ■ {current['name']}",
             tooltip=f"当前类别：{current['name']}\n在右侧「类别」里切换"
         )
 
@@ -3591,7 +3859,9 @@ class AnnotatePage(QWidget):
             self.btn_add_class.setEnabled(has_project)
         if hasattr(self, 'btn_mark_negative_sample'):
             self.btn_mark_negative_sample.setEnabled(has_image)
-        for name in ('btn_delete_random_samples', 'btn_export_annotations', 'btn_export_dataset'):
+        # 批处理跟着项目走（和它还在 AI 组里时一样）：它的对话框自己会提示先选图片
+        for name in ('btn_batch_process', 'btn_delete_random_samples',
+                     'btn_export_annotations', 'btn_export_dataset'):
             button = getattr(self, name, None)
             if button is not None:
                 button.setEnabled(has_project)
@@ -3664,22 +3934,15 @@ class AnnotatePage(QWidget):
         # 保存图片数据
         self.images = data.get('images', [])
         
-        # 设置项目名和任务类型选择器
+        # 同步任务类型选择器（项目名归左侧流程栏显示，这一页不再重复）
         if self.current_project_id:
             project = db.get_project(self.current_project_id)
             if project:
-                self._set_elided_text(
-                    self.project_name_label,
-                    project.get('name') or f"项目 {self.current_project_id}"
-                )
-
                 task_type = project.get('type')
                 if task_type in ['detect', 'segment', 'pose', 'classify', 'obb']:
                     index = self.task_combo.findText(task_type)
                     if index >= 0:
                         self.task_combo.setCurrentIndex(index)
-        else:
-            self._set_elided_text(self.project_name_label, "未选择项目")
 
         # 开始加载图片列表（使用多线程加载缩略图）
         self.load_image_list()
@@ -3713,18 +3976,20 @@ class AnnotatePage(QWidget):
         # 从数据库获取图片列表（很快）
         self.images = db.get_project_images(self.current_project_id)
         self._invalidate_sample_stats_cache()
-        
+        self._refresh_image_display_names()
+
         # 先创建所有列表项（显示占位符）
         for image in self.images:
             item = QListWidgetItem()
             item.setData(Qt.ItemDataRole.UserRole, image['id'])
-            
+
             # 设置显示文本
             status_text = "✓" if image.get('status') == 'annotated' else "○"
-            item.setText(f"{status_text} {image['filename']}")
-            
+            item.setText(f"{status_text} {self._image_display_name(image)}")
+            item.setToolTip(self._image_tooltip(image))
+
             self.image_list.addItem(item)
-        
+
         self.update_status_bar()
         self.update_sample_control_panel()
         
@@ -3746,23 +4011,47 @@ class AnnotatePage(QWidget):
         """加载完成回调"""
         pass
     
+    def _refresh_image_display_names(self):
+        """整个列表一起算显示名：重名的（两段视频抽到同一个帧号）才需要补区分信息，
+        所以必须整批算，不能一张一张各算各的。"""
+        aliases = display_names([img.get('filename', '') for img in self.images])
+        self._image_display_names = {
+            img['id']: alias for img, alias in zip(self.images, aliases)
+        }
+
+    def _image_display_name(self, image: Dict) -> str:
+        """列表里显示的名字：抽帧名念成「帧 223」，普通文件名原样。"""
+        cached = getattr(self, '_image_display_names', {}).get(image['id'])
+        return cached or display_name(image.get('filename', ''))
+
+    def _image_tooltip(self, image: Dict) -> str:
+        """完整文件名和分辨率不丢，只是从列表挪进了提示里。"""
+        filename = image.get('filename', '')
+        width = image.get('width', 0)
+        height = image.get('height', 0)
+        if width and height:
+            return f"{filename}\n{width}x{height}"
+        return filename
+
     def update_image_list_display(self):
         """更新图片列表显示"""
         # 重新加载图片数据
         if self.current_project_id:
             self.images = db.get_project_images(self.current_project_id)
-            
+            self._refresh_image_display_names()
+
             # 更新图片列表项
             for i in range(self.image_list.count()):
                 item = self.image_list.item(i)
                 image_id = item.data(Qt.ItemDataRole.UserRole)
-                
+
                 # 找到对应的图片数据
                 image_data = next((img for img in self.images if img['id'] == image_id), None)
                 if image_data:
                     # 更新显示文本
                     status_text = "✓" if image_data.get('status') == 'annotated' else "○"
-                    item.setText(f"{status_text} {image_data['filename']}")
+                    item.setText(f"{status_text} {self._image_display_name(image_data)}")
+                    item.setToolTip(self._image_tooltip(image_data))
 
             # 图片的已标注状态变了，进度也要跟着变
             self.update_status_bar()
@@ -3793,7 +4082,7 @@ class AnnotatePage(QWidget):
             # 设置颜色
             color = QColor(cls.get('color', '#808080'))
             item.setForeground(color)
-            item.setSizeHint(QSize(item.sizeHint().width(), 30))
+            item.setSizeHint(QSize(item.sizeHint().width(), 28))
             
             self.class_list.addItem(item)
             
@@ -5139,9 +5428,7 @@ class AnnotatePage(QWidget):
     
     def on_batch_inference_progress(self, progress, current, total, image_name):
         """批量推理进度回调"""
-        # 更新状态栏
-        self.status_annotation.setText(f"自动标注: {current}/{total}")
-        self.status_position.setText(f"当前: {image_name}")
+        self._set_elided_text(self.status_batch, f"批处理: {current}/{total} · {image_name}")
         self.repaint()
     
     def on_batch_inference_completed(self, success, message, processed_count):
@@ -5979,10 +6266,12 @@ class AnnotatePage(QWidget):
     def update_status_bar(self):
         """更新状态栏，并顺带刷新顶部信息条和按钮可用性。"""
         total = len(self.images)
+        annotated = sum(1 for img in self.images if img.get('status') == 'annotated')
         index = self._current_image_index()
         current = index + 1 if index >= 0 else 0
 
         self.status_image.setText(f"当前: {current}/{total}")
+        self.status_progress.setText(f"标注: {annotated}/{total}")
         self.status_annotation.setText(f"本图标注: {len(self.annotations)}")
         tool_names = {
             'rectangle': '矩形',
@@ -5993,7 +6282,7 @@ class AnnotatePage(QWidget):
         }
         self.status_tool.setText(f"工具: {tool_names.get(self.canvas.current_tool, self.canvas.current_tool)}")
         # 批量任务留下的临时进度文字到这里就该清掉
-        self.status_position.setText("")
+        self._set_elided_text(self.status_batch, "")
 
         self._update_context_bar()
         self._update_action_availability()

--- a/gui/pages/auto_label_dialog.py
+++ b/gui/pages/auto_label_dialog.py
@@ -20,6 +20,7 @@ import json
 from typing import Dict, List, Optional
 
 from gui.styles import COLORS
+from gui.widgets.app_dialog import confirm, show_warning
 
 # LLM配置文件路径
 LLM_CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'config', 'llm_config.json')
@@ -804,25 +805,17 @@ class AutoLabelDialog(QDialog):
         self.lbl_notice.setStyleSheet(f"color: {color};")
 
     def on_save_clicked(self):
-        """保存按钮点击事件，输出调试信息"""
+        """保存设置。
+
+        原来这里不管写没写成功都直接 accept()——SAM / LLM 配置写失败（目录只读、
+        磁盘满、文件被占用）时窗口照样关掉，用户看到的是「点了保存，什么都没发生」，
+        下次打开发现设置根本没存上。现在：写成功才关窗，写失败就留在原地把原因说出来。
+        """
         # 自定义来源却没选文件：存下去只会得到一个用不了的配置
         if self.model_source == "custom" and not self.custom_model_path:
             self.tab_widget.setCurrentIndex(0)
-            QMessageBox.warning(self, "提示", "已选择自定义模型，请先浏览选择模型文件")
+            self._set_status("已选择自定义模型，请先浏览选择模型文件。", COLORS['error'])
             return
-
-        # 获取模型信息
-        model_path = self.get_model_path()
-        model_task = self.cb_model_task.currentText() if hasattr(self, 'cb_model_task') else 'detect'
-        model_version = self.cb_model_version.currentText() if hasattr(self, 'cb_model_version') else ''
-        model_size = self.cb_model_size.currentData() or self.cb_model_size.currentText() if hasattr(self, 'cb_model_size') else ''
-
-        # 构建模型名称
-        if self.model_source == "custom":
-            model_name = os.path.basename(model_path) if model_path else "自定义模型"
-        else:
-            model_name = f"{model_version}-{model_size}-{model_task}" if model_version else model_path
-
 
         # 检查SAM模型是否存在
         if hasattr(self, 'cb_sam_type') and hasattr(self, 'cb_sam_model'):
@@ -831,42 +824,51 @@ class AutoLabelDialog(QDialog):
 
             if model_file and not _sam_model_exists(model_file):
                 if sam_type == "SAM3":
-                    QMessageBox.warning(
-                        self,
-                        "SAM3模型未找到",
-                        f"SAM3模型文件不存在: {model_file}\n\n"
-                        f"SAM3不支持自动下载。\n"
-                        f"请到以下页面下载 sam3.pt，放到项目根目录后重试：\n"
-                        f"{SAM3_DOWNLOAD_URL}"
+                    self.tab_widget.setCurrentIndex(1)
+                    show_warning(
+                        self, "找不到 SAM3 模型",
+                        f"{model_file} 不在本地，而 SAM3 不支持自动下载。",
+                        detail=f"请到 {SAM3_DOWNLOAD_URL} 下载 sam3.pt，放到项目根目录后重试。",
                     )
                     return
 
-                # 模型不存在，提示用户下载
-                reply = QMessageBox.question(
-                    self,
-                    "模型不存在",
-                    f"SAM模型文件不存在: {model_file}\n\n"
-                    f"模型类型: {sam_type}\n"
-                    f"需要下载模型才能使用SAM功能。\n\n"
-                    f"是否现在下载？\n"
-                    f"（下载可能需要一些时间，取决于网络状况）",
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
-                )
-
-                if reply == QMessageBox.StandardButton.Yes:
-                    # 尝试下载模型
+                # 模型不存在，问一下要不要现在下
+                if confirm(
+                    self, "模型还没下载",
+                    f"{sam_type} 要用的 {model_file} 不在本地，下载之后才能用 SAM 标注。",
+                    detail="下载要花一些时间，取决于网络。也可以先保存其他设置，之后再下。",
+                    confirm_text="现在下载",
+                ):
                     self.download_sam_model(sam_type, model_file)
-                else:
-                    # 用户选择不下载，清空SAM配置
-                    print(f"[SAM] 用户选择不下载模型，SAM功能将不可用")
 
-        # 保存SAM配置
-        self.save_sam_config()
+        # 两份配置都写盘成功，才算保存成功
+        sam_saved = self.save_sam_config()
+        llm_saved = self.save_llm_config()
 
-        # 保存LLM配置
-        self.save_llm_config()
+        if not (sam_saved and llm_saved):
+            # 只有一份写失败时，另一份是真的已经写进去了——不能笼统说「设置没有写入」，
+            # 那会让用户以为可以放心重试或放弃，实际上磁盘上已经是半新半旧的状态。
+            failed = []
+            saved_ok = []
+            if sam_saved:
+                saved_ok.append("SAM 配置")
+            else:
+                failed.append(f"SAM 配置（{SAM_CONFIG_FILE}）")
+            if llm_saved:
+                saved_ok.append("LLM 配置")
+            else:
+                failed.append(f"LLM 配置（{LLM_CONFIG_FILE}）")
 
-        # 调用accept保存设置
+            message = "保存失败：" + "；".join(failed) + " 没有写入"
+            if saved_ok:
+                message += "；" + "、".join(saved_ok) + " 已经写入"
+            message += "。请检查文件是否可写后重试。"
+
+            self._set_status(message, COLORS['error'])
+            return
+
+        # 走到这里 = 两份配置都落盘了。accept() 只在这一条路上发生，
+        # 所以调用方拿到 Accepted 就等于「真的保存成功了」。
         self.accept()
 
     def download_sam_model(self, sam_type: str, model_file: str):
@@ -1120,16 +1122,21 @@ class AutoLabelDialog(QDialog):
         self._update_sam_usage_mode_options(sam_type, config.get("usage_mode", "normal"))
 
     def save_sam_config(self) -> bool:
-        """保存SAM配置到配置文件。"""
+        """保存SAM配置到配置文件。写不进去返回 False（调用方要据此留住窗口）。
+
+        建目录也要算在「写失败」里：原来 makedirs 在 try 外面，配置目录建不出来时
+        直接抛异常，而不是返回 False——调用方以为只会拿到 True/False，结果是崩一下。
+        """
         config = self.get_sam_config()
-        config_dir = os.path.dirname(SAM_CONFIG_FILE)
-        if not os.path.exists(config_dir):
-            os.makedirs(config_dir)
         try:
+            config_dir = os.path.dirname(SAM_CONFIG_FILE)
+            if config_dir and not os.path.exists(config_dir):
+                os.makedirs(config_dir)
             with open(SAM_CONFIG_FILE, "w", encoding="utf-8") as f:
                 json.dump(config, f, ensure_ascii=False, indent=2)
             return True
-        except Exception:
+        except Exception as e:
+            print(f"保存SAM配置失败: {e}")
             return False
 
     @classmethod
@@ -1254,13 +1261,11 @@ class AutoLabelDialog(QDialog):
             'user_prompt': self.te_llm_user_prompt.toPlainText()
         }
 
-        # 确保配置目录存在
-        config_dir = os.path.dirname(LLM_CONFIG_FILE)
-        if not os.path.exists(config_dir):
-            os.makedirs(config_dir)
-
-        # 保存到文件
+        # 建目录和写文件都可能失败，一起算在「没保存成功」里
         try:
+            config_dir = os.path.dirname(LLM_CONFIG_FILE)
+            if config_dir and not os.path.exists(config_dir):
+                os.makedirs(config_dir)
             with open(LLM_CONFIG_FILE, 'w', encoding='utf-8') as f:
                 json.dump(config, f, ensure_ascii=False, indent=2)
             return True

--- a/gui/pages/auto_label_dialog.py
+++ b/gui/pages/auto_label_dialog.py
@@ -2,6 +2,9 @@
 """
 自动打标签弹窗
 用于设置自动打标签的参数和选项
+
+每个标签页都按同一条线索排：模型/服务 → 参数 → （可折叠的高级项），
+底部固定一条「将要发生什么」的预览 + 风险/执行状态，主操作只有「保存设置」一个。
 """
 
 from PyQt6.QtWidgets import (
@@ -155,424 +158,413 @@ SIZE_NAMES = {
 }
 
 
+class CollapsibleSection(QWidget):
+    """可折叠的高级设置区：默认收起，只有需要的人才展开。"""
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        self._title = title
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
+        self.toggle_button = QPushButton()
+        self.toggle_button.setObjectName("link")
+        self.toggle_button.setCheckable(True)
+        self.toggle_button.toggled.connect(self._on_toggled)
+        layout.addWidget(self.toggle_button, alignment=Qt.AlignmentFlag.AlignLeft)
+
+        self.body = QWidget()
+        self.body.setVisible(False)
+        layout.addWidget(self.body)
+
+        self._sync_text()
+
+    def _on_toggled(self, checked: bool):
+        self.body.setVisible(checked)
+        self._sync_text()
+
+    def _sync_text(self):
+        arrow = "▾" if self.toggle_button.isChecked() else "▸"
+        self.toggle_button.setText(f"{arrow} {self._title}")
+
+    def set_expanded(self, expanded: bool):
+        self.toggle_button.setChecked(expanded)
+
+
+def _sam_model_exists(model_file: str) -> bool:
+    """SAM 模型文件是否已经在本地（下载逻辑找的就是这几个位置）。"""
+    if not model_file:
+        return False
+    candidates = [
+        model_file,
+        os.path.join('models', model_file),
+        os.path.join(os.path.expanduser('~'), '.cache', 'ultralytics', model_file),
+    ]
+    return any(os.path.exists(path) for path in candidates)
+
+
 class AutoLabelDialog(QDialog):
     """自动打标签弹窗"""
-    
+
     # 信号定义
     single_inference_requested = pyqtSignal(str, float, float, dict, str, str)  # 单张推理请求
     batch_inference_requested = pyqtSignal(str, float, float, dict, list, bool, str)  # 批量推理请求
-    
+
     def __init__(self, parent=None, project_classes=None):
         super().__init__(parent)
         self.setWindowTitle("自动打标签设置")
-        self.setMinimumSize(700, 500)
-        
+        self.setMinimumSize(700, 560)
+
         # 当前项目类别
         self.project_classes = project_classes or []
-        
+
         # 模型信息
         self.selected_model_version = "YOLOv8"
         self.selected_model_size = "n"
         self.model_source = "official"  # official or custom
         self.custom_model_path = ""
-        
+
         # 推理参数
         self.conf_threshold = 0.5
         self.iou_threshold = 0.45
         self.infer_only_unlabeled = True
         self.overwrite_labels = False
-        
+
         # 类别映射
         self.class_mappings = {}
-        
+
         # 初始化UI
         self.init_ui()
 
         # 加载SAM配置
         self.load_sam_config()
-        
+
         # 加载LLM配置
         self.load_llm_config()
-        
+
+        # 底部预览随当前标签页刷新
+        self.update_preview()
+
     def init_ui(self):
         """初始化界面"""
         main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 创建标签页
+        main_layout.setContentsMargins(20, 20, 20, 16)
+        main_layout.setSpacing(12)
+
+        # 标题与说明
+        heading = QLabel("自动标注设置")
+        heading.setObjectName("h2")
+        main_layout.addWidget(heading)
+
+        subtitle = QLabel("先选一种标注方式，再调参数。设置保存后，标注页的自动标注就按这里的配置执行。")
+        subtitle.setObjectName("subtitle")
+        subtitle.setWordWrap(True)
+        main_layout.addWidget(subtitle)
+
+        # 三种标注方式各一个标签页
         self.tab_widget = QTabWidget()
-        self.tab_widget.setStyleSheet(f"""
-            QTabWidget::pane {{
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                background-color: {COLORS['panel']};
-            }}
-            QTabBar::tab {{
-                background-color: {COLORS['sidebar']};
-                color: {COLORS['text_secondary']};
-                padding: 8px 16px;
-                margin-right: 4px;
-                border-top-left-radius: 4px;
-                border-top-right-radius: 4px;
-            }}
-            QTabBar::tab:selected {{
-                background-color: {COLORS['primary']};
-                color: white;
-            }}
-        """)
-        
-        # YOLO自动标注页面
-        yolo_tab = self.create_yolo_tab()
-        self.tab_widget.addTab(yolo_tab, "🤖 YOLO自动标注")
-        
-        # SAM自动标注页面
-        sam_tab = self.create_sam_tab()
-        self.tab_widget.addTab(sam_tab, "🎯 SAM自动标注")
-        
-        # LLM自动标注页面
-        llm_tab = self.create_llm_tab()
-        self.tab_widget.addTab(llm_tab, "🧠 LLM自动标注")
-        
-        main_layout.addWidget(self.tab_widget)
-        
-        # 按钮组
+        self.tab_widget.addTab(self._wrap_scroll(self.create_yolo_tab()), "YOLO 检测")
+        self.tab_widget.addTab(self._wrap_scroll(self.create_sam_tab()), "SAM 分割")
+        self.tab_widget.addTab(self._wrap_scroll(self.create_llm_tab()), "LLM 视觉")
+        self.tab_widget.currentChanged.connect(lambda _: self.update_preview())
+
+        main_layout.addWidget(self.tab_widget, 1)
+
+        # 预览确认 + 风险/执行状态
+        self.lbl_preview = QLabel()
+        self.lbl_preview.setWordWrap(True)
+        main_layout.addWidget(self.lbl_preview)
+
+        self.lbl_notice = QLabel()
+        self.lbl_notice.setWordWrap(True)
+        main_layout.addWidget(self.lbl_notice)
+
+        # 按钮组：主操作只有「保存设置」
         button_layout = QHBoxLayout()
-        
-        # 保存按钮
-        self.btn_save = QPushButton("保存")
-        self.btn_save.clicked.connect(self.on_save_clicked)
-        button_layout.addWidget(self.btn_save)
-        
-        # 取消按钮
+        button_layout.addStretch()
+
         self.btn_cancel = QPushButton("取消")
+        self.btn_cancel.setObjectName("secondary")
+        self.btn_cancel.setToolTip("放弃修改，保持原有设置")
         self.btn_cancel.clicked.connect(self.reject)
         button_layout.addWidget(self.btn_cancel)
-        
+
+        self.btn_save = QPushButton("保存设置")
+        self.btn_save.setObjectName("primary")
+        self.btn_save.clicked.connect(self.on_save_clicked)
+        button_layout.addWidget(self.btn_save)
+
         main_layout.addLayout(button_layout)
-    
+
+    def _wrap_scroll(self, content: QWidget) -> QScrollArea:
+        """标签页内容放进滚动区：窗口再小也只是出滚动条，不截断。"""
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        scroll.setWidget(content)
+        return scroll
+
     def create_yolo_tab(self) -> QWidget:
         """创建YOLO自动标注页面"""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(16)
-        
-        # 模型选择组
-        model_group = self.create_model_selection_group()
-        layout.addWidget(model_group)
-        
-        # 推理参数组
-        params_group = self.create_inference_params_group()
-        layout.addWidget(params_group)
-        
-        # 类别映射组
-        mapping_group = self.create_class_mapping_group()
-        layout.addWidget(mapping_group)
-        
+        layout.setSpacing(14)
+
+        # 来源 → 参数 → 高级
+        layout.addWidget(self.create_model_selection_group())
+        layout.addWidget(self.create_inference_params_group())
+        layout.addWidget(self.create_class_mapping_section())
+
         layout.addStretch()
         return tab
-    
+
     def create_sam_tab(self) -> QWidget:
         """创建SAM自动标注页面"""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(16)
-        
-        # SAM模型选择组
-        sam_model_group = self.create_sam_model_group()
-        layout.addWidget(sam_model_group)
-        
-        # SAM推理参数组
-        sam_params_group = self.create_sam_params_group()
-        layout.addWidget(sam_params_group)
+        layout.setSpacing(14)
 
-        # SAM使用方式组
-        sam_usage_group = self.create_sam_usage_group()
-        layout.addWidget(sam_usage_group)
-        
+        layout.addWidget(self.create_sam_model_group())
+        layout.addWidget(self.create_sam_params_group())
+        layout.addWidget(self.create_sam_usage_group())
+
         layout.addStretch()
         return tab
-    
+
     def create_model_selection_group(self) -> QGroupBox:
-        """创建模型选择组"""
-        group = QGroupBox("模型选择")
-        group.setStyleSheet(self.get_group_style())
-        
+        """创建模型选择组：先定来源，再定具体模型"""
+        group = QGroupBox("模型来源")
+
         layout = QVBoxLayout(group)
-        
-        # 模型版本、型号和任务
-        version_size_task_layout = QHBoxLayout()
-        
-        # 模型版本
-        version_layout = QFormLayout()
+        layout.setSpacing(8)
+
+        # 官方预训练模型
+        self.rbtn_official = QRadioButton("官方预训练模型（首次使用会自动下载）")
+        self.rbtn_official.setChecked(True)
+        self.rbtn_official.toggled.connect(self.on_model_source_changed)
+        layout.addWidget(self.rbtn_official)
+
+        # 官方模型的版本 / 型号 / 任务
+        self.official_widget = QWidget()
+        official_layout = QFormLayout(self.official_widget)
+        official_layout.setContentsMargins(24, 0, 0, 0)
+
         self.cb_model_version = QComboBox()
         self.cb_model_version.addItems(sorted(ULTRALYTICS_MODELS.keys()))
         self.cb_model_version.currentTextChanged.connect(self.on_model_version_changed)
-        version_layout.addRow("模型版本:", self.cb_model_version)
-        version_size_task_layout.addLayout(version_layout)
-        
-        # 模型型号
-        size_layout = QFormLayout()
+        official_layout.addRow("模型版本:", self.cb_model_version)
+
         self.cb_model_size = QComboBox()
-        size_layout.addRow("型号:", self.cb_model_size)
-        version_size_task_layout.addLayout(size_layout)
-        
-        # 任务类型
-        task_layout = QFormLayout()
+        self.cb_model_size.currentTextChanged.connect(lambda _: self.update_preview())
+        official_layout.addRow("型号:", self.cb_model_size)
+
         self.cb_model_task = QComboBox()
-        task_layout.addRow("任务类型:", self.cb_model_task)
-        version_size_task_layout.addLayout(task_layout)
-        
-        layout.addLayout(version_size_task_layout)
-        
-        # 模型来源
-        source_group = QGroupBox("模型来源")
-        source_group.setStyleSheet(self.get_inner_group_style())
-        source_layout = QVBoxLayout(source_group)
-        
-        # 官方预训练模型
-        self.rbtn_official = QRadioButton("官方预训练模型")
-        self.rbtn_official.setChecked(True)
-        self.rbtn_official.toggled.connect(self.on_model_source_changed)
-        source_layout.addWidget(self.rbtn_official)
-        
+        self.cb_model_task.currentTextChanged.connect(lambda _: self.update_preview())
+        official_layout.addRow("任务类型:", self.cb_model_task)
+
+        layout.addWidget(self.official_widget)
+
         # 自定义模型
-        custom_layout = QHBoxLayout()
-        self.rbtn_custom = QRadioButton("自定义模型")
+        self.rbtn_custom = QRadioButton("自定义模型（本地 .pt / .pth 文件）")
         self.rbtn_custom.toggled.connect(self.on_model_source_changed)
-        custom_layout.addWidget(self.rbtn_custom)
-        
+        layout.addWidget(self.rbtn_custom)
+
+        self.custom_widget = QWidget()
+        custom_layout = QHBoxLayout(self.custom_widget)
+        custom_layout.setContentsMargins(24, 0, 0, 0)
+
+        self.lbl_custom_model = QLabel("未选择模型文件")
+        self.lbl_custom_model.setObjectName("caption")
+        custom_layout.addWidget(self.lbl_custom_model, 1)
+
         self.btn_browse_model = QPushButton("浏览...")
-        self.btn_browse_model.setEnabled(False)
         self.btn_browse_model.clicked.connect(self.browse_custom_model)
         custom_layout.addWidget(self.btn_browse_model)
-        
-        source_layout.addLayout(custom_layout)
-        
-        layout.addWidget(source_group)
-        
-        # 初始化模型型号列表
+
+        layout.addWidget(self.custom_widget)
+
+        # 初始化模型型号列表 + 来源可用状态
         self.on_model_version_changed(self.cb_model_version.currentText())
-        
+        self.on_model_source_changed()
+
         return group
-    
+
     def create_inference_params_group(self) -> QGroupBox:
         """创建推理参数组"""
         group = QGroupBox("推理参数")
-        group.setStyleSheet(self.get_group_style())
-        
+
         layout = QVBoxLayout(group)
-        
+        layout.setSpacing(8)
+
         # 阈值设置
-        thresholds_layout = QHBoxLayout()
-        
-        # 置信度阈值
-        conf_layout = QFormLayout()
+        form = QFormLayout()
+
         self.sb_conf_threshold = QDoubleSpinBox()
         self.sb_conf_threshold.setRange(0.0, 1.0)
         self.sb_conf_threshold.setSingleStep(0.05)
         self.sb_conf_threshold.setValue(0.5)
-        conf_layout.addRow("置信度:", self.sb_conf_threshold)
-        thresholds_layout.addLayout(conf_layout)
-        
-        # IOU阈值
-        iou_layout = QFormLayout()
+        self.sb_conf_threshold.valueChanged.connect(lambda _: self.update_preview())
+        form.addRow("置信度:", self.sb_conf_threshold)
+
         self.sb_iou_threshold = QDoubleSpinBox()
         self.sb_iou_threshold.setRange(0.0, 1.0)
         self.sb_iou_threshold.setSingleStep(0.05)
         self.sb_iou_threshold.setValue(0.45)
-        iou_layout.addRow("IOU阈值:", self.sb_iou_threshold)
-        thresholds_layout.addLayout(iou_layout)
-        
-        layout.addLayout(thresholds_layout)
-        
+        self.sb_iou_threshold.valueChanged.connect(lambda _: self.update_preview())
+        form.addRow("IOU阈值:", self.sb_iou_threshold)
+
+        layout.addLayout(form)
+
         # 推理选项
-        options_layout = QVBoxLayout()
-        
         self.chk_only_unlabeled = QCheckBox("仅推理无标签数据")
         self.chk_only_unlabeled.setChecked(True)
-        options_layout.addWidget(self.chk_only_unlabeled)
-        
+        self.chk_only_unlabeled.toggled.connect(lambda _: self.update_preview())
+        layout.addWidget(self.chk_only_unlabeled)
+
         self.chk_overwrite = QCheckBox("覆盖原标签")
         self.chk_overwrite.setChecked(False)
-        options_layout.addWidget(self.chk_overwrite)
-        
-        layout.addLayout(options_layout)
-        
+        self.chk_overwrite.toggled.connect(lambda _: self.update_preview())
+        layout.addWidget(self.chk_overwrite)
+
+        overwrite_hint = QLabel("勾选后，推理结果会替换图片上已有的标注，且无法撤销。")
+        overwrite_hint.setObjectName("caption")
+        overwrite_hint.setWordWrap(True)
+        layout.addWidget(overwrite_hint)
+
         return group
-    
-    def create_class_mapping_group(self) -> QGroupBox:
-        """创建类别映射组"""
-        group = QGroupBox("类别映射")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        
+
+    def create_class_mapping_section(self) -> CollapsibleSection:
+        """类别映射：进阶用法，默认折叠"""
+        section = CollapsibleSection("类别映射（可选：模型类别与项目类别不一致时使用）")
+
+        layout = QVBoxLayout(section.body)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
         # 启用映射选项
-        enable_mapping_layout = QHBoxLayout()
         self.chk_enable_mapping = QCheckBox("启用类别映射")
         self.chk_enable_mapping.setChecked(False)
         self.chk_enable_mapping.stateChanged.connect(self.on_enable_mapping_changed)
-        enable_mapping_layout.addWidget(self.chk_enable_mapping)
-        enable_mapping_layout.addStretch()
-        layout.addLayout(enable_mapping_layout)
-        
+        layout.addWidget(self.chk_enable_mapping)
+
         # 模型类别文件加载
-        model_class_file_layout = QHBoxLayout()
-        self.btn_load_classes = QPushButton("加载模型classes.txt")
+        self.btn_load_classes = QPushButton("加载模型 classes.txt")
         self.btn_load_classes.clicked.connect(self.load_model_classes)
         self.btn_load_classes.setEnabled(False)
-        model_class_file_layout.addWidget(self.btn_load_classes)
+        layout.addWidget(self.btn_load_classes, alignment=Qt.AlignmentFlag.AlignLeft)
         self.model_classes_path = ""
         self.model_classes = []
-        layout.addLayout(model_class_file_layout)
-        
-        # 分割器
+
+        # 两侧类别对照
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        
-        # 模型类别列表
+
         model_class_widget = QWidget()
         model_class_layout = QVBoxLayout(model_class_widget)
+        model_class_layout.setContentsMargins(0, 0, 0, 0)
         model_class_layout.addWidget(QLabel("模型类别"))
         self.model_class_list = QListWidget()
         model_class_layout.addWidget(self.model_class_list)
         splitter.addWidget(model_class_widget)
-        
-        # 项目类别列表
+
         project_class_widget = QWidget()
         project_class_layout = QVBoxLayout(project_class_widget)
+        project_class_layout.setContentsMargins(0, 0, 0, 0)
         project_class_layout.addWidget(QLabel("项目类别"))
         self.project_class_list = QListWidget()
         project_class_layout.addWidget(self.project_class_list)
         splitter.addWidget(project_class_widget)
-        
+
         layout.addWidget(splitter)
-        
+
         # 映射按钮
         mapping_buttons_layout = QHBoxLayout()
-        
+
         self.btn_edit_mapping = QPushButton("编辑映射")
         self.btn_edit_mapping.clicked.connect(self.edit_mapping)
         self.btn_edit_mapping.setEnabled(False)
         mapping_buttons_layout.addWidget(self.btn_edit_mapping)
-        
+
         self.btn_apply_all = QPushButton("一键应用模型类别")
+        self.btn_apply_all.setToolTip("用模型的类别列表覆盖项目类别，保存后写入项目")
         self.btn_apply_all.clicked.connect(self.apply_all_model_classes)
         self.btn_apply_all.setEnabled(False)
         mapping_buttons_layout.addWidget(self.btn_apply_all)
-        
+        mapping_buttons_layout.addStretch()
+
         layout.addLayout(mapping_buttons_layout)
-        
+
         # 初始化类别列表
         self.update_class_lists()
-        
-        return group
-    
-    def get_group_style(self) -> str:
-        """获取分组框样式"""
-        return f"""
-            QGroupBox {{
-                font-weight: bold;
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                margin-top: 12px;
-                padding-top: 10px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px;
-            }}
-        """
-    
-    def get_inner_group_style(self) -> str:
-        """获取内部分组框样式"""
-        return f"""
-            QGroupBox {{
-                font-weight: normal;
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                margin-top: 8px;
-                padding-top: 8px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 8px;
-                padding: 0 4px;
-                font-size: 12px;
-            }}
-        """
-    
+
+        return section
+
     def on_model_version_changed(self, version: str):
         """模型版本改变时更新型号和任务类型列表"""
         self.cb_model_size.clear()
         self.cb_model_task.clear()
-        
+
         if version in ULTRALYTICS_MODELS:
             # 更新型号列表
             sizes = ULTRALYTICS_MODELS[version]['sizes']
             for size in sizes:
                 display_name = SIZE_NAMES.get(size, size)
                 self.cb_model_size.addItem(display_name, size)
-            
+
             # 更新任务类型列表
             tasks = ULTRALYTICS_MODELS[version]['tasks']
             for task in tasks:
                 self.cb_model_task.addItem(task)
-            
+
             # 默认选择第一个任务类型
             if tasks:
                 self.cb_model_task.setCurrentIndex(0)
-    
+
+        self.update_preview()
+
     def on_model_source_changed(self):
         """模型来源改变时更新界面"""
         if self.rbtn_custom.isChecked():
-            self.btn_browse_model.setEnabled(True)
             self.model_source = "custom"
         else:
-            self.btn_browse_model.setEnabled(False)
             self.model_source = "official"
-    
+
+        is_custom = self.model_source == "custom"
+        self.btn_browse_model.setEnabled(is_custom)
+        self.lbl_custom_model.setEnabled(is_custom)
+        self.official_widget.setEnabled(not is_custom)
+        self.update_preview()
+
     def browse_custom_model(self):
         """浏览自定义模型文件"""
         file_path, _ = QFileDialog.getOpenFileName(
-            self, "选择模型文件", 
+            self, "选择模型文件",
             "", "PyTorch models (*.pt *.pth)"
         )
         if file_path:
             self.custom_model_path = file_path
-    
-    def update_class_lists(self):
-        """更新类别列表"""
-        # 清空列表
-        self.model_class_list.clear()
-        self.project_class_list.clear()
-        
-        # 添加模型类别（示例）
-        model_classes = ["person", "car", "dog", "cat", "bird"]
-        for i, cls in enumerate(model_classes):
-            item = QListWidgetItem(f"{i}: {cls}")
-            self.model_class_list.addItem(item)
-        
-        # 添加项目类别
-        for cls in self.project_classes:
-            item = QListWidgetItem(f"{cls['id']}: {cls['name']}")
-            color = QColor(cls.get('color', '#808080'))
-            item.setForeground(color)
-            self.project_class_list.addItem(item)
-    
+            self.lbl_custom_model.setText(os.path.basename(file_path))
+            self.lbl_custom_model.setToolTip(file_path)
+            self.update_preview()
+
     def edit_mapping(self):
         """编辑类别映射"""
+        if not self.model_classes:
+            QMessageBox.warning(self, "警告", "请先加载模型classes.txt文件")
+            return
+
         # 这里可以实现一个更复杂的映射编辑界面
+        # 暂时使用简单的消息框
         QMessageBox.information(self, "编辑映射", "类别映射编辑功能开发中...")
-    
+
     def add_class(self):
         """添加新类别"""
         # 这里可以实现添加新类别的功能
         QMessageBox.information(self, "添加类别", "添加类别功能开发中...")
-    
+
     def on_single_inference(self):
         """单张推理"""
         # 获取模型路径
@@ -580,10 +572,10 @@ class AutoLabelDialog(QDialog):
         if not model_path:
             QMessageBox.warning(self, "错误", "请选择有效的模型")
             return
-        
+
         # 获取任务类型
         model_task = self.cb_model_task.currentText() if hasattr(self, 'cb_model_task') else 'detect'
-        
+
         # 发送信号
         self.single_inference_requested.emit(
             model_path,
@@ -595,7 +587,7 @@ class AutoLabelDialog(QDialog):
         )
         # 关闭弹窗
         self.accept()
-    
+
     def on_batch_inference(self):
         """一键推理"""
         # 获取模型路径
@@ -603,10 +595,10 @@ class AutoLabelDialog(QDialog):
         if not model_path:
             QMessageBox.warning(self, "错误", "请选择有效的模型")
             return
-        
+
         # 获取任务类型
         model_task = self.cb_model_task.currentText() if hasattr(self, 'cb_model_task') else 'detect'
-        
+
         # 发送信号
         self.batch_inference_requested.emit(
             model_path,
@@ -619,17 +611,17 @@ class AutoLabelDialog(QDialog):
         )
         # 关闭弹窗
         self.accept()
-    
+
     def run_single_inference(self, image_path: str):
         """运行单张推理"""
         self.current_image_path = image_path
         self.exec()
-    
+
     def run_batch_inference(self, images: list):
         """运行批量推理"""
         self.current_images = images
         self.exec()
-    
+
     def get_model_path(self) -> str:
         """获取模型路径"""
         if self.model_source == "custom":
@@ -642,18 +634,18 @@ class AutoLabelDialog(QDialog):
                 prefix = ULTRALYTICS_MODELS[version]['prefix']
                 return f"{prefix}{size}"
         return ""
-    
+
     def on_enable_mapping_changed(self, state):
         """启用映射选项改变时的处理"""
         enabled = state == Qt.CheckState.Checked.value
         self.btn_load_classes.setEnabled(enabled)
         self.btn_edit_mapping.setEnabled(enabled and len(self.model_classes) > 0)
         self.btn_apply_all.setEnabled(enabled and len(self.model_classes) > 0)
-        
+
     def load_model_classes(self):
         """加载模型classes.txt文件"""
         file_path, _ = QFileDialog.getOpenFileName(
-            self, "选择模型classes.txt文件", 
+            self, "选择模型classes.txt文件",
             "", "Text files (*.txt)"
         )
         if file_path:
@@ -671,7 +663,7 @@ class AutoLabelDialog(QDialog):
                     QMessageBox.warning(self, "警告", "classes.txt文件为空")
             except Exception as e:
                 QMessageBox.critical(self, "错误", f"加载classes.txt文件失败: {str(e)}")
-    
+
     def update_model_class_list(self):
         """更新模型类别列表"""
         self.model_class_list.clear()
@@ -680,18 +672,18 @@ class AutoLabelDialog(QDialog):
                 item = QListWidgetItem(f"{i}: {cls}")
                 self.model_class_list.addItem(item)
         else:
-            # 添加默认模型类别（示例）
-            model_classes = ["person", "car", "dog", "cat", "bird"]
-            for i, cls in enumerate(model_classes):
-                item = QListWidgetItem(f"{i}: {cls}")
-                self.model_class_list.addItem(item)
-    
+            # 还没加载：给出空状态，而不是一串看着像真数据的示例类别
+            placeholder = QListWidgetItem("尚未加载模型类别，请点击「加载模型 classes.txt」")
+            placeholder.setFlags(Qt.ItemFlag.NoItemFlags)
+            placeholder.setForeground(QColor(COLORS['text_disabled']))
+            self.model_class_list.addItem(placeholder)
+
     def apply_all_model_classes(self):
         """一键应用模型类别到项目"""
         if not self.model_classes:
             QMessageBox.warning(self, "警告", "请先加载模型classes.txt文件")
             return
-        
+
         # 创建新的项目类别列表
         new_classes = []
         for i, cls_name in enumerate(self.model_classes):
@@ -703,15 +695,15 @@ class AutoLabelDialog(QDialog):
                 'name': cls_name,
                 'color': color
             })
-        
+
         # 更新项目类别
         self.project_classes = new_classes
         self.update_project_class_list()
-        
+
         # 发送信号通知主窗口更新类别
         # 这里可以添加一个信号来通知主窗口
         QMessageBox.information(self, "成功", f"成功应用 {len(new_classes)} 个模型类别到项目")
-    
+
     def update_project_class_list(self):
         """更新项目类别列表"""
         self.project_class_list.clear()
@@ -720,106 +712,178 @@ class AutoLabelDialog(QDialog):
             color = QColor(cls.get('color', '#808080'))
             item.setForeground(color)
             self.project_class_list.addItem(item)
-    
-    def edit_mapping(self):
-        """编辑类别映射"""
-        if not self.model_classes:
-            QMessageBox.warning(self, "警告", "请先加载模型classes.txt文件")
+
+    def update_class_lists(self):
+        """更新类别列表"""
+        self.update_model_class_list()
+        self.update_project_class_list()
+
+    def set_classes(self, classes: list):
+        """设置项目类别"""
+        self.project_classes = classes
+        self.update_class_lists()
+
+    def get_model_task(self) -> str:
+        """获取当前选择的任务类型"""
+        return self.cb_model_task.currentText() if hasattr(self, 'cb_model_task') else 'detect'
+
+    def get_class_mappings(self):
+        """获取类别映射"""
+        if not self.chk_enable_mapping.isChecked():
+            return {}
+
+        # 这里可以返回更复杂的映射
+        # 暂时返回空映射
+        return self.class_mappings
+
+    # ==================== 预览与状态 ====================
+
+    def update_preview(self):
+        """刷新底部「将要发生什么」的预览，以及风险 / 状态提示。"""
+        if not hasattr(self, 'lbl_preview') or not hasattr(self, 'tab_widget'):
             return
-        
-        # 这里可以实现一个更复杂的映射编辑界面
-        # 暂时使用简单的消息框
-        QMessageBox.information(self, "编辑映射", "类别映射编辑功能开发中...")
-    
+
+        index = self.tab_widget.currentIndex()
+        if index == 0:
+            preview, notice, color = self._yolo_preview()
+        elif index == 1:
+            preview, notice, color = self._sam_preview()
+        else:
+            preview, notice, color = self._llm_preview()
+
+        self.lbl_preview.setText(preview)
+        self.lbl_preview.setStyleSheet(f"color: {COLORS['text_secondary']};")
+        self.lbl_notice.setText(notice)
+        self.lbl_notice.setStyleSheet(f"color: {color};")
+
+    def _yolo_preview(self):
+        if self.model_source == "custom":
+            model_name = os.path.basename(self.custom_model_path) if self.custom_model_path else "未选择模型文件"
+        else:
+            model_name = f"{self.cb_model_version.currentText()} {self.cb_model_size.currentText()}"
+
+        scope = "仅未标注图片" if self.chk_only_unlabeled.isChecked() else "全部图片"
+        preview = (
+            f"保存后自动标注将使用：{model_name} · {self.get_model_task()} · "
+            f"置信度 {self.sb_conf_threshold.value():.2f} / IoU {self.sb_iou_threshold.value():.2f} · {scope}"
+        )
+
+        if self.model_source == "custom" and not self.custom_model_path:
+            return preview, "还没有选择自定义模型文件，保存前请先浏览选择。", COLORS['error']
+        if self.chk_overwrite.isChecked():
+            return preview, "已勾选「覆盖原标签」：推理结果会替换图片已有标注，无法撤销。", COLORS['error']
+        return preview, "", COLORS['text_secondary']
+
+    def _sam_preview(self):
+        sam_type = self.cb_sam_type.currentText()
+        model_file = self.cb_sam_model.currentData()
+        model_name = self.cb_sam_model.currentText()
+        mode = self.cb_sam_usage_mode.currentText()
+        device = self.cb_sam_device.currentText()
+
+        preview = f"SAM 标注将使用：{model_name} · 设备 {device} · {mode}"
+
+        if not _sam_model_exists(model_file):
+            if sam_type == "SAM3":
+                return preview, f"{model_file} 不在本地，且不支持自动下载：请从 {SAM3_DOWNLOAD_URL} 下载后放到项目根目录。", COLORS['warning']
+            return preview, f"{model_file} 不在本地，保存时会询问是否下载。", COLORS['warning']
+        return preview, f"{model_file} 已在本地，可直接使用。", COLORS['success']
+
+    def _llm_preview(self):
+        model_name = self.le_llm_model_name.text().strip() or "未填写模型名称"
+        base_url = self.le_llm_base_url.text().strip() or "未填写 Base URL"
+        preview = f"LLM 标注将调用：{model_name} @ {base_url}"
+
+        if not self.le_llm_api_key.text().strip():
+            return preview, "还没有填写 API Key，LLM 自动标注不可用。", COLORS['warning']
+        return preview, "API Key 以明文保存在 config/llm_config.json，请勿共享该文件。", COLORS['warning']
+
+    def _set_status(self, text: str, color: str):
+        """执行状态（当前只有 SAM 模型下载会用到）。"""
+        self.lbl_notice.setText(text)
+        self.lbl_notice.setStyleSheet(f"color: {color};")
+
     def on_save_clicked(self):
         """保存按钮点击事件，输出调试信息"""
+        # 自定义来源却没选文件：存下去只会得到一个用不了的配置
+        if self.model_source == "custom" and not self.custom_model_path:
+            self.tab_widget.setCurrentIndex(0)
+            QMessageBox.warning(self, "提示", "已选择自定义模型，请先浏览选择模型文件")
+            return
+
         # 获取模型信息
         model_path = self.get_model_path()
         model_task = self.cb_model_task.currentText() if hasattr(self, 'cb_model_task') else 'detect'
         model_version = self.cb_model_version.currentText() if hasattr(self, 'cb_model_version') else ''
         model_size = self.cb_model_size.currentData() or self.cb_model_size.currentText() if hasattr(self, 'cb_model_size') else ''
-        
+
         # 构建模型名称
         if self.model_source == "custom":
             model_name = os.path.basename(model_path) if model_path else "自定义模型"
         else:
             model_name = f"{model_version}-{model_size}-{model_task}" if model_version else model_path
 
-        
+
         # 检查SAM模型是否存在
         if hasattr(self, 'cb_sam_type') and hasattr(self, 'cb_sam_model'):
             sam_type = self.cb_sam_type.currentText()
             model_file = self.cb_sam_model.currentData()
-            
-            if model_file:
-                # 检查模型文件是否存在
-                model_paths = [
-                    model_file,
-                    os.path.join('models', model_file),
-                    os.path.join(os.path.expanduser('~'), '.cache', 'ultralytics', model_file),
-                ]
-                
-                model_exists = False
-                for path in model_paths:
-                    if os.path.exists(path):
-                        model_exists = True
-                        break
-                
-                if not model_exists:
-                    if sam_type == "SAM3":
-                        QMessageBox.warning(
-                            self,
-                            "SAM3模型未找到",
-                            f"SAM3模型文件不存在: {model_file}\n\n"
-                            f"SAM3不支持自动下载。\n"
-                            f"请到以下页面下载 sam3.pt，放到项目根目录后重试：\n"
-                            f"{SAM3_DOWNLOAD_URL}"
-                        )
-                        return
 
-                    # 模型不存在，提示用户下载
-                    reply = QMessageBox.question(
+            if model_file and not _sam_model_exists(model_file):
+                if sam_type == "SAM3":
+                    QMessageBox.warning(
                         self,
-                        "模型不存在",
-                        f"SAM模型文件不存在: {model_file}\n\n"
-                        f"模型类型: {sam_type}\n"
-                        f"需要下载模型才能使用SAM功能。\n\n"
-                        f"是否现在下载？\n"
-                        f"（下载可能需要一些时间，取决于网络状况）",
-                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+                        "SAM3模型未找到",
+                        f"SAM3模型文件不存在: {model_file}\n\n"
+                        f"SAM3不支持自动下载。\n"
+                        f"请到以下页面下载 sam3.pt，放到项目根目录后重试：\n"
+                        f"{SAM3_DOWNLOAD_URL}"
                     )
-                    
-                    if reply == QMessageBox.StandardButton.Yes:
-                        # 尝试下载模型
-                        self.download_sam_model(sam_type, model_file)
-                    else:
-                        # 用户选择不下载，清空SAM配置
-                        print(f"[SAM] 用户选择不下载模型，SAM功能将不可用")
-        
+                    return
+
+                # 模型不存在，提示用户下载
+                reply = QMessageBox.question(
+                    self,
+                    "模型不存在",
+                    f"SAM模型文件不存在: {model_file}\n\n"
+                    f"模型类型: {sam_type}\n"
+                    f"需要下载模型才能使用SAM功能。\n\n"
+                    f"是否现在下载？\n"
+                    f"（下载可能需要一些时间，取决于网络状况）",
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+                )
+
+                if reply == QMessageBox.StandardButton.Yes:
+                    # 尝试下载模型
+                    self.download_sam_model(sam_type, model_file)
+                else:
+                    # 用户选择不下载，清空SAM配置
+                    print(f"[SAM] 用户选择不下载模型，SAM功能将不可用")
+
         # 保存SAM配置
         self.save_sam_config()
 
         # 保存LLM配置
         self.save_llm_config()
-        
+
         # 调用accept保存设置
         self.accept()
-    
+
     def download_sam_model(self, sam_type: str, model_file: str):
         """下载SAM模型"""
         try:
             from PyQt6.QtWidgets import QProgressDialog
             from PyQt6.QtCore import Qt, QThread, pyqtSignal
-            
+
             class ModelDownloadWorker(QThread):
                 """模型下载工作线程"""
                 download_finished = pyqtSignal(bool, str)
-                
+
                 def __init__(self, sam_type, model_file):
                     super().__init__()
                     self.sam_type = sam_type
                     self.model_file = model_file
-                
+
                 def run(self):
                     try:
                         # 根据类型导入正确的类来触发下载
@@ -830,156 +894,137 @@ class AutoLabelDialog(QDialog):
                             # SAM, SAM2, MobileSAM 都使用SAM类
                             from ultralytics import SAM
                             model = SAM(self.model_file)
-                        
+
                         self.download_finished.emit(True, f"模型 {self.model_file} 下载成功")
                     except Exception as e:
                         self.download_finished.emit(False, f"下载失败: {str(e)}")
-            
+
             # 显示进度对话框
+            self._set_status(f"正在下载模型 {model_file}...", COLORS['text_secondary'])
             progress = QProgressDialog(f"正在下载模型 {model_file}...", "取消", 0, 0, self)
             progress.setWindowModality(Qt.WindowModality.WindowModal)
             progress.setCancelButton(None)
             progress.show()
-            
+
             # 创建下载线程
             self.download_worker = ModelDownloadWorker(sam_type, model_file)
             self.download_worker.download_finished.connect(
                 lambda success, msg: self.on_model_download_finished(success, msg, progress)
             )
             self.download_worker.start()
-            
+
         except Exception as e:
+            self._set_status(f"启动下载失败: {str(e)}", COLORS['error'])
             QMessageBox.critical(self, "错误", f"启动下载失败: {str(e)}")
-    
+
     def on_model_download_finished(self, success: bool, message: str, progress_dialog):
         """模型下载完成回调"""
         progress_dialog.close()
-        
+
         if success:
+            self._set_status(message, COLORS['success'])
             QMessageBox.information(self, "成功", message)
         else:
+            self._set_status(message, COLORS['error'])
             QMessageBox.critical(self, "下载失败", message)
-    
-    def get_model_task(self) -> str:
-        """获取当前选择的任务类型"""
-        return self.cb_model_task.currentText() if hasattr(self, 'cb_model_task') else 'detect'
-    
-    def get_class_mappings(self):
-        """获取类别映射"""
-        if not self.chk_enable_mapping.isChecked():
-            return {}
-        
-        # 这里可以返回更复杂的映射
-        # 暂时返回空映射
-        return self.class_mappings
-    
-    def update_class_lists(self):
-        """更新类别列表"""
-        # 清空列表
-        self.model_class_list.clear()
-        self.project_class_list.clear()
-        
-        # 添加模型类别
-        if self.model_classes:
-            for i, cls in enumerate(self.model_classes):
-                item = QListWidgetItem(f"{i}: {cls}")
-                self.model_class_list.addItem(item)
-        else:
-            # 添加默认模型类别（示例）
-            model_classes = ["person", "car", "dog", "cat", "bird"]
-            for i, cls in enumerate(model_classes):
-                item = QListWidgetItem(f"{i}: {cls}")
-                self.model_class_list.addItem(item)
-        
-        # 添加项目类别
-        for cls in self.project_classes:
-            item = QListWidgetItem(f"{cls['id']}: {cls['name']}")
-            color = QColor(cls.get('color', '#808080'))
-            item.setForeground(color)
-            self.project_class_list.addItem(item)
-    
-    def set_classes(self, classes: list):
-        """设置项目类别"""
-        self.project_classes = classes
-        self.update_class_lists()
-    
+
     # ==================== SAM相关方法 ====================
-    
+
     def create_sam_model_group(self) -> QGroupBox:
         """创建SAM模型选择组"""
-        group = QGroupBox("SAM模型选择")
-        group.setStyleSheet(self.get_group_style())
-        
+        group = QGroupBox("SAM 模型")
+
         layout = QFormLayout(group)
-        
+
         # SAM类型选择
         self.cb_sam_type = QComboBox()
         self.cb_sam_type.addItems(list(SAM_MODELS.keys()))
         self.cb_sam_type.currentTextChanged.connect(self.on_sam_type_changed)
         layout.addRow("模型类型:", self.cb_sam_type)
-        
+
         # SAM型号选择
         self.cb_sam_model = QComboBox()
+        self.cb_sam_model.currentTextChanged.connect(lambda _: self.update_preview())
         layout.addRow("模型型号:", self.cb_sam_model)
-        
+
         # 初始化型号列表
         self.on_sam_type_changed(self.cb_sam_type.currentText())
-        
+
         # 设备选择
         self.cb_sam_device = QComboBox()
         self.cb_sam_device.addItems(["自动选择", "CPU", "CUDA:0", "CUDA:1", "CUDA:2", "CUDA:3"])
+        self.cb_sam_device.currentTextChanged.connect(lambda _: self.update_preview())
         layout.addRow("设备:", self.cb_sam_device)
-        
+
         return group
-    
+
     def create_sam_params_group(self) -> QGroupBox:
-        """创建SAM推理参数组"""
+        """创建SAM推理参数组：常用的留在外面，FastSAM 专用的收起来"""
         group = QGroupBox("推理参数")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QFormLayout(group)
-        
+
+        layout = QVBoxLayout(group)
+        layout.setSpacing(8)
+
+        form = QFormLayout()
+
         # 图像尺寸
         self.sb_sam_imgsz = QDoubleSpinBox()
         self.sb_sam_imgsz.setRange(256, 2048)
         self.sb_sam_imgsz.setValue(1024)
         self.sb_sam_imgsz.setSingleStep(64)
-        layout.addRow("图像尺寸:", self.sb_sam_imgsz)
-        
+        form.addRow("图像尺寸:", self.sb_sam_imgsz)
+
+        layout.addLayout(form)
+
+        advanced = CollapsibleSection("高级参数（仅 FastSAM 生效）")
+        advanced_layout = QFormLayout(advanced.body)
+        advanced_layout.setContentsMargins(0, 0, 0, 0)
+
         # 置信度阈值（FastSAM用）
         self.sb_sam_conf = QDoubleSpinBox()
         self.sb_sam_conf.setRange(0.01, 1.0)
         self.sb_sam_conf.setValue(0.4)
         self.sb_sam_conf.setDecimals(2)
         self.sb_sam_conf.setSingleStep(0.05)
-        layout.addRow("置信度阈值:", self.sb_sam_conf)
-        
+        advanced_layout.addRow("置信度阈值:", self.sb_sam_conf)
+
         # IoU阈值（FastSAM用）
         self.sb_sam_iou = QDoubleSpinBox()
         self.sb_sam_iou.setRange(0.1, 1.0)
         self.sb_sam_iou.setValue(0.9)
         self.sb_sam_iou.setDecimals(2)
         self.sb_sam_iou.setSingleStep(0.05)
-        layout.addRow("IoU阈值:", self.sb_sam_iou)
-        
+        advanced_layout.addRow("IoU阈值:", self.sb_sam_iou)
+
         # Retina masks选项（FastSAM用）
         self.chk_sam_retina = QCheckBox("使用Retina Masks")
         self.chk_sam_retina.setChecked(True)
-        layout.addRow(self.chk_sam_retina)
-        
+        advanced_layout.addRow(self.chk_sam_retina)
+
+        layout.addWidget(advanced)
+
         return group
 
     def create_sam_usage_group(self) -> QGroupBox:
         """创建SAM使用方式组"""
         group = QGroupBox("使用方式")
-        group.setStyleSheet(self.get_group_style())
-        layout = QFormLayout(group)
+        layout = QVBoxLayout(group)
+        layout.setSpacing(6)
 
+        form = QFormLayout()
         self.cb_sam_usage_mode = QComboBox()
-        layout.addRow("模式:", self.cb_sam_usage_mode)
+        self.cb_sam_usage_mode.currentTextChanged.connect(lambda _: self.update_preview())
+        form.addRow("模式:", self.cb_sam_usage_mode)
+        layout.addLayout(form)
+
+        hint = QLabel("记忆标注只有 SAM2 / SAM3 提供，其他模型只有普通标注。")
+        hint.setObjectName("caption")
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
         self._update_sam_usage_mode_options(self.cb_sam_type.currentText())
         return group
-    
+
     def on_sam_type_changed(self, sam_type: str):
         """SAM类型改变时更新型号列表"""
         self.cb_sam_model.clear()
@@ -988,6 +1033,7 @@ class AutoLabelDialog(QDialog):
             for name, file in models.items():
                 self.cb_sam_model.addItem(f"{name} ({file})", file)
         self._update_sam_usage_mode_options(sam_type)
+        self.update_preview()
 
     def _update_sam_usage_mode_options(self, sam_type: str, target_mode: str = None):
         """根据SAM类型更新可选使用方式。"""
@@ -1003,12 +1049,12 @@ class AutoLabelDialog(QDialog):
             if idx >= 0:
                 self.cb_sam_usage_mode.setCurrentIndex(idx)
         self.cb_sam_usage_mode.blockSignals(False)
-    
+
     def get_sam_config(self) -> dict:
         """获取SAM配置"""
         sam_type = self.cb_sam_type.currentText()
         model_file = self.cb_sam_model.currentData()
-        
+
         # 获取设备
         device = self.cb_sam_device.currentText()
         if device == "自动选择":
@@ -1021,7 +1067,7 @@ class AutoLabelDialog(QDialog):
             device = 'cpu'
         elif device.startswith("CUDA:"):
             device = device.split(":")[1]
-        
+
         return {
             'sam_type': sam_type,
             'model_file': model_file,
@@ -1099,77 +1145,89 @@ class AutoLabelDialog(QDialog):
             except Exception:
                 pass
         return config
-    
+
     # ==================== LLM相关方法 ====================
-    
+
     def create_llm_tab(self) -> QWidget:
         """创建LLM自动标注页面"""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(16)
-        
-        # API配置组
-        api_group = self.create_llm_api_group()
-        layout.addWidget(api_group)
-        
-        # 提示词配置组
-        prompt_group = self.create_llm_prompt_group()
-        layout.addWidget(prompt_group)
-        
+        layout.setSpacing(14)
+
+        layout.addWidget(self.create_llm_api_group())
+        layout.addWidget(self.create_llm_prompt_section())
+
         layout.addStretch()
         return tab
-    
+
     def create_llm_api_group(self) -> QGroupBox:
         """创建LLM API配置组"""
-        group = QGroupBox("API配置")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QFormLayout(group)
-        
+        group = QGroupBox("视觉模型服务")
+
+        layout = QVBoxLayout(group)
+        layout.setSpacing(8)
+
+        form = QFormLayout()
+
         # API Key
         self.le_llm_api_key = QLineEdit()
         self.le_llm_api_key.setEchoMode(QLineEdit.EchoMode.Password)
         self.le_llm_api_key.setPlaceholderText("请输入API Key")
-        layout.addRow("API Key:", self.le_llm_api_key)
-        
+        self.le_llm_api_key.textChanged.connect(lambda _: self.update_preview())
+        form.addRow("API Key:", self.le_llm_api_key)
+
         # Base URL
         self.le_llm_base_url = QLineEdit()
         self.le_llm_base_url.setPlaceholderText("请输入Base URL")
-        layout.addRow("Base URL:", self.le_llm_base_url)
-        
+        self.le_llm_base_url.textChanged.connect(lambda _: self.update_preview())
+        form.addRow("Base URL:", self.le_llm_base_url)
+
         # Model Name
         self.le_llm_model_name = QLineEdit()
         self.le_llm_model_name.setPlaceholderText("请输入模型名称")
-        layout.addRow("模型名称:", self.le_llm_model_name)
-        
+        self.le_llm_model_name.textChanged.connect(lambda _: self.update_preview())
+        form.addRow("模型名称:", self.le_llm_model_name)
+
+        layout.addLayout(form)
+
+        hint = QLabel("兼容 OpenAI 接口的视觉模型即可；标注时按当前选中的类别逐张调用。")
+        hint.setObjectName("caption")
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
         return group
-    
-    def create_llm_prompt_group(self) -> QGroupBox:
-        """创建LLM提示词配置组"""
-        group = QGroupBox("提示词配置")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        
+
+    def create_llm_prompt_section(self) -> CollapsibleSection:
+        """提示词模板：默认折叠，不挡住上面的基础配置"""
+        section = CollapsibleSection("提示词模板（高级）")
+
+        layout = QVBoxLayout(section.body)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
         # 系统提示词
         layout.addWidget(QLabel("系统提示词:"))
         self.te_llm_system_prompt = QTextEdit()
         self.te_llm_system_prompt.setMaximumHeight(120)
         layout.addWidget(self.te_llm_system_prompt)
-        
+
         # 用户提示词
-        layout.addWidget(QLabel("用户提示词 (使用 {target} 作为类别占位符):"))
+        layout.addWidget(QLabel("用户提示词:"))
         self.te_llm_user_prompt = QTextEdit()
         self.te_llm_user_prompt.setMaximumHeight(120)
         layout.addWidget(self.te_llm_user_prompt)
-        
-        return group
-    
+
+        hint = QLabel("{target} 会被替换成当前选中的类别名称。")
+        hint.setObjectName("caption")
+        layout.addWidget(hint)
+
+        return section
+
     def load_llm_config(self):
         """加载LLM配置"""
         config = DEFAULT_LLM_CONFIG.copy()
-        
+
         # 从文件加载配置
         if os.path.exists(LLM_CONFIG_FILE):
             try:
@@ -1178,14 +1236,14 @@ class AutoLabelDialog(QDialog):
                     config.update(saved_config)
             except Exception as e:
                 print(f"加载LLM配置失败: {e}")
-        
+
         # 设置到UI
         self.le_llm_api_key.setText(config.get('api_key', ''))
         self.le_llm_base_url.setText(config.get('base_url', ''))
         self.le_llm_model_name.setText(config.get('model_name', ''))
         self.te_llm_system_prompt.setPlainText(config.get('system_prompt', ''))
         self.te_llm_user_prompt.setPlainText(config.get('user_prompt', ''))
-    
+
     def save_llm_config(self):
         """保存LLM配置"""
         config = {
@@ -1195,12 +1253,12 @@ class AutoLabelDialog(QDialog):
             'system_prompt': self.te_llm_system_prompt.toPlainText(),
             'user_prompt': self.te_llm_user_prompt.toPlainText()
         }
-        
+
         # 确保配置目录存在
         config_dir = os.path.dirname(LLM_CONFIG_FILE)
         if not os.path.exists(config_dir):
             os.makedirs(config_dir)
-        
+
         # 保存到文件
         try:
             with open(LLM_CONFIG_FILE, 'w', encoding='utf-8') as f:
@@ -1209,7 +1267,7 @@ class AutoLabelDialog(QDialog):
         except Exception as e:
             print(f"保存LLM配置失败: {e}")
             return False
-    
+
     def get_llm_config(self) -> dict:
         """获取LLM配置"""
         return {

--- a/gui/pages/batch_process_dialog.py
+++ b/gui/pages/batch_process_dialog.py
@@ -2,283 +2,248 @@
 """
 批量处理标注对话框
 支持批量删除和批量修改标注类别
+
+界面按用户的操作顺序组织：选择范围 → 处理方式 → 确认执行。
+弹窗是非模态的：用户要一边在画布上点像素点，一边在这里设置。
 """
 
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QGroupBox, QFormLayout, QSpinBox, QComboBox, QListWidget,
+    QGroupBox, QFormLayout, QSpinBox, QListWidget,
     QListWidgetItem, QRadioButton, QButtonGroup, QMessageBox,
-    QSplitter, QWidget, QScrollArea, QFrame
+    QStackedWidget, QWidget, QScrollArea
 )
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QColor
-import os
-from typing import List, Dict, Tuple, Optional
+from PyQt6.QtGui import QColor, QGuiApplication
+from typing import List, Tuple
 
 from gui.styles import COLORS
 
 
 class BatchProcessDialog(QDialog):
     """批量处理标注对话框"""
-    
+
     # 信号定义
     process_requested = pyqtSignal(dict)  # 发送处理请求
-    
+
     def __init__(self, parent=None, project_classes=None, total_images=0):
         super().__init__(parent)
         self.setWindowTitle("批量处理标注")
-        
-        # 获取屏幕分辨率并设置对话框大小
-        from PyQt6.QtGui import QGuiApplication
-        screen = QGuiApplication.primaryScreen()
-        screen_geometry = screen.geometry()
-        screen_width = screen_geometry.width()
-        screen_height = screen_geometry.height()
-        
-        # 设置对话框大小为屏幕高度的90%，宽度600
-        dialog_height = int(screen_height * 0.9)
-        self.setMinimumSize(600, dialog_height)
-        self.resize(600, dialog_height)
-        
+
         # 项目类别
         self.project_classes = project_classes or []
         self.total_images = total_images
-        
+
         # 选择的像素点
         self.selected_points = []
-        
+
         # 初始化UI
         self.init_ui()
-    
+
+        # 窗口尺寸：内容放在滚动区里，窗口再小也不会截断
+        available = QGuiApplication.primaryScreen().availableGeometry()
+        self.setMinimumSize(520, 480)
+        self.resize(560, min(760, int(available.height() * 0.85)))
+
     def init_ui(self):
         """初始化界面"""
         main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 标题
+        main_layout.setContentsMargins(20, 20, 20, 16)
+        main_layout.setSpacing(12)
+
+        # 标题与说明
         title = QLabel("批量处理标注")
-        title.setStyleSheet("font-size: 18px; font-weight: bold;")
+        title.setObjectName("h2")
         main_layout.addWidget(title)
-        
-        # 说明文字
-        desc = QLabel("1. 在图片上点击选择像素点（可多选）\n2. 设置处理范围\n3. 选择操作类型和类别\n4. 点击执行")
-        desc.setStyleSheet("color: gray; margin-bottom: 10px;")
+
+        desc = QLabel("对指定范围内的图片，批量删除或改写覆盖了指定坐标的标注。")
+        desc.setObjectName("subtitle")
+        desc.setWordWrap(True)
         main_layout.addWidget(desc)
-        
-        # 步骤1：像素点选择状态
-        self.point_group = QGroupBox("步骤1：像素点选择")
-        self.point_group.setStyleSheet(self.get_group_style())
-        point_layout = QVBoxLayout(self.point_group)
-        
+
+        # 可滚动的设置区
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        body = QWidget()
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 6, 0)
+        body_layout.setSpacing(14)
+
+        body_layout.addWidget(self.create_scope_group())
+        body_layout.addWidget(self.create_operation_group())
+        body_layout.addWidget(self.create_confirm_group())
+        body_layout.addStretch()
+
+        scroll.setWidget(body)
+        main_layout.addWidget(scroll, 1)
+
+        # 底部按钮
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+
+        self.btn_cancel = QPushButton("取消")
+        self.btn_cancel.setObjectName("secondary")
+        self.btn_cancel.clicked.connect(self.reject)
+        button_layout.addWidget(self.btn_cancel)
+
+        self.btn_execute = QPushButton("执行批量删除")
+        self.btn_execute.setObjectName("primary")
+        self.btn_execute.clicked.connect(self.execute_process)
+        button_layout.addWidget(self.btn_execute)
+
+        main_layout.addLayout(button_layout)
+
+        # 初始状态更新
+        self.on_operation_changed()
+
+    # ==================== 步骤1：选择范围 ====================
+
+    def create_scope_group(self) -> QGroupBox:
+        """像素点 + 图片区间，一起构成「要处理哪些标注」。"""
+        self.point_group = QGroupBox("1 · 选择范围")
+        layout = QVBoxLayout(self.point_group)
+        layout.setSpacing(8)
+
+        point_hint = QLabel("在图片上点击目标位置（可多选）。范围内每张图片里，覆盖这些坐标的标注才会被处理。")
+        point_hint.setObjectName("caption")
+        point_hint.setWordWrap(True)
+        layout.addWidget(point_hint)
+
         self.point_status = QLabel("未选择像素点")
-        self.point_status.setStyleSheet("color: orange;")
-        point_layout.addWidget(self.point_status)
-        
+        self.point_status.setStyleSheet(f"color: {COLORS['warning']};")
+        layout.addWidget(self.point_status)
+
         self.selected_points_list = QListWidget()
-        self.selected_points_list.setMaximumHeight(100)
-        point_layout.addWidget(self.selected_points_list)
-        
+        self.selected_points_list.setMaximumHeight(96)
+        layout.addWidget(self.selected_points_list)
+
         btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
         self.btn_clear_points = QPushButton("清除所有点")
+        self.btn_clear_points.setObjectName("ghost")
         self.btn_clear_points.clicked.connect(self.clear_points)
         self.btn_clear_points.setEnabled(False)
         btn_layout.addWidget(self.btn_clear_points)
-        btn_layout.addStretch()
-        point_layout.addLayout(btn_layout)
-        
-        main_layout.addWidget(self.point_group)
-        
-        # 步骤2：处理范围
-        range_group = QGroupBox("步骤2：处理范围")
-        range_group.setStyleSheet(self.get_group_style())
-        range_layout = QFormLayout(range_group)
-        
+        layout.addLayout(btn_layout)
+
+        # 图片区间
+        range_layout = QFormLayout()
+        range_layout.setContentsMargins(0, 4, 0, 0)
+
         self.start_image = QSpinBox()
         self.start_image.setRange(1, max(1, self.total_images))
         self.start_image.setValue(1)
+        self.start_image.valueChanged.connect(self.update_execute_button)
         range_layout.addRow("起始图片:", self.start_image)
-        
+
         self.end_image = QSpinBox()
         self.end_image.setRange(1, max(1, self.total_images))
         self.end_image.setValue(self.total_images)
+        self.end_image.valueChanged.connect(self.update_execute_button)
         range_layout.addRow("结束图片:", self.end_image)
-        
-        range_info = QLabel(f"共 {self.total_images} 张图片")
-        range_info.setStyleSheet("color: gray;")
+
+        range_info = QLabel(f"按当前图片列表顺序计数，共 {self.total_images} 张图片")
+        range_info.setObjectName("caption")
         range_layout.addRow(range_info)
-        
-        main_layout.addWidget(range_group)
-        
-        # 步骤3：操作类型
-        op_group = QGroupBox("步骤3：操作类型")
-        op_group.setStyleSheet(self.get_group_style())
+
+        layout.addLayout(range_layout)
+
+        return self.point_group
+
+    # ==================== 步骤2：处理方式 ====================
+
+    def create_operation_group(self) -> QGroupBox:
+        """选删除还是改类别，并给出对应的类别选择。"""
+        op_group = QGroupBox("2 · 处理方式")
         op_layout = QVBoxLayout(op_group)
-        
+        op_layout.setSpacing(8)
+
         self.op_group = QButtonGroup(self)
-        
-        self.rbtn_delete = QRadioButton("批量删除")
+
+        self.rbtn_delete = QRadioButton("删除标注")
         self.rbtn_delete.setChecked(True)
         self.rbtn_delete.toggled.connect(self.on_operation_changed)
-        self.rbtn_delete.setStyleSheet("""
-            QRadioButton {
-                color: white;
-                font-size: 14px;
-            }
-            QRadioButton::indicator {
-                width: 16px;
-                height: 16px;
-                border-radius: 8px;
-                border: 2px solid white;
-                background-color: transparent;
-            }
-            QRadioButton::indicator:checked {
-                background-color: white;
-                border: 2px solid white;
-            }
-            QRadioButton::indicator:unchecked {
-                background-color: transparent;
-                border: 2px solid white;
-            }
-        """)
         self.op_group.addButton(self.rbtn_delete)
         op_layout.addWidget(self.rbtn_delete)
-        
-        self.rbtn_modify = QRadioButton("批量修改类别")
+
+        self.rbtn_modify = QRadioButton("修改标注类别")
         self.rbtn_modify.toggled.connect(self.on_operation_changed)
-        self.rbtn_modify.setStyleSheet("""
-            QRadioButton {
-                color: white;
-                font-size: 14px;
-            }
-            QRadioButton::indicator {
-                width: 16px;
-                height: 16px;
-                border-radius: 8px;
-                border: 2px solid white;
-                background-color: transparent;
-            }
-            QRadioButton::indicator:checked {
-                background-color: white;
-                border: 2px solid white;
-            }
-            QRadioButton::indicator:unchecked {
-                background-color: transparent;
-                border: 2px solid white;
-            }
-        """)
         self.op_group.addButton(self.rbtn_modify)
         op_layout.addWidget(self.rbtn_modify)
-        
-        main_layout.addWidget(op_group)
-        
-        # 步骤4：类别选择
-        self.class_group = QGroupBox("步骤4：类别选择")
-        self.class_group.setStyleSheet(self.get_group_style())
-        self.class_layout = QVBoxLayout(self.class_group)
-        
-        # 根据操作类型动态显示不同的类别选择界面
-        self.class_stack = QWidget()
-        self.class_stack_layout = QVBoxLayout(self.class_stack)
-        self.class_stack_layout.setContentsMargins(0, 0, 0, 0)
-        
+
+        # 两种方式各有各的类别选择，用堆叠页切换，避免同时堆一屏控件
+        self.class_stack = QStackedWidget()
+
         # 删除模式：多选要删除的类别
         self.delete_class_widget = QWidget()
         delete_class_layout = QVBoxLayout(self.delete_class_widget)
-        delete_class_layout.setContentsMargins(0, 0, 0, 0)
-        
-        delete_label = QLabel("选择要删除的类别（可多选）:")
+        delete_class_layout.setContentsMargins(0, 4, 0, 0)
+        delete_class_layout.setSpacing(6)
+
+        delete_label = QLabel("删除这些类别的标注（可多选）")
         delete_class_layout.addWidget(delete_label)
-        
+
         self.delete_class_list = QListWidget()
         self.delete_class_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        self.delete_class_list.setMinimumHeight(110)
+        self.delete_class_list.itemSelectionChanged.connect(self.update_execute_button)
         self.populate_class_list(self.delete_class_list)
         delete_class_layout.addWidget(self.delete_class_list)
-        
-        self.class_stack_layout.addWidget(self.delete_class_widget)
-        
+
+        self.class_stack.addWidget(self.delete_class_widget)
+
         # 修改模式：多选初始类别，单选目标类别
         self.modify_class_widget = QWidget()
         modify_class_layout = QVBoxLayout(self.modify_class_widget)
-        modify_class_layout.setContentsMargins(0, 0, 0, 0)
-        
-        # 初始类别
-        source_layout = QVBoxLayout()
-        source_label = QLabel("选择初始类别（可多选）:")
-        source_layout.addWidget(source_label)
-        
+        modify_class_layout.setContentsMargins(0, 4, 0, 0)
+        modify_class_layout.setSpacing(6)
+
+        source_label = QLabel("把这些类别的标注（可多选）")
+        modify_class_layout.addWidget(source_label)
+
         self.source_class_list = QListWidget()
         self.source_class_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        self.source_class_list.setMinimumHeight(96)
+        self.source_class_list.itemSelectionChanged.connect(self.update_execute_button)
         self.populate_class_list(self.source_class_list)
-        source_layout.addWidget(self.source_class_list)
-        
-        modify_class_layout.addLayout(source_layout)
-        
-        # 目标类别
-        target_layout = QVBoxLayout()
-        target_label = QLabel("选择目标类别（单选）:")
-        target_layout.addWidget(target_label)
-        
+        modify_class_layout.addWidget(self.source_class_list)
+
+        target_label = QLabel("改为这个类别（单选）")
+        modify_class_layout.addWidget(target_label)
+
         self.target_class_list = QListWidget()
         self.target_class_list.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self.target_class_list.setMinimumHeight(96)
+        self.target_class_list.itemSelectionChanged.connect(self.update_execute_button)
         self.populate_class_list(self.target_class_list)
-        target_layout.addWidget(self.target_class_list)
-        
-        modify_class_layout.addLayout(target_layout)
-        
-        self.class_stack_layout.addWidget(self.modify_class_widget)
-        self.modify_class_widget.hide()
-        
-        self.class_layout.addWidget(self.class_stack)
-        main_layout.addWidget(self.class_group)
-        
-        # 底部按钮
-        button_layout = QHBoxLayout()
-        
-        self.btn_execute = QPushButton("执行批量处理")
-        self.btn_execute.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {COLORS['primary']};
-                color: white;
-                font-weight: bold;
-                padding: 10px 20px;
-            }}
-            QPushButton:hover {{
-                background-color: {COLORS['primary']};
-            }}
-            QPushButton:disabled {{
-                background-color: gray;
-            }}
-        """)
-        self.btn_execute.clicked.connect(self.execute_process)
-        button_layout.addWidget(self.btn_execute)
-        
-        self.btn_cancel = QPushButton("取消")
-        self.btn_cancel.clicked.connect(self.reject)
-        button_layout.addWidget(self.btn_cancel)
-        
-        main_layout.addLayout(button_layout)
-        
-        # 初始状态更新
-        self.update_execute_button()
-    
-    def get_group_style(self) -> str:
-        """获取分组框样式"""
-        return f"""
-            QGroupBox {{
-                font-weight: bold;
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                margin-top: 12px;
-                padding-top: 10px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px;
-            }}
-        """
-    
+        modify_class_layout.addWidget(self.target_class_list)
+
+        self.class_stack.addWidget(self.modify_class_widget)
+
+        op_layout.addWidget(self.class_stack)
+
+        return op_group
+
+    # ==================== 步骤3：确认 ====================
+
+    def create_confirm_group(self) -> QGroupBox:
+        """执行前把「将要发生什么」一句话讲清楚。"""
+        self.class_group = QGroupBox("3 · 确认")
+        layout = QVBoxLayout(self.class_group)
+        layout.setSpacing(6)
+
+        self.summary_label = QLabel()
+        self.summary_label.setWordWrap(True)
+        layout.addWidget(self.summary_label)
+
+        self.risk_label = QLabel()
+        self.risk_label.setWordWrap(True)
+        self.risk_label.setStyleSheet(f"color: {COLORS['error']};")
+        layout.addWidget(self.risk_label)
+
+        return self.class_group
+
     def populate_class_list(self, list_widget: QListWidget):
         """填充类别列表"""
         list_widget.clear()
@@ -289,64 +254,107 @@ class BatchProcessDialog(QDialog):
             color = QColor(cls.get('color', '#808080'))
             item.setForeground(color)
             list_widget.addItem(item)
-    
+
     def on_operation_changed(self):
         """操作类型改变时"""
         if self.rbtn_delete.isChecked():
-            self.delete_class_widget.show()
-            self.modify_class_widget.hide()
+            self.class_stack.setCurrentWidget(self.delete_class_widget)
         else:
-            self.delete_class_widget.hide()
-            self.modify_class_widget.show()
-    
+            self.class_stack.setCurrentWidget(self.modify_class_widget)
+        self.update_execute_button()
+
     def add_point(self, x: int, y: int):
         """添加像素点"""
         self.selected_points.append((x, y))
         self.update_points_display()
         self.update_execute_button()
-    
+
     def clear_points(self):
         """清除所有像素点"""
         self.selected_points.clear()
         self.update_points_display()
         self.update_execute_button()
-    
+
     def update_points_display(self):
         """更新像素点显示"""
         self.selected_points_list.clear()
         for i, (x, y) in enumerate(self.selected_points):
             item = QListWidgetItem(f"点 {i+1}: ({x}, {y})")
             self.selected_points_list.addItem(item)
-        
+
         # 更新状态
         if self.selected_points:
             self.point_status.setText(f"已选择 {len(self.selected_points)} 个像素点")
-            self.point_status.setStyleSheet("color: green;")
+            self.point_status.setStyleSheet(f"color: {COLORS['success']};")
             self.btn_clear_points.setEnabled(True)
         else:
             self.point_status.setText("未选择像素点")
-            self.point_status.setStyleSheet("color: orange;")
+            self.point_status.setStyleSheet(f"color: {COLORS['warning']};")
             self.btn_clear_points.setEnabled(False)
-    
+
     def update_execute_button(self):
-        """更新执行按钮状态"""
-        has_points = len(self.selected_points) > 0
-        self.btn_execute.setEnabled(has_points)
-    
+        """按当前选择刷新主操作按钮、摘要和风险说明"""
+        is_delete = self.rbtn_delete.isChecked()
+        image_count = max(0, self.end_image.value() - self.start_image.value() + 1)
+
+        self.btn_execute.setText("执行批量删除" if is_delete else "执行批量修改")
+
+        missing = None
+        if not self.selected_points:
+            missing = "还需在图片上点击至少一个像素点"
+        elif self.start_image.value() > self.end_image.value():
+            missing = "起始图片不能大于结束图片"
+        elif is_delete and not self.delete_class_list.selectedItems():
+            missing = "还需选择要删除的类别"
+        elif not is_delete and not self.source_class_list.selectedItems():
+            missing = "还需选择初始类别"
+        elif not is_delete and not self.target_class_list.selectedItems():
+            missing = "还需选择目标类别"
+
+        self.btn_execute.setEnabled(missing is None)
+
+        if missing:
+            self.summary_label.setText(missing)
+            self.summary_label.setStyleSheet(f"color: {COLORS['text_secondary']};")
+            self.risk_label.setText("")
+            return
+
+        self.summary_label.setStyleSheet(f"color: {COLORS['text_primary']};")
+        point_count = len(self.selected_points)
+        if is_delete:
+            names = self._selected_class_names(self.delete_class_list)
+            self.summary_label.setText(
+                f"将在第 {self.start_image.value()}–{self.end_image.value()} 张（共 {image_count} 张）图片中，"
+                f"删除覆盖这 {point_count} 个坐标、且类别为 {names} 的标注。"
+            )
+            self.risk_label.setText("删除会直接写入数据库，无法撤销。")
+        else:
+            sources = self._selected_class_names(self.source_class_list)
+            target = self._selected_class_names(self.target_class_list)
+            self.summary_label.setText(
+                f"将在第 {self.start_image.value()}–{self.end_image.value()} 张（共 {image_count} 张）图片中，"
+                f"把覆盖这 {point_count} 个坐标、类别为 {sources} 的标注改为 {target}。"
+            )
+            self.risk_label.setText("修改会直接写入数据库，无法撤销。")
+
+    def _selected_class_names(self, list_widget: QListWidget) -> str:
+        """选中类别的可读名称，供摘要文案使用。"""
+        return "、".join(item.text().split(": ", 1)[-1] for item in list_widget.selectedItems())
+
     def execute_process(self):
         """执行批量处理"""
         if not self.selected_points:
             QMessageBox.warning(self, "提示", "请先选择像素点")
             return
-        
+
         # 获取处理范围
         start_idx = self.start_image.value() - 1  # 转换为0-based索引
         end_idx = self.end_image.value() - 1
-        
+
         if start_idx > end_idx:
             QMessageBox.warning(self, "提示", "起始图片不能大于结束图片")
             return
-        
+
         # 构建处理配置
         config = {
             'points': self.selected_points.copy(),
@@ -354,7 +362,7 @@ class BatchProcessDialog(QDialog):
             'end_idx': end_idx,
             'operation': 'delete' if self.rbtn_delete.isChecked() else 'modify'
         }
-        
+
         if self.rbtn_delete.isChecked():
             # 获取要删除的类别
             selected_items = self.delete_class_list.selectedItems()
@@ -368,19 +376,30 @@ class BatchProcessDialog(QDialog):
             if not source_items:
                 QMessageBox.warning(self, "提示", "请选择初始类别")
                 return
-            
+
             target_items = self.target_class_list.selectedItems()
             if not target_items:
                 QMessageBox.warning(self, "提示", "请选择目标类别")
                 return
-            
+
             config['source_classes'] = [item.data(Qt.ItemDataRole.UserRole) for item in source_items]
             config['target_class'] = target_items[0].data(Qt.ItemDataRole.UserRole)
-        
+
+        # 最后一道确认：这一步会直接改数据库且不可撤销
+        reply = QMessageBox.question(
+            self,
+            "确认批量删除" if config['operation'] == 'delete' else "确认批量修改",
+            f"{self.summary_label.text()}\n\n{self.risk_label.text()}\n\n确定执行吗？",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
         # 发送处理请求
         self.process_requested.emit(config)
         self.accept()
-    
+
     def get_selected_points(self) -> List[Tuple[int, int]]:
         """获取选择的像素点"""
         return self.selected_points.copy()

--- a/gui/pages/import_page.py
+++ b/gui/pages/import_page.py
@@ -1,21 +1,24 @@
 # -*- coding: utf-8 -*-
 """
-导入页面
-支持图像文件夹批量导入、视频抽帧、已有标注导入
+数据导入页面（第 1 步）
+
+页面只负责一件事：把图片弄进当前项目。
+项目的选择/新建/删除入口在主窗口侧边栏，这里不再重复放一个项目下拉框。
 """
 
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QScrollArea, QGridLayout, QFrame, QFileDialog, QProgressBar,
     QMenu, QMessageBox, QComboBox, QLineEdit, QListWidget, QListWidgetItem,
-    QDialog,
+    QDialog, QStackedWidget, QSizePolicy,
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize
-from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QIcon
+from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QIcon, QFontMetrics
 import cv2
 import numpy as np
+import threading
 from pathlib import Path
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Tuple, Callable
 import os
 
 from gui.styles import COLORS
@@ -24,39 +27,66 @@ from core.import_manager import ImportManager
 from core.annotation_importer import AnnotationImporter
 from gui.widgets.loading_dialog import LoadingOverlay
 from gui.widgets.group_select_dialog import GroupSelectDialog, ask_import_group
+from gui.widgets.task_type_dialog import ask_task_type, task_type_label
+from gui.widgets.workflow_widgets import EmptyState
 
 
-# 视频导入线程
-class VideoImportThread(QThread):
-    """视频导入后台线程"""
+# 数据导入线程：文件夹 / 多图 / 视频，实际工作全部委托给 core.import_manager，
+# 主线程不做逐文件复制、解码或数据库写入。
+class ImportWorkerThread(QThread):
+    """通用后台导入线程"""
+
     progress_updated = pyqtSignal(int, str)
-    finished = pyqtSignal(bool, str, int, int)
-    
-    def __init__(self, video_path, project_id, frame_interval, group_id=None):
+    # success, error_message, cancelled, imported, skipped
+    # 注意：不能叫 finished —— QThread 自带同名信号（线程真正退出时才发），
+    # 定义同名信号会把它遮住，导致没人能再监听「线程真的跑完了」这件事，
+    # 从而在还没运行结束时就被提前释放引用，触发
+    # "QThread: Destroyed while thread is still running"。
+    result_ready = pyqtSignal(bool, str, bool, int, int)
+
+    def __init__(self, project_id, group_id, kind, source, frame_interval=1):
         super().__init__()
-        self.video_path = video_path
         self.project_id = project_id
-        self.frame_interval = frame_interval
         self.group_id = group_id
-    
+        self.kind = kind  # 'folder' | 'images' | 'video'
+        self.source = source
+        self.frame_interval = frame_interval
+        self._cancel_event = threading.Event()
+
+    def cancel(self):
+        """请求取消：最迟在下一个文件/帧边界停止。"""
+        self._cancel_event.set()
+
     def run(self):
-        """运行视频导入"""
+        """运行导入"""
         try:
-            from core.import_manager import ImportManager
             import_manager = ImportManager(self.project_id, group_id=self.group_id)
-            
+
             def progress_callback(progress, message):
                 self.progress_updated.emit(progress, message)
-            
-            imported, skipped = import_manager.import_video(
-                self.video_path,
-                frame_interval=self.frame_interval,
-                progress_callback=progress_callback
-            )
-            
-            self.finished.emit(True, "视频导入完成", imported, skipped)
+
+            if self.kind == 'folder':
+                imported, skipped = import_manager.import_folder(
+                    self.source, progress_callback=progress_callback,
+                    cancel_event=self._cancel_event,
+                )
+            elif self.kind == 'images':
+                imported, skipped = import_manager.import_images(
+                    self.source, progress_callback=progress_callback,
+                    cancel_event=self._cancel_event,
+                )
+            elif self.kind == 'video':
+                imported, skipped = import_manager.import_video(
+                    self.source, frame_interval=self.frame_interval,
+                    progress_callback=progress_callback,
+                    cancel_event=self._cancel_event,
+                )
+            else:
+                raise ValueError(f"未知导入类型: {self.kind}")
+
+            self.result_ready.emit(True, "", self._cancel_event.is_set(), imported, skipped)
         except Exception as e:
-            self.finished.emit(False, f"导入失败: {str(e)}", 0, 0)
+            self.result_ready.emit(False, str(e), False, 0, 0)
 
 
 class ImageLoadWorker(QThread):
@@ -119,8 +149,13 @@ class ImageLoadWorker(QThread):
 
 
 class ImportPage(QWidget):
-    """导入页面"""
-    
+    """数据导入页面"""
+
+    # 项目列表变了（新建 / 删除），附带之后应该选中的项目 id（没有则 None）
+    projects_changed = pyqtSignal(object)
+    # 当前项目的图片或标注数量变了，主窗口据此刷新流程进度
+    project_data_changed = pyqtSignal()
+
     def __init__(self):
         super().__init__()
         self.current_project_id = None
@@ -129,8 +164,25 @@ class ImportPage(QWidget):
         self.load_worker = None
         self._image_load_generation = 0
         self.thumbnail_widgets = []  # 存储缩略图控件引用
+
+        # 导入任务状态：与上面的缩略图加载状态（load_worker/_image_load_generation）
+        # 完全分离，切页、刷新缩略图都不应该影响这一组状态
+        self._active_import_thread = None
+        # 被取消/作废但线程还没真正跑完的（比如切项目）：必须继续持有引用，
+        # 直到 QThread 原生 finished 信号确认线程真的退出了才能放手，
+        # 否则会在线程仍在运行时被 GC，触发 "QThread: Destroyed while thread is still running"。
+        self._retired_import_threads = []
+        self._import_busy = False
+        self._import_generation = 0
+        self._import_finalize_pending = False
+        self._import_finalize_summary = ""
+        self._import_finalize_cancelled = False
+        self._import_before_ids = set()
+
         self.init_ui()
         self.refresh_view_filter_options()
+        self.update_project_bar()
+        self.update_view_mode()
 
     def _remove_cached_thumbnails(self, storage_paths):
         """按路径移除缩略图缓存。"""
@@ -152,574 +204,478 @@ class ImportPage(QWidget):
     def init_ui(self):
         """初始化界面"""
         main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 标题区域
-        title_layout = QHBoxLayout()
-        
-        title = QLabel("数据导入")
-        title.setObjectName("title")
-        title.setStyleSheet("font-size: 24px; font-weight: bold;")
-        title_layout.addWidget(title)
-        
-        title_layout.addStretch()
-        
-        # 项目选择
-        project_label = QLabel("当前项目:")
-        project_label.setStyleSheet(f"color: {COLORS['text_secondary']};")
-        title_layout.addWidget(project_label)
-        
-        self.project_combo = QComboBox()
-        self.project_combo.setFixedWidth(200)
-        self.project_combo.addItem("请选择项目...")
-        self.project_combo.currentIndexChanged.connect(self.on_project_changed)
-        title_layout.addWidget(self.project_combo)
-        
-        # 任务类别显示和设置
-        self.task_type_label = QLabel("任务类别: 未设置")
-        self.task_type_label.setStyleSheet(f"color: {COLORS['text_secondary']}; padding: 0 10px;")
-        self.task_type_label.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.task_type_label.mousePressEvent = self.on_task_type_clicked
-        title_layout.addWidget(self.task_type_label)
-        
-        # 新建项目按钮
-        new_project_btn = QPushButton("+ 新建项目")
-        new_project_btn.setObjectName("secondary")
-        new_project_btn.clicked.connect(self.create_new_project)
-        title_layout.addWidget(new_project_btn)
-        
-        # 删除项目按钮
-        delete_project_btn = QPushButton("🗑 删除项目")
-        delete_project_btn.setObjectName("secondary")
-        delete_project_btn.clicked.connect(self.delete_current_project)
-        title_layout.addWidget(delete_project_btn)
-        
-        title_layout.addStretch()
-        
-        main_layout.addLayout(title_layout)
-        
-        # 说明文字
-        desc = QLabel("请导入需要标注和训练的图像数据，支持批量导入文件夹、单张图片、视频抽帧以及已有标注导入")
-        desc.setObjectName("subtitle")
-        desc.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 13px;")
-        desc.setWordWrap(True)
-        main_layout.addWidget(desc)
-        
-        # 工具栏
-        toolbar = self.create_toolbar()
-        main_layout.addWidget(toolbar)
-        
-        # 进度条（默认隐藏）
+        main_layout.setContentsMargins(24, 18, 24, 18)
+        main_layout.setSpacing(14)
+
+        # 项目信息条：当前项目叫什么、要做哪种任务
+        self.project_bar = self.create_project_bar()
+        main_layout.addWidget(self.project_bar)
+
+        # 工具栏：左边加数据，右边管数据
+        self.toolbar = self.create_toolbar()
+        main_layout.addWidget(self.toolbar)
+
+        # 导入任务状态条（默认隐藏）：只反映“导入任务”本身，
+        # 跟下面缩略图加载用的 progress_bar 是两套独立状态
+        self.import_status_frame = self.create_import_status_bar()
+        self.import_status_frame.setVisible(False)
+        main_layout.addWidget(self.import_status_frame)
+
+        # 缩略图加载进度条（默认隐藏）
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
-        self.progress_bar.setStyleSheet(f"""
-            QProgressBar {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                text-align: center;
-                color: white;
-                height: 20px;
-            }}
-            QProgressBar::chunk {{
-                background-color: {COLORS['primary']};
-                border-radius: 3px;
-            }}
-        """)
+        self.progress_bar.setTextVisible(False)
         main_layout.addWidget(self.progress_bar)
-        
-        # 图像列表区域 - 使用QListWidget代替自定义网格，性能更好
-        self.image_list = QListWidget()
-        self.image_list.setViewMode(QListWidget.ViewMode.IconMode)
-        self.image_list.setIconSize(QSize(160, 160))
-        self.image_list.setSpacing(16)
-        self.image_list.setResizeMode(QListWidget.ResizeMode.Adjust)
-        self.image_list.setMovement(QListWidget.Movement.Static)
-        self.image_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
-        self.image_list.setUniformItemSizes(True)  # 统一项目大小，优化布局
-        self.image_list.setGridSize(QSize(180, 200))  # 设置固定网格大小
-        self.image_list.itemClicked.connect(self.on_image_clicked)
-        self.image_list.setStyleSheet('''
-            QListWidget {
-                background-color: #1E1E1E;
-                border: none;
-            }
-            QListWidget::item {
-                background-color: #2D2D30;
-                border: 2px solid #3e3e42;
-                border-radius: 8px;
-                padding: 8px;
-            }
-            QListWidget::item:selected {
-                border: 2px solid #007ACC;
-            }
-        ''')
-        main_layout.addWidget(self.image_list)
-        
+
+        # 图片区：没项目 / 没图片 / 图片网格，三选一
+        self.view_stack = QStackedWidget()
+        self.view_stack.addWidget(self.create_no_project_state())   # 0
+        self.view_stack.addWidget(self.create_no_image_state())     # 1
+        self.view_stack.addWidget(self.create_image_grid())         # 2
+        main_layout.addWidget(self.view_stack, 1)
+
         # 状态栏
         self.status_bar = self.create_status_bar()
         main_layout.addWidget(self.status_bar)
-        
-        # 加载项目列表
-        self.load_projects()
-    
+
+    def create_project_bar(self) -> QFrame:
+        """项目信息条：项目名 + 任务类型 + 删除项目"""
+        bar = QFrame()
+        bar.setObjectName("card")
+
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(16, 12, 16, 12)
+        layout.setSpacing(12)
+
+        self.project_name_label = QLabel("未选择项目")
+        self.project_name_label.setObjectName("h2")
+        # 名字可能很长，不能让它把任务类型 / 删除按钮挤出去，超出部分省略并放进 tooltip
+        self.project_name_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        self.project_name_label.setMaximumWidth(280)
+        layout.addWidget(self.project_name_label)
+
+        self.btn_task_type = QPushButton("任务类型：未设置")
+        self.btn_task_type.setToolTip("决定标注工具和训练方式，一般选「目标检测」")
+        self.btn_task_type.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_task_type.clicked.connect(self.change_task_type)
+        layout.addWidget(self.btn_task_type)
+
+        layout.addStretch()
+
+        self.btn_delete_project = QPushButton("删除项目")
+        self.btn_delete_project.setObjectName("danger")
+        self.btn_delete_project.setToolTip("连同项目里的图片和标注一起删除，不可恢复")
+        self.btn_delete_project.clicked.connect(self.delete_current_project)
+        layout.addWidget(self.btn_delete_project)
+
+        return bar
+
     def create_toolbar(self) -> QFrame:
         """创建工具栏"""
         toolbar = QFrame()
-        toolbar.setStyleSheet(f"""
-            QFrame {{
-                background-color: {COLORS['panel']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-            }}
-        """)
-        
+        toolbar.setObjectName("toolbar")
+
         layout = QHBoxLayout(toolbar)
-        layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(12)
-        
-        # 导入文件夹按钮
-        self.btn_import_folder = QPushButton("📁 导入文件夹")
-        self.btn_import_folder.setToolTip("批量导入整个文件夹中的图像")
+        layout.setContentsMargins(14, 10, 14, 10)
+        layout.setSpacing(6)
+
+        # 主操作：绝大多数人是导入一个文件夹
+        self.btn_import_folder = QPushButton("导入文件夹")
+        self.btn_import_folder.setObjectName("primary")
+        self.btn_import_folder.setToolTip("把一个文件夹里的图片一次性全部导入")
         self.btn_import_folder.clicked.connect(self.import_folder)
         layout.addWidget(self.btn_import_folder)
-        
-        # 导入图片按钮
-        self.btn_import_images = QPushButton("🖼 导入图片")
+
+        self.btn_import_images = QPushButton("导入图片")
         self.btn_import_images.setToolTip("选择单张或多张图片导入")
         self.btn_import_images.clicked.connect(self.import_images)
         layout.addWidget(self.btn_import_images)
-        
-        # 导入视频按钮
-        self.btn_import_video = QPushButton("🎬 导入视频")
-        self.btn_import_video.setToolTip("从视频中抽取帧导入")
+
+        self.btn_import_video = QPushButton("导入视频")
+        self.btn_import_video.setToolTip("从视频里每隔若干帧抽一张图片导入")
         self.btn_import_video.clicked.connect(self.import_video)
         layout.addWidget(self.btn_import_video)
-        
-        # 导入标注按钮
-        self.btn_import_annotations = QPushButton("📋 导入标注")
-        self.btn_import_annotations.setToolTip("导入已有的标注文件（YOLO/COCO/VOC格式）")
+
+        self.btn_import_annotations = QPushButton("导入标注")
+        self.btn_import_annotations.setToolTip("导入已标注数据（YOLO / COCO / VOC 格式）")
         self.btn_import_annotations.clicked.connect(self.import_annotations)
         layout.addWidget(self.btn_import_annotations)
-        
+
         layout.addStretch()
-        
-        # 视图切换按钮
+
+        filter_label = QLabel("筛选")
+        filter_label.setObjectName("caption")
+        layout.addWidget(filter_label)
+
         self.view_combo = QComboBox()
-        self.view_combo.setFixedWidth(160)
+        self.view_combo.setMinimumWidth(110)
         self.view_combo.currentTextChanged.connect(self.filter_images)
-        layout.addWidget(QLabel("筛选:"))
         layout.addWidget(self.view_combo)
-        
-        # 移动分组按钮
-        self.btn_move_group = QPushButton("📂 移动分组")
-        self.btn_move_group.setObjectName("secondary")
+
+        self.btn_move_group = QPushButton("移动分组")
+        self.btn_move_group.setToolTip("把选中图片移到指定分组")
         self.btn_move_group.clicked.connect(self.move_selected_to_group)
         layout.addWidget(self.btn_move_group)
-        
-        # 删除选中按钮
-        self.btn_delete_selected = QPushButton("🗑 删除选中")
-        self.btn_delete_selected.setObjectName("secondary")
+
+        self.btn_delete_selected = QPushButton("删除选中")
         self.btn_delete_selected.clicked.connect(self.delete_selected_images)
         layout.addWidget(self.btn_delete_selected)
-        
-        # 删除全部按钮
-        self.btn_clear = QPushButton("🗑 清空")
-        self.btn_clear.setObjectName("secondary")
+
+        self.btn_clear = QPushButton("清空")
+        self.btn_clear.setObjectName("danger")
+        self.btn_clear.setToolTip("删除当前项目里的全部图片")
         self.btn_clear.clicked.connect(self.clear_all_images)
         layout.addWidget(self.btn_clear)
-        
+
         return toolbar
-    
+
+    def create_import_status_bar(self) -> QFrame:
+        """导入任务状态条：状态文字 + 进度条 + 取消按钮。
+
+        只在有导入任务时出现，跟缩略图加载进度条（self.progress_bar）
+        是两套独立状态，互不清空对方。
+        """
+        frame = QFrame()
+        frame.setObjectName("card")
+
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(16, 10, 16, 10)
+        layout.setSpacing(6)
+
+        top_row = QHBoxLayout()
+        top_row.setSpacing(10)
+
+        self.import_status_label = QLabel("")
+        self.import_status_label.setObjectName("caption")
+        top_row.addWidget(self.import_status_label, 1)
+
+        self.btn_cancel_import = QPushButton("取消导入")
+        self.btn_cancel_import.setObjectName("danger")
+        self.btn_cancel_import.setVisible(False)
+        self.btn_cancel_import.clicked.connect(self._cancel_active_import)
+        top_row.addWidget(self.btn_cancel_import)
+
+        layout.addLayout(top_row)
+
+        self.import_progress_bar = QProgressBar()
+        self.import_progress_bar.setTextVisible(False)
+        layout.addWidget(self.import_progress_bar)
+
+        return frame
+
+    def create_no_project_state(self) -> EmptyState:
+        """还没有项目时的引导。"""
+        state = EmptyState(
+            "还没有项目",
+            "新建一个项目开始。",
+        )
+        state.add_action("新建项目", self.create_new_project, primary=True)
+        return state
+
+    def create_no_image_state(self) -> EmptyState:
+        """项目里还没有图片时的引导。"""
+        state = EmptyState(
+            "还没有图片",
+            "",
+        )
+        state.add_action("导入文件夹", self.import_folder, primary=True)
+        state.add_action("导入图片", self.import_images)
+        state.add_action("导入视频", self.import_video)
+        return state
+
+    def create_image_grid(self) -> QListWidget:
+        """图片缩略图网格。"""
+        self.image_list = QListWidget()
+        self.image_list.setViewMode(QListWidget.ViewMode.IconMode)
+        self.image_list.setIconSize(QSize(160, 160))
+        self.image_list.setSpacing(10)
+        self.image_list.setResizeMode(QListWidget.ResizeMode.Adjust)
+        self.image_list.setMovement(QListWidget.Movement.Static)
+        self.image_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        self.image_list.setUniformItemSizes(True)
+        self.image_list.setGridSize(QSize(184, 208))
+        self.image_list.itemClicked.connect(self.on_image_clicked)
+        # 注意：这里不写 item 的 background-color，
+        # 让代码里 setBackground 设的「已标注」底色能显示出来
+        self.image_list.setStyleSheet(f"""
+            QListWidget {{
+                background-color: {COLORS['background']};
+                border: 1px solid {COLORS['border']};
+                border-radius: 8px;
+                padding: 8px;
+            }}
+            QListWidget::item {{
+                border: 1px solid {COLORS['border']};
+                border-radius: 8px;
+                padding: 6px;
+            }}
+            QListWidget::item:selected {{
+                border: 1px solid {COLORS['primary']};
+            }}
+        """)
+        return self.image_list
+
+    def _apply_item_status(self, item: QListWidgetItem, image_data: Dict):
+        """让「哪些图已经标过」在网格里一眼看得出来：勾号 + 绿字，不只靠颜色。"""
+        filename = image_data['filename']
+        annotated = image_data.get('status') == 'annotated'
+
+        if annotated:
+            item.setText(f"✓ {filename}")
+            item.setForeground(QColor(COLORS['success']))
+            item.setBackground(QColor(COLORS['success_soft']))
+        else:
+            item.setText(filename)
+            item.setForeground(QColor(COLORS['text_secondary']))
+            item.setBackground(QColor(COLORS['panel']))
+
     def create_status_bar(self) -> QFrame:
         """创建状态栏"""
         status_bar = QFrame()
-        status_bar.setStyleSheet(f"""
-            QFrame {{
-                background-color: {COLORS['panel']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-            }}
-            QLabel {{
-                color: {COLORS['text_secondary']};
-                font-size: 12px;
-                padding: 4px 12px;
-            }}
-        """)
-        
+        status_bar.setObjectName("card")
+
         layout = QHBoxLayout(status_bar)
-        layout.setContentsMargins(12, 8, 12, 8)
-        
+        layout.setContentsMargins(16, 8, 16, 8)
+        layout.setSpacing(16)
+
         self.status_total = QLabel("共 0 张图片")
         layout.addWidget(self.status_total)
-        
-        layout.addWidget(QLabel("|"))
-        
-        self.status_annotated = QLabel("已标注: 0")
+
+        self.status_annotated = QLabel("已标注 0")
         self.status_annotated.setStyleSheet(f"color: {COLORS['success']};")
         layout.addWidget(self.status_annotated)
-        
-        layout.addWidget(QLabel("|"))
-        
-        self.status_pending = QLabel("未标注: 0")
+
+        self.status_pending = QLabel("未标注 0")
+        self.status_pending.setStyleSheet(f"color: {COLORS['text_secondary']};")
         layout.addWidget(self.status_pending)
-        
+
         layout.addStretch()
 
         self.btn_refresh_status = QPushButton("刷新")
-        self.btn_refresh_status.setObjectName("secondary")
-        self.btn_refresh_status.setMinimumWidth(72)
-        self.btn_refresh_status.setFixedHeight(34)
+        self.btn_refresh_status.setObjectName("ghost")
         self.btn_refresh_status.setToolTip("重新读取当前项目的图片与标注状态")
-        self.btn_refresh_status.clicked.connect(self.refresh_project_images)
+        self.btn_refresh_status.clicked.connect(self.force_refresh_images)
         layout.addWidget(self.btn_refresh_status)
-        self._update_refresh_button_state()
-        
+
         return status_bar
 
-    def _update_refresh_button_state(self):
-        """根据当前项目状态更新刷新按钮可用性。"""
-        if hasattr(self, 'btn_refresh_status'):
-            self.btn_refresh_status.setEnabled(bool(self.current_project_id))
-    
-    def load_projects(self):
-        """加载项目列表"""
-        self.project_combo.clear()
-        self.project_combo.addItem("请选择项目...", None)
-        
-        projects = db.get_all_projects()
-        for project in projects:
-            self.project_combo.addItem(project['name'], project['id'])
-        self._update_refresh_button_state()
-    
-    def on_project_changed(self, index):
-        """项目选择改变"""
-        project_id = self.project_combo.currentData()
+    # ==================== 项目 ====================
+
+    def set_project(self, project_id):
+        """由主窗口调用：切换当前项目。"""
+        self.stop_image_loading()
+        if self._import_busy:
+            # 项目context变了，旧项目的导入任务不再有意义：只请求取消、
+            # 把这一批回调标记作废，但线程本身可能还在跑（cancel() 只是设个
+            # 事件，最迟在下一个文件/帧边界才会真正退出）——不能在这里就丢掉
+            # 引用，否则 QThread 对象会在仍在运行时被 GC，触发
+            # "QThread: Destroyed while thread is still running"。
+            # 把它转移到「已作废但还没退出」的列表里继续持有，真正退出
+            # （原生 finished 信号）时再释放，见 _on_import_thread_actually_finished。
+            if self._active_import_thread is not None:
+                self._active_import_thread.cancel()
+                self._retired_import_threads.append(self._active_import_thread)
+                self._active_import_thread = None
+            self._import_generation += 1
+            self._end_import_ui()
+        self.current_project_id = project_id
+        self.images = []
+        self.image_list.clear()
+        self.thumbnail_widgets.clear()
+
+        self.refresh_view_filter_options()
+        self.update_project_bar()
+
         if project_id:
-            self.current_project_id = project_id
-            self._update_refresh_button_state()
-            self.refresh_view_filter_options()
             self.load_project_images()
-            # 更新任务类别显示
-            self.update_task_type_display()
         else:
-            self.stop_image_loading()
-            self.current_project_id = None
-            self._update_refresh_button_state()
-            self.refresh_view_filter_options()
-            self.image_list.clear()
-            self.images = []
-            self.thumbnail_widgets.clear()
-            self.progress_bar.setVisible(False)
             self.update_status_bar()
-            # 重置任务类别显示
-            self.task_type_label.setText("任务类别: 未设置")
+            self.update_view_mode()
+
+    def update_project_bar(self):
+        """刷新项目信息条与按钮可用性。"""
+        has_project = bool(self.current_project_id)
+
+        project = db.get_project(self.current_project_id) if has_project else None
+        if project:
+            name = project.get('name', '未命名项目')
+            self.btn_task_type.setText(f"任务类型：{task_type_label(project.get('type'))}")
+        else:
+            name = "未选择项目"
+            self.btn_task_type.setText("任务类型：未设置")
+
+        metrics = QFontMetrics(self.project_name_label.font())
+        elided = metrics.elidedText(name, Qt.TextElideMode.ElideRight, self.project_name_label.maximumWidth())
+        self.project_name_label.setText(elided)
+        self.project_name_label.setToolTip(name)
+
+        for button in (
+            self.btn_task_type, self.btn_delete_project,
+            self.btn_import_folder, self.btn_import_images,
+            self.btn_import_video, self.btn_import_annotations,
+            self.btn_move_group, self.btn_delete_selected, self.btn_clear,
+            self.btn_refresh_status, self.view_combo,
+        ):
+            button.setEnabled(has_project)
+
+        # 导入任务进行中：即使有项目，也不能再启动新导入或破坏当前项目
+        if self._import_busy:
+            self._set_import_controls_enabled(False)
+
+    def update_view_mode(self):
+        """在「没项目 / 没图片 / 有图片」三种状态之间切换。"""
+        has_project = bool(self.current_project_id)
+
+        # 没有项目时，工具栏和状态栏全是灰的、没意义，直接收起来，只留一句引导
+        self.project_bar.setVisible(has_project)
+        self.toolbar.setVisible(has_project)
+        self.status_bar.setVisible(has_project)
+
+        if not has_project:
+            self.view_stack.setCurrentIndex(0)
+        elif not self.images:
+            self.view_stack.setCurrentIndex(1)
+        else:
+            self.view_stack.setCurrentIndex(2)
+
+    def force_refresh_images(self):
+        """刷新按钮：强制重读一次。"""
+        if self.current_project_id:
+            self.load_project_images()
 
     def refresh_project_images(self):
-        """手动刷新当前项目图片与标注状态。"""
+        """由主窗口在进入本页时调用：数据变了才重建列表。"""
         if not self.current_project_id:
             return
+
+        latest = db.get_project_images(self.current_project_id)
+        latest_signature = [(img['id'], img.get('status')) for img in latest]
+        current_signature = [(img['id'], img.get('status')) for img in self.images]
+        if latest_signature == current_signature:
+            return
+
         self.load_project_images()
-    
-    def update_task_type_display(self):
-        """更新任务类别显示"""
-        if self.current_project_id:
-            project = db.get_project(self.current_project_id)
-            if project:
-                task_type = project.get('type', '未设置')
-                self.task_type_label.setText(f"任务类别: {task_type}")
-    
-    def on_task_type_clicked(self, event):
-        """任务类别点击事件"""
+
+    def change_task_type(self):
+        """修改当前项目的任务类型。"""
         if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择一个项目")
             return
-        
-        # 显示任务类别选择对话框
-        from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QRadioButton, QPushButton, QLabel
-        
-        dialog = QDialog(self)
-        dialog.setWindowTitle("选择任务类型")
-        dialog.setFixedSize(300, 250)
-        dialog.setStyleSheet("""
-            QDialog {
-                background-color: """ + COLORS['background'] + """;
-            }
-            QLabel {
-                color: """ + COLORS['text_primary'] + """;
-                font-size: 14px;
-            }
-            QRadioButton {
-                color: """ + COLORS['text_primary'] + """;
-                font-size: 14px;
-            }
-            QRadioButton::indicator {
-                width: 16px;
-                height: 16px;
-                border: 2px solid """ + COLORS['border'] + """;
-                border-radius: 8px;
-                background-color: """ + COLORS['sidebar'] + """;
-            }
-            QRadioButton::indicator:checked {
-                border: 2px solid """ + COLORS['primary'] + """;
-                background-color: white;
-            }
-        """)
-        
-        layout = QVBoxLayout(dialog)
-        
-        label = QLabel("请选择项目的任务类型:")
-        layout.addWidget(label)
-        
-        # 获取当前任务类型
-        current_task_type = "detect"
+
         project = db.get_project(self.current_project_id)
-        if project and project.get('type'):
-            current_task_type = project['type']
-        
-        detect_radio = QRadioButton("detect (目标检测)")
-        if current_task_type == "detect":
-            detect_radio.setChecked(True)
-        layout.addWidget(detect_radio)
-        
-        segment_radio = QRadioButton("segment (实例分割)")
-        if current_task_type == "segment":
-            segment_radio.setChecked(True)
-        layout.addWidget(segment_radio)
-        
-        pose_radio = QRadioButton("pose (关键点检测)")
-        if current_task_type == "pose" or current_task_type == "point":
-            pose_radio.setChecked(True)
-        layout.addWidget(pose_radio)
-        
-        classify_radio = QRadioButton("classify (图像分类)")
-        if current_task_type == "classify":
-            classify_radio.setChecked(True)
-        layout.addWidget(classify_radio)
-        
+        current = (project or {}).get('type') or 'detect'
 
-        
-        btn_layout = QHBoxLayout()
-        ok_btn = QPushButton("确定")
-        ok_btn.clicked.connect(dialog.accept)
-        cancel_btn = QPushButton("取消")
-        cancel_btn.setObjectName("secondary")
-        cancel_btn.clicked.connect(dialog.reject)
-        btn_layout.addWidget(ok_btn)
-        btn_layout.addWidget(cancel_btn)
-        layout.addLayout(btn_layout)
-        
-        if dialog.exec() != QDialog.DialogCode.Accepted:
+        task_type = ask_task_type(self, current=current, title="修改任务类型")
+        if not task_type:
             return
-        
-        # 确定任务类型
-        if detect_radio.isChecked():
-            task_type = "detect"
-        elif segment_radio.isChecked():
-            task_type = "segment"
-        elif pose_radio.isChecked():
-            task_type = "pose"
-        elif classify_radio.isChecked():
-            task_type = "classify"
 
-        else:
-            task_type = "detect"
-        
-        # 更新项目的任务类型
         db.update_project(self.current_project_id, type=task_type)
-        # 更新显示
-        self.update_task_type_display()
-    
+        self.update_project_bar()
+
     def create_new_project(self):
-        """创建新项目"""
-        from PyQt6.QtWidgets import QInputDialog, QDialog, QVBoxLayout, QHBoxLayout, QRadioButton, QPushButton, QLabel
-        
-        name, ok = QInputDialog.getText(self, "新建项目", "请输入项目名称:")
-        if not ok or not name:
-            return
-        
-        # 创建任务标签选择对话框
-        dialog = QDialog(self)
-        dialog.setWindowTitle("选择任务类型")
-        dialog.setFixedSize(300, 300)
-        dialog.setStyleSheet("""
-            QDialog {
-                background-color: """ + COLORS['background'] + """;
-            }
-            QLabel {
-                color: """ + COLORS['text_primary'] + """;
-                font-size: 14px;
-            }
-            QRadioButton {
-                color: """ + COLORS['text_primary'] + """;
-                font-size: 14px;
-            }
-            QRadioButton::indicator {
-                width: 16px;
-                height: 16px;
-                border: 2px solid """ + COLORS['border'] + """;
-                border-radius: 8px;
-                background-color: """ + COLORS['sidebar'] + """;
-            }
-            QRadioButton::indicator:checked {
-                border: 2px solid """ + COLORS['primary'] + """;
-                background-color: white;
-            }
-        """)
-        
-        layout = QVBoxLayout(dialog)
-        
-        label = QLabel("请选择项目的任务类型:")
-        layout.addWidget(label)
-        
-        detect_radio = QRadioButton("detect (目标检测)")
-        detect_radio.setChecked(True)
-        layout.addWidget(detect_radio)
-        
-        segment_radio = QRadioButton("segment (实例分割)")
-        layout.addWidget(segment_radio)
-        
-        pose_radio = QRadioButton("pose (关键点检测)")
-        layout.addWidget(pose_radio)
-        
-        classify_radio = QRadioButton("classify (图像分类)")
-        layout.addWidget(classify_radio)
-        
+        """创建新项目：先起名字，再选任务类型。"""
+        from PyQt6.QtWidgets import QInputDialog
 
-        
-        btn_layout = QHBoxLayout()
-        ok_btn = QPushButton("确定")
-        ok_btn.clicked.connect(dialog.accept)
-        cancel_btn = QPushButton("取消")
-        cancel_btn.setObjectName("secondary")
-        cancel_btn.clicked.connect(dialog.reject)
-        btn_layout.addWidget(ok_btn)
-        btn_layout.addWidget(cancel_btn)
-        layout.addLayout(btn_layout)
-        
-        if dialog.exec() != QDialog.DialogCode.Accepted:
+        name, ok = QInputDialog.getText(self, "新建项目", "给项目起个名字（比如「安全帽检测」）：")
+        if not ok or not name.strip():
             return
-        
-        # 确定任务类型
-        if detect_radio.isChecked():
-            task_type = "detect"
-        elif segment_radio.isChecked():
-            task_type = "segment"
-        elif pose_radio.isChecked():
-            task_type = "pose"
-        elif classify_radio.isChecked():
-            task_type = "classify"
 
-        else:
-            task_type = "detect"
-        
-        # 创建项目
+        task_type = ask_task_type(self, current='detect', title="这个项目要做什么")
+        if not task_type:
+            return
+
         project_id = db.create_project(
-            name=name,
+            name=name.strip(),
             description="",
             project_type=task_type,
             classes=[]
         )
-        self.load_projects()
-        index = self.project_combo.findData(project_id)
-        if index >= 0:
-            self.project_combo.setCurrentIndex(index)
-    
+        # 交给主窗口去刷新下拉框并选中新项目
+        self.projects_changed.emit(project_id)
+
     def delete_current_project(self):
-        """删除当前选中的项目"""
-        project_id = self.project_combo.currentData()
-        
-        if not project_id:
-            QMessageBox.warning(self, "提示", "请先选择一个项目")
+        """删除当前项目。"""
+        if not self.current_project_id:
             return
-        
-        # 获取项目名称
-        project_name = self.project_combo.currentText()
-        
-        # 确认删除
+
+        project = db.get_project(self.current_project_id)
+        project_name = (project or {}).get('name', '')
+
         reply = QMessageBox.question(
             self,
             "确认删除",
-            f"确定要删除项目 \"{project_name}\" 吗？\n\n这将删除该项目中的所有图片和标注数据，此操作不可恢复！",
+            f"确定要删除项目「{project_name}」吗？\n\n"
+            "项目里的所有图片和标注都会一起删除，无法恢复。",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.No
         )
-        
-        if reply == QMessageBox.StandardButton.Yes:
-            try:
-                self.stop_image_loading()
-                # 获取项目信息，包括存储路径
-                project = db.get_project(project_id)
-                project_storage_path = project.get('storage_path', '') if project else ''
-                
-                # 删除项目（数据库会自动级联删除相关图片和标注）
-                db.delete_project(project_id)
-                
-                # 删除项目文件夹
-                if project_storage_path and os.path.exists(project_storage_path):
-                    try:
-                        import shutil
-                        shutil.rmtree(project_storage_path)
-                    except Exception as e:
-                        # 文件夹删除失败不影响项目删除
-                        print(f"删除项目文件夹失败: {e}")
-                
-                # 清空当前项目ID
-                self.current_project_id = None
-                removed_storage_paths = [img.get('storage_path', '') for img in self.images]
-                
-                # 清空图片列表
-                self.image_list.clear()
-                self.images = []
-                self.thumbnail_widgets.clear()
-                self._remove_cached_thumbnails(removed_storage_paths)
-                
-                # 更新状态栏
-                self.update_status_bar()
-                
-                # 重新加载项目列表
-                self.load_projects()
-                
-                QMessageBox.information(self, "成功", f"项目 \"{project_name}\" 已删除")
-                
-            except Exception as e:
-                QMessageBox.critical(self, "错误", f"删除项目失败: {str(e)}")
-    
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            self.stop_image_loading()
+            project_storage_path = (project or {}).get('storage_path', '')
+
+            db.delete_project(self.current_project_id)
+
+            if project_storage_path and os.path.exists(project_storage_path):
+                try:
+                    import shutil
+                    shutil.rmtree(project_storage_path)
+                except Exception as e:
+                    # 文件夹删不掉不影响项目已经删除的事实
+                    print(f"删除项目文件夹失败: {e}")
+
+            removed_storage_paths = [img.get('storage_path', '') for img in self.images]
+            self.current_project_id = None
+            self.image_list.clear()
+            self.images = []
+            self.thumbnail_widgets.clear()
+            self._remove_cached_thumbnails(removed_storage_paths)
+
+            self.update_status_bar()
+            self.update_project_bar()
+            self.update_view_mode()
+            self.projects_changed.emit(None)
+
+        except Exception as e:
+            QMessageBox.critical(self, "错误", f"删除项目失败: {str(e)}")
+
     def load_project_images(self):
         """加载项目图像 - 使用多线程"""
         if not self.current_project_id:
             return
 
+        # 全量重载会把最新数据（含刚导入的）一次性读回来，之前那个
+        # 「导入后台正在整理缩略图」的收尾就不用再等了，直接结束掉，
+        # 避免它的世代被下面的 stop_image_loading 作废后再也等不到回调、卡住不收尾。
+        if self._import_finalize_pending:
+            self._end_import_ui(self._import_finalize_summary, cancelled=self._import_finalize_cancelled)
+
         # 停止之前的加载，并创建新的加载世代
         self.stop_image_loading(reset_progress=False)
-        current_generation = self._image_load_generation
-        
+
         # 清空列表
         self.image_list.clear()
         self.thumbnail_widgets.clear()
-        
+
         # 从数据库获取图片列表（很快）
         self.images = db.get_project_images(self.current_project_id)
         self.update_status_bar()
-        
+        self.update_view_mode()
+
         if not self.images:
             self.progress_bar.setVisible(False)
             return
-        
+
         # 先创建所有列表项（显示占位符）
         uncached_tasks = []
         for index, image_data in enumerate(self.images):
             item = QListWidgetItem()
             item.setData(Qt.ItemDataRole.UserRole, image_data['id'])
-            item.setText(image_data['filename'])
             item.setToolTip(f"{image_data['filename']}\n{image_data.get('width', 0)}x{image_data.get('height', 0)}")
-            
-            # 设置状态标记
-            status = image_data.get('status', 'pending')
-            if status == 'annotated':
-                item.setBackground(QColor(COLORS['success']))
-            
+
+            self._apply_item_status(item, image_data)
+
             # 设置项目大小提示，确保即使没有图标也有足够高度
             item.setSizeHint(QSize(180, 200))
 
@@ -729,22 +685,31 @@ class ImportPage(QWidget):
                 item.setIcon(QIcon(cached_pixmap))
             else:
                 uncached_tasks.append((index, image_data))
-            
+
             self.image_list.addItem(item)
 
         self.filter_images(self.view_combo.currentText())
-        
+
         if not uncached_tasks:
             self.progress_bar.setVisible(False)
             return
 
-        # 仅对未命中的缩略图显示非阻塞进度条
+        self._start_thumbnail_worker(uncached_tasks)
+
+    def _start_thumbnail_worker(self, tasks: List[Tuple[int, Dict]], on_finished: Callable[[], None] = None):
+        """启动缩略图后台加载线程。
+
+        跟导入任务状态完全独立：这里只负责把 tasks（(行号, 图片记录) 列表）
+        对应的缩略图在后台生成好，不做任何导入相关判断。
+        """
+        self.stop_image_loading(reset_progress=False)
+        current_generation = self._image_load_generation
+
         self.progress_bar.setVisible(True)
-        self.progress_bar.setMaximum(len(uncached_tasks))
+        self.progress_bar.setMaximum(len(tasks))
         self.progress_bar.setValue(0)
-        
-        # 启动后台加载线程
-        self.load_worker = ImageLoadWorker(uncached_tasks)
+
+        self.load_worker = ImageLoadWorker(tasks)
         self.load_worker.image_loaded.connect(
             lambda index, pixmap, storage_path, generation=current_generation: self.on_image_loaded(
                 generation, index, pixmap, storage_path
@@ -756,10 +721,10 @@ class ImportPage(QWidget):
             )
         )
         self.load_worker.finished_loading.connect(
-            lambda generation=current_generation: self.on_load_finished(generation)
+            lambda generation=current_generation, cb=on_finished: self.on_load_finished(generation, cb)
         )
         self.load_worker.start()
-    
+
     def on_image_loaded(self, generation: int, index: int, pixmap: QPixmap, storage_path: str):
         """单个图片加载完成回调（在主线程执行）"""
         if generation != self._image_load_generation:
@@ -772,18 +737,25 @@ class ImportPage(QWidget):
                 item.setIcon(icon)
                 # 缓存
                 self.thumbnail_cache[storage_path] = pixmap
-    
+
     def on_load_progress(self, generation: int, current: int, total: int):
         """加载进度回调"""
         if generation != self._image_load_generation:
             return
         self.progress_bar.setValue(current)
-    
-    def on_load_finished(self, generation: int):
+
+    def on_load_finished(self, generation: int, on_finished: Callable[[], None] = None):
         """加载完成回调"""
         if generation != self._image_load_generation:
             return
+        worker = self.load_worker
         self.load_worker = None
+        if worker is not None:
+            # finished_loading 跟 ImportWorkerThread 的 result_ready 是同一类问题：
+            # 在 run() 返回前手动 emit，不代表线程已经真正退出。这里同步等一下
+            # （此时线程本来就快跑完了，代价可以忽略），确保丢引用前线程已经
+            # 真正结束，避免它在还在运行时被 GC 掉。
+            worker.wait()
         self.progress_bar.setVisible(False)
 
         if hasattr(self, 'loading_overlay'):
@@ -791,11 +763,13 @@ class ImportPage(QWidget):
             self.loading_overlay.deleteLater()
             delattr(self, 'loading_overlay')
 
+        if on_finished:
+            on_finished()
+
     def _build_image_list_item(self, image_data: Dict) -> QListWidgetItem:
         """创建图片列表项（占位图标）"""
         item = QListWidgetItem()
         item.setData(Qt.ItemDataRole.UserRole, image_data['id'])
-        item.setText(image_data['filename'])
 
         group_id = image_data.get('group_id')
         group_name = "未分组"
@@ -810,59 +784,61 @@ class ImportPage(QWidget):
             f"分组: {group_name}"
         )
 
-        status = image_data.get('status', 'pending')
-        if status == 'annotated':
-            item.setBackground(QColor(COLORS['success']))
+        self._apply_item_status(item, image_data)
 
         item.setSizeHint(QSize(180, 200))
         return item
 
-    def _load_thumbnail_pixmap(self, storage_path: str) -> QPixmap:
-        """同步加载单张缩略图（用于增量追加）"""
-        pixmap = None
-        if storage_path and os.path.exists(storage_path):
-            try:
-                img = cv2.imread(storage_path)
-                if img is not None:
-                    img = cv2.resize(img, (160, 160))
-                    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-                    h, w, ch = img.shape
-                    bytes_per_line = ch * w
-                    qt_image = QImage(img.data, w, h, bytes_per_line, QImage.Format.Format_RGB888)
-                    pixmap = QPixmap.fromImage(qt_image)
-            except Exception:
-                pass
+    def _append_imported_images(self, before_image_ids: set,
+                                 on_thumbnails_ready: Callable[[], None] = None) -> int:
+        """导入后仅增量追加新图片，返回追加数量。
 
-        if pixmap is None or pixmap.isNull():
-            pixmap = QPixmap(160, 160)
-            pixmap.fill(QColor(COLORS['sidebar']))
-        return pixmap
-
-    def _append_imported_images(self, before_image_ids: set) -> int:
-        """导入后仅增量追加新图片，返回追加数量"""
+        缩略图改为丢给后台的 ImageLoadWorker 生成，不在 UI 线程同步 cv2.imread；
+        `on_thumbnails_ready` 保证恰好被调用一次——没有新图/缩略图全部命中缓存时
+        同步调用，否则等后台线程真正做完再调用。
+        """
         if not self.current_project_id:
+            if on_thumbnails_ready:
+                on_thumbnails_ready()
             return 0
 
         latest_images = db.get_project_images(self.current_project_id)
-        new_images = [img for img in latest_images if img.get('id') not in before_image_ids]
+        # 同时排除 before_image_ids（导入前已有的）和 self.images 里已存在的
+        # （可能被中途的一次全量重载提前补上了），避免同一张图重复出现
+        existing_ids = {img.get('id') for img in self.images}
+        new_images = [
+            img for img in latest_images
+            if img.get('id') not in before_image_ids and img.get('id') not in existing_ids
+        ]
         if not new_images:
+            if on_thumbnails_ready:
+                on_thumbnails_ready()
             return 0
 
         self.images.extend(new_images)
 
+        uncached_tasks = []
         for image_data in new_images:
             item = self._build_image_list_item(image_data)
             self.image_list.addItem(item)
+            row_index = self.image_list.count() - 1
 
             storage_path = image_data.get('storage_path', '')
-            pixmap = self.thumbnail_cache.get(storage_path)
-            if pixmap is None:
-                pixmap = self._load_thumbnail_pixmap(storage_path)
-                self.thumbnail_cache[storage_path] = pixmap
-            item.setIcon(QIcon(pixmap))
+            cached_pixmap = self.thumbnail_cache.get(storage_path)
+            if cached_pixmap is not None and not cached_pixmap.isNull():
+                item.setIcon(QIcon(cached_pixmap))
+            else:
+                uncached_tasks.append((row_index, image_data))
 
         self.update_status_bar()
+        self.update_view_mode()
         self.filter_images(self.view_combo.currentText())
+
+        if uncached_tasks:
+            self._start_thumbnail_worker(uncached_tasks, on_finished=on_thumbnails_ready)
+        elif on_thumbnails_ready:
+            on_thumbnails_ready()
+
         return len(new_images)
 
     def refresh_view_filter_options(self):
@@ -944,15 +920,191 @@ class ImportPage(QWidget):
         pass
     
     def update_status_bar(self):
-        """更新状态栏"""
+        """更新状态栏，并把进度变化告诉主窗口"""
         total = len(self.images)
         annotated = sum(1 for img in self.images if img.get('status') == 'annotated')
         pending = total - annotated
-        
+
         self.status_total.setText(f"共 {total} 张图片")
-        self.status_annotated.setText(f"已标注: {annotated}")
-        self.status_pending.setText(f"未标注: {pending}")
-    
+        self.status_annotated.setText(f"已标注 {annotated}")
+        self.status_pending.setText(f"未标注 {pending}")
+
+        self.project_data_changed.emit()
+
+    # ==================== 导入任务状态 ====================
+    # 下面这组方法管理「导入任务」本身的状态（进行中 / 取消 / 完成），
+    # 跟缩略图加载状态（load_project_images / on_load_finished 那组）完全分开。
+
+    def _set_import_controls_enabled(self, enabled: bool):
+        """导入中要禁掉的，只有会启动重复导入、或者会破坏当前项目的操作。"""
+        for button in (
+            self.btn_import_folder, self.btn_import_images,
+            self.btn_import_video, self.btn_import_annotations,
+            self.btn_delete_project, self.btn_clear,
+        ):
+            button.setEnabled(enabled)
+
+    def _start_import_ui(self, message: str, indeterminate: bool = True):
+        """进入「导入中」状态：用户点确认导入后，一个事件循环内就要看到这个。"""
+        self._import_busy = True
+        self._import_finalize_pending = False
+
+        self.import_status_frame.setVisible(True)
+        self.import_status_label.setText(message)
+        if indeterminate:
+            self.import_progress_bar.setRange(0, 0)  # 总量未知：忙碌态
+        else:
+            self.import_progress_bar.setRange(0, 100)
+            self.import_progress_bar.setValue(0)
+
+        self.btn_cancel_import.setVisible(True)
+        self.btn_cancel_import.setEnabled(True)
+        self._set_import_controls_enabled(False)
+
+    def _set_import_progress(self, progress: int, message: str = None):
+        """更新导入状态文字 / 进度；progress < 0 表示总量未知，切到忙碌态。"""
+        if message is not None:
+            self.import_status_label.setText(message)
+        if progress is None or progress < 0:
+            self.import_progress_bar.setRange(0, 0)
+        else:
+            self.import_progress_bar.setRange(0, 100)
+            self.import_progress_bar.setValue(min(max(progress, 0), 100))
+
+    def _end_import_ui(self, summary: str = None, cancelled: bool = False):
+        """结束导入（成功/取消/失败都会走这里）：恢复控件，取消按钮收起。
+
+        `summary` 有值时，把结果留在页面里（页内状态），不用弹窗打断操作；
+        没有值（比如失败场景，调用方会另外弹错误框）时直接把状态条收起来。
+        `cancelled` 为真时不把进度条拉满到 100%——取消是半途而废，不是
+        「普通完成」，进度条应该停在中断时的真实进度上，不能误导成已完成。
+
+        注意：这里不清空 self._active_import_thread —— 线程是否真的退出了
+        由 QThread 原生 finished 信号决定（见 _on_import_thread_actually_finished），
+        这里只是 UI 收尾，跟线程生命周期分开管理。
+        """
+        self._import_busy = False
+        self._import_finalize_pending = False
+
+        self.btn_cancel_import.setVisible(False)
+        if summary:
+            self.import_status_label.setText(summary)
+            if not cancelled:
+                self.import_progress_bar.setRange(0, 100)
+                self.import_progress_bar.setValue(100)
+            self.import_status_frame.setVisible(True)
+        else:
+            self.import_status_frame.setVisible(False)
+
+        self.update_project_bar()
+
+    def _cancel_active_import(self):
+        """取消按钮：请求后台线程停止，最迟在下一个文件/帧边界生效。"""
+        if self._active_import_thread is not None:
+            self._active_import_thread.cancel()
+            self.btn_cancel_import.setEnabled(False)
+            self.import_status_label.setText("正在取消…")
+
+    def _on_import_thread_actually_finished(self, thread):
+        """QThread 原生 finished：线程真的退出了，这里才是唯一安全释放引用的地方。
+
+        跟 result_ready（业务结果，run() 返回前手动 emit）分开：无论正常完成、
+        失败、取消，还是切项目导致的作废，最终都会走到这里——只有这里能保证
+        `thread.isRunning()` 已经是 False，不会出现线程还在跑就被 GC / deleteLater
+        的情况。
+        """
+        if self._active_import_thread is thread:
+            self._active_import_thread = None
+        if thread in self._retired_import_threads:
+            self._retired_import_threads.remove(thread)
+        # finished 信号发出时线程已经在退出的路上，wait() 在这里只是确保万无
+        # 一失（此时通常立即返回），之后再安全地交给 Qt 事件循环销毁对象。
+        thread.wait()
+        thread.deleteLater()
+
+    def _start_data_import(self, kind: str, source, group_id,
+                            frame_interval: int = 1, initial_message: str = "",
+                            indeterminate: bool = True):
+        """统一入口：文件夹 / 多图 / 视频导入都从这里起后台线程。"""
+        if not self.current_project_id:
+            return
+        if self._import_busy:
+            QMessageBox.information(self, "提示", "已有导入任务在进行，请稍候")
+            return
+
+        self._import_generation += 1
+        generation = self._import_generation
+        self._import_before_ids = {img.get('id') for img in self.images}
+
+        self._start_import_ui(initial_message, indeterminate=indeterminate)
+
+        thread = ImportWorkerThread(
+            self.current_project_id, group_id, kind, source, frame_interval=frame_interval
+        )
+        thread.progress_updated.connect(
+            lambda progress, message, g=generation: self._on_import_progress(g, progress, message)
+        )
+        thread.result_ready.connect(
+            lambda success, error, cancelled, imported, skipped, g=generation, t=thread:
+            self._on_import_worker_finished(g, t, success, error, cancelled, imported, skipped)
+        )
+        # QThread 原生 finished：只有它才代表线程真的退出了（result_ready 是我们
+        # 自己在 run() 返回前手动 emit 的业务结果，不代表 OS 线程已经结束）。
+        # 只有在这里才真正释放引用，避免 "Destroyed while thread is still running"。
+        thread.finished.connect(lambda t=thread: self._on_import_thread_actually_finished(t))
+        self._active_import_thread = thread
+        thread.start()
+
+    def _on_import_progress(self, generation: int, progress: int, message: str):
+        if generation != self._import_generation:
+            return
+        self._set_import_progress(progress, message)
+
+    def _on_import_worker_finished(self, generation: int, thread, success: bool, error: str,
+                                    cancelled: bool, imported: int, skipped: int):
+        # result_ready 是线程自己在 run() 返回前手动 emit 的，这一刻 run() 几乎
+        # 已经跑完但严格意义上还没退出（QThread 原生 finished/isRunning() 变
+        # False 要稍后才会发生）。同步 wait() 一下，把这个窗口关掉——此时线程
+        # 本来就即将结束，等待成本可以忽略不计，但能确保调用方（包括后面可能
+        # 立刻释放 self 的场景）拿到结果时线程已经真正退出，不会有人在这个
+        # 窗口期把仍在运行的 QThread 销毁掉。
+        thread.wait()
+
+        if generation != self._import_generation:
+            return
+
+        if not success:
+            self._end_import_ui()
+            QMessageBox.critical(self, "导入失败", f"导入过程中发生错误:\n{error}")
+            return
+
+        prefix = "已取消" if cancelled else "导入完成"
+        summary = f"{prefix}：成功导入 {imported} 张，跳过 {skipped} 张"
+
+        if imported > 0:
+            self._import_finalize_pending = True
+            self._import_finalize_summary = summary
+            self._import_finalize_cancelled = cancelled
+            self._set_import_progress(-1, "正在整理缩略图…")
+            appended = self._append_imported_images(
+                self._import_before_ids,
+                on_thumbnails_ready=lambda g=generation, s=summary, c=cancelled: self._finish_import_finalization(g, s, c),
+            )
+            if appended == 0:
+                # 兜底：数据库里应该有新图但没识别出来，回退全量重载保证界面和数据库一致
+                # （on_thumbnails_ready 在这条分支里已经同步跑过，导入态已经收尾了）
+                self.load_project_images()
+        else:
+            self._end_import_ui(summary, cancelled=cancelled)
+
+        self.refresh_view_filter_options()
+
+    def _finish_import_finalization(self, generation: int, summary: str, cancelled: bool = False):
+        """后台缩略图整理真正完成后才收尾——这时才算导入任务完全结束。"""
+        if generation != self._import_generation:
+            return
+        self._end_import_ui(summary, cancelled=cancelled)
+
     def import_folder(self):
         """导入文件夹"""
         if not self.current_project_id:
@@ -1005,41 +1157,25 @@ class ImportPage(QWidget):
             self.process_video_import(file_path, group_id=group_id)
     
     def process_video_import(self, file_path: str, group_id: int = None):
-        """处理视频导入"""
+        """处理视频导入：抽帧间隔问完，后台线程负责剩下的一切。"""
         if not self.current_project_id:
             return
-        
-        self._video_import_before_ids = {img.get('id') for img in self.images}
-        
+
         from PyQt6.QtWidgets import QInputDialog
         interval, ok = QInputDialog.getInt(
             self, "抽帧设置",
             "请输入抽帧间隔（每隔多少帧抽取一帧）:",
             value=30, min=1, max=1000
         )
-        
+
         if not ok:
             return
-        
-        # 显示进度条
-        self.progress_bar.setVisible(True)
-        self.progress_bar.setValue(0)
-        
-        # 创建并启动视频导入线程
-        self.video_import_thread = VideoImportThread(
-            file_path, 
-            self.current_project_id, 
-            interval,
-            group_id=group_id,
+
+        self._start_data_import(
+            'video', file_path, group_id, frame_interval=interval,
+            initial_message=f"正在打开视频: {Path(file_path).name}",
         )
-        
-        # 连接信号
-        self.video_import_thread.progress_updated.connect(self.update_import_progress)
-        self.video_import_thread.finished.connect(self.on_video_import_finished)
-        
-        # 启动线程
-        self.video_import_thread.start()
-    
+
     def import_annotations(self):
         """导入已有标注"""
         if not self.current_project_id:
@@ -1054,142 +1190,53 @@ class ImportPage(QWidget):
         
         task_type = project.get('type')
         if not task_type or task_type not in ['detect', 'segment', 'pose', 'classify']:
-            # 提示选择任务类型
-            from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QRadioButton, QPushButton, QLabel
-            
-            dialog = QDialog(self)
-            dialog.setWindowTitle("选择任务类型")
-            dialog.setFixedSize(300, 200)
-            dialog.setStyleSheet("""
-                QDialog {
-                    background-color: """ + COLORS['background'] + """;
-                }
-                QLabel {
-                    color: """ + COLORS['text_primary'] + """;
-                    font-size: 14px;
-                }
-                QRadioButton {
-                    color: """ + COLORS['text_primary'] + """;
-                    font-size: 14px;
-                }
-                QRadioButton::indicator {
-                    width: 16px;
-                    height: 16px;
-                    border: 2px solid """ + COLORS['border'] + """;
-                    border-radius: 8px;
-                    background-color: """ + COLORS['sidebar'] + """;
-                }
-                QRadioButton::indicator:checked {
-                    border: 2px solid """ + COLORS['primary'] + """;
-                    background-color: white;
-                }
-            """)
-            
-            layout = QVBoxLayout(dialog)
-            
-            label = QLabel("请选择项目的任务类型:")
-            layout.addWidget(label)
-            
-            detect_radio = QRadioButton("detect (目标检测)")
-            detect_radio.setChecked(True)
-            layout.addWidget(detect_radio)
-            
-            segment_radio = QRadioButton("segment (实例分割)")
-            layout.addWidget(segment_radio)
-            
-            pose_radio = QRadioButton("pose (关键点检测)")
-            layout.addWidget(pose_radio)
-            
-            cls_radio = QRadioButton("cls (分类)")
-            layout.addWidget(cls_radio)
-            
-
-            
-            btn_layout = QHBoxLayout()
-            ok_btn = QPushButton("确定")
-            ok_btn.clicked.connect(dialog.accept)
-            cancel_btn = QPushButton("取消")
-            cancel_btn.setObjectName("secondary")
-            cancel_btn.clicked.connect(dialog.reject)
-            btn_layout.addWidget(ok_btn)
-            btn_layout.addWidget(cancel_btn)
-            layout.addLayout(btn_layout)
-            
-            if dialog.exec() != QDialog.DialogCode.Accepted:
+            task_type = ask_task_type(self, current='detect', title="这个项目要做什么")
+            if not task_type:
                 return
-            
-            # 确定任务类型
-            if detect_radio.isChecked():
-                task_type = "detect"
-            elif segment_radio.isChecked():
-                task_type = "segment"
-            elif pose_radio.isChecked():
-                task_type = "pose"
-            elif cls_radio.isChecked():
-                task_type = "classify"
-
-            else:
-                task_type = "detect"
-            
-            # 更新项目的任务类型
             db.update_project(self.current_project_id, type=task_type)
-        
+            self.update_project_bar()
+
         # 选择标注格式
-        from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QRadioButton, QPushButton, QLabel
-        
+        from PyQt6.QtWidgets import QRadioButton
+
         dialog = QDialog(self)
         dialog.setWindowTitle("选择标注格式")
-        dialog.setFixedSize(300, 200)
-        dialog.setStyleSheet("""
-            QDialog {
-                background-color: """ + COLORS['background'] + """;
-            }
-            QLabel {
-                color: """ + COLORS['text_primary'] + """;
-                font-size: 14px;
-            }
-            QRadioButton {
-                color: """ + COLORS['text_primary'] + """;
-                font-size: 14px;
-            }
-            QRadioButton::indicator {
-                width: 16px;
-                height: 16px;
-                border: 2px solid """ + COLORS['border'] + """;
-                border-radius: 8px;
-                background-color: """ + COLORS['sidebar'] + """;
-            }
-            QRadioButton::indicator:checked {
-                border: 2px solid """ + COLORS['primary'] + """;
-                background-color: white;
-            }
-        """)
-        
+        dialog.setMinimumWidth(360)
+
         layout = QVBoxLayout(dialog)
-        
-        label = QLabel("请选择要导入的标注格式:")
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(10)
+
+        label = QLabel("你的标注文件是哪种格式？")
+        label.setObjectName("subtitle")
         layout.addWidget(label)
-        
-        yolo_radio = QRadioButton("YOLO格式 (txt)")
+
+        yolo_radio = QRadioButton("YOLO 格式")
+        yolo_radio.setToolTip("一张图片配一个 .txt")
         yolo_radio.setChecked(True)
         layout.addWidget(yolo_radio)
-        
-        coco_radio = QRadioButton("COCO格式 (json)")
+
+        coco_radio = QRadioButton("COCO 格式")
+        coco_radio.setToolTip("整个数据集一个 .json")
         layout.addWidget(coco_radio)
-        
-        voc_radio = QRadioButton("Pascal VOC格式 (xml)")
+
+        voc_radio = QRadioButton("Pascal VOC 格式")
+        voc_radio.setToolTip("一张图片配一个 .xml")
         layout.addWidget(voc_radio)
-        
+
         btn_layout = QHBoxLayout()
-        ok_btn = QPushButton("确定")
-        ok_btn.clicked.connect(dialog.accept)
+        btn_layout.setContentsMargins(0, 8, 0, 0)
+        btn_layout.addStretch()
         cancel_btn = QPushButton("取消")
-        cancel_btn.setObjectName("secondary")
         cancel_btn.clicked.connect(dialog.reject)
-        btn_layout.addWidget(ok_btn)
         btn_layout.addWidget(cancel_btn)
+        ok_btn = QPushButton("确定")
+        ok_btn.setObjectName("primary")
+        ok_btn.setDefault(True)
+        ok_btn.clicked.connect(dialog.accept)
+        btn_layout.addWidget(ok_btn)
         layout.addLayout(btn_layout)
-        
+
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return
 
@@ -1444,102 +1491,28 @@ class ImportPage(QWidget):
         self.import_thread.start()
     
     def process_folder_import(self, folder_path: str, group_id: int = None):
-        """处理文件夹导入"""
+        """处理文件夹导入：扫描、复制、写库全部丢给后台线程。"""
         if not self.current_project_id:
             return
-        
-        try:
-            self.progress_bar.setVisible(True)
-            self.progress_bar.setValue(0)
-            before_ids = {img.get('id') for img in self.images}
-            
-            import_manager = ImportManager(self.current_project_id, group_id=group_id)
-            imported, skipped = import_manager.import_folder(
-                folder_path,
-                progress_callback=self.update_import_progress
-            )
-            if imported > 0:
-                appended = self._append_imported_images(before_ids)
-                if appended == 0:
-                    # 兜底：若无法识别新增项，回退全量重载
-                    self.load_project_images()
-            
-            QMessageBox.information(
-                self, "导入完成",
-                f"文件夹导入完成！\n成功导入: {imported} 张\n跳过: {skipped} 张"
-            )
-            self.refresh_view_filter_options()
-            
-        except Exception as e:
-            QMessageBox.critical(self, "导入失败", f"导入过程中发生错误:\n{str(e)}")
-        finally:
-            self.progress_bar.setVisible(False)
-    
-    def process_image_import(self, file_paths: List[str], group_id: int = None):
-        """处理图像导入"""
-        if not self.current_project_id:
-            return
-        
-        try:
-            self.progress_bar.setVisible(True)
-            self.progress_bar.setValue(0)
-            before_ids = {img.get('id') for img in self.images}
-            
-            import_manager = ImportManager(self.current_project_id, group_id=group_id)
-            imported, skipped = import_manager.import_images(
-                file_paths,
-                progress_callback=self.update_import_progress
-            )
-            if imported > 0:
-                appended = self._append_imported_images(before_ids)
-                if appended == 0:
-                    # 兜底：若无法识别新增项，回退全量重载
-                    self.load_project_images()
-            
-            QMessageBox.information(
-                self, "导入完成",
-                f"图片导入完成！\n成功导入: {imported} 张\n跳过: {skipped} 张"
-            )
-            self.refresh_view_filter_options()
-            
-        except Exception as e:
-            QMessageBox.critical(self, "导入失败", f"导入过程中发生错误:\n{str(e)}")
-        finally:
-            self.progress_bar.setVisible(False)
-    
-    def update_import_progress(self, progress: int, message: str):
-        """更新导入进度"""
-        self.progress_bar.setValue(progress)
-    
-    def on_video_import_finished(self, success: bool, message: str, imported: int, skipped: int):
-        """视频导入完成回调"""
-        # 隐藏进度条
-        self.progress_bar.setVisible(False)
-        
-        if success:
-            before_ids = getattr(self, '_video_import_before_ids', None)
-            if imported > 0 and isinstance(before_ids, set):
-                appended = self._append_imported_images(before_ids)
-                if appended == 0:
-                    # 兜底：若无法识别新增项，回退全量重载
-                    self.load_project_images()
-            elif imported > 0:
-                # 未获取到导入前快照时，保持原有行为
-                self.load_project_images()
-            
-            # 显示成功消息
-            QMessageBox.information(
-                self, "导入完成",
-                f"视频导入完成！\n成功导入: {imported} 帧\n跳过: {skipped} 帧"
-            )
-            self.refresh_view_filter_options()
-        else:
-            # 显示错误消息
-            QMessageBox.critical(self, "导入失败", message)
 
-        if hasattr(self, '_video_import_before_ids'):
-            delattr(self, '_video_import_before_ids')
-    
+        folder_name = Path(folder_path).name or folder_path
+        self._start_data_import(
+            'folder', folder_path, group_id,
+            initial_message=f"正在准备导入文件夹: {folder_name}",
+        )
+
+    def process_image_import(self, file_paths: List[str], group_id: int = None):
+        """处理图像导入：复制、写库全部丢给后台线程。"""
+        if not self.current_project_id:
+            return
+
+        total = len(file_paths)
+        self._start_data_import(
+            'images', file_paths, group_id,
+            initial_message=f"正在导入 0/{total} 张图片",
+            indeterminate=False,
+        )
+
     def clear_all_images(self):
         """清空所有图像"""
         if not self.images:
@@ -1572,6 +1545,7 @@ class ImportPage(QWidget):
                 self.thumbnail_widgets.clear()
                 self._remove_cached_thumbnails(removed_storage_paths)
                 self.update_status_bar()
+                self.update_view_mode()
             else:
                 # 部分失败时回退到全量重载，确保UI与数据库一致
                 self.load_project_images()
@@ -1689,7 +1663,8 @@ class ImportPage(QWidget):
                 self.image_list.takeItem(row)
 
             self.update_status_bar()
-        
+            self.update_view_mode()
+
         if failed == 0:
             QMessageBox.information(self, "删除完成", f"已成功删除 {deleted} 张图片")
         else:

--- a/gui/pages/import_page.py
+++ b/gui/pages/import_page.py
@@ -9,11 +9,11 @@
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QScrollArea, QGridLayout, QFrame, QFileDialog, QProgressBar,
-    QMenu, QMessageBox, QComboBox, QLineEdit, QListWidget, QListWidgetItem,
-    QDialog, QStackedWidget, QSizePolicy,
+    QMenu, QComboBox, QLineEdit, QListWidget, QListWidgetItem,
+    QDialog, QStackedWidget, QSizePolicy, QToolButton,
 )
-from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize
-from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QIcon, QFontMetrics
+from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize, QTimer
+from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QFont, QIcon
 import cv2
 import numpy as np
 import threading
@@ -22,13 +22,27 @@ from typing import List, Dict, Optional, Tuple, Callable
 import os
 
 from gui.styles import COLORS
+from gui.display_names import display_name, display_names
 from models.database import db
-from core.import_manager import ImportManager
+from core.import_manager import ImportManager, VIDEO_MODE_INTERVAL, VIDEO_MODE_RANDOM
 from core.annotation_importer import AnnotationImporter
 from gui.widgets.loading_dialog import LoadingOverlay
 from gui.widgets.group_select_dialog import GroupSelectDialog, ask_import_group
 from gui.widgets.task_type_dialog import ask_task_type, task_type_label
 from gui.widgets.workflow_widgets import EmptyState
+from gui.widgets.app_dialog import (
+    ask_text, confirm, confirm_destructive, show_info, show_warning,
+)
+from gui.widgets.video_extract_dialog import ask_video_extract_plan
+
+
+def short_task_label(task_type: str) -> str:
+    """工具栏胶囊上只放中文那半截：「目标检测 detect」→「目标检测」。
+
+    共用的任务类型对话框仍然显示带英文的完整标签——在那里，detect / segment
+    这些词要和 YOLO 的术语对得上，是有用的信息；而工具栏上它只是把胶囊撑长。
+    """
+    return task_type_label(task_type).split(' ')[0]
 
 
 # 数据导入线程：文件夹 / 多图 / 视频，实际工作全部委托给 core.import_manager，
@@ -44,13 +58,16 @@ class ImportWorkerThread(QThread):
     # "QThread: Destroyed while thread is still running"。
     result_ready = pyqtSignal(bool, str, bool, int, int)
 
-    def __init__(self, project_id, group_id, kind, source, frame_interval=1):
+    def __init__(self, project_id, group_id, kind, source, frame_interval=1,
+                 video_mode=VIDEO_MODE_INTERVAL, sample_count=None):
         super().__init__()
         self.project_id = project_id
         self.group_id = group_id
         self.kind = kind  # 'folder' | 'images' | 'video'
         self.source = source
         self.frame_interval = frame_interval
+        self.video_mode = video_mode        # 'interval' | 'random'
+        self.sample_count = sample_count    # 随机模式要抽的张数
         self._cancel_event = threading.Event()
 
     def cancel(self):
@@ -80,6 +97,8 @@ class ImportWorkerThread(QThread):
                     self.source, frame_interval=self.frame_interval,
                     progress_callback=progress_callback,
                     cancel_event=self._cancel_event,
+                    mode=self.video_mode,
+                    sample_count=self.sample_count,
                 )
             else:
                 raise ValueError(f"未知导入类型: {self.kind}")
@@ -148,6 +167,82 @@ class ImageLoadWorker(QThread):
         self._is_running = False
 
 
+class _ResponsiveThumbnailGrid(QListWidget):
+    """图片缩略图网格：列数跟着视口宽度走，不留一整列的空白。
+
+    固定 gridSize 在窗口宽度和「整数个格子」对不上时，要么挤出横向滚动条，
+    要么在最右边留一条不够放下一格的空白（比如 890px 宽只塞得下 4 个 184px
+    格子，剩下 154px 就那么空着）。这里在视口变化时重算列数，让 usable
+    宽度正好被列数整除，余数摊薄到每一格里，而不是攒成一条空白。
+    """
+
+    _PREFERRED_CELL_WIDTH = 184
+    _MIN_CELL_WIDTH = 156
+    _MAX_CELL_WIDTH = 220
+    _VIEWPORT_INSET = 4
+    _MIN_ICON_EXTENT = 120
+    _MAX_ICON_EXTENT = 160
+    _ICON_HORIZONTAL_ALLOWANCE = 24
+    _CELL_VERTICAL_ALLOWANCE = 30
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # 用定时器把重算推迟到下一轮事件循环：resizeEvent 里直接 setGridSize
+        # 可能马上再触发一次 resizeEvent，级联下去；排队执行、且只在视口真的
+        # 变化时才动，就不会递归。
+        self._grid_update_timer = QTimer(self)
+        self._grid_update_timer.setSingleShot(True)
+        self._grid_update_timer.timeout.connect(self._recalculate_grid)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._grid_update_timer.start(0)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._grid_update_timer.start(0)
+
+    def _recalculate_grid(self):
+        viewport = self.viewport()
+        if viewport is None:
+            return
+        usable = max(1, viewport.width() - self._VIEWPORT_INSET)
+
+        columns = max(1, round(usable / self._PREFERRED_CELL_WIDTH))
+        cell_width = usable // columns
+
+        # 太宽：多分几列；分到会低于下限就停，不做无意义的震荡
+        while cell_width > self._MAX_CELL_WIDTH:
+            next_columns = columns + 1
+            next_cell_width = usable // next_columns
+            if next_cell_width < self._MIN_CELL_WIDTH:
+                break
+            columns = next_columns
+            cell_width = next_cell_width
+
+        # 太窄：少分几列；退回 1 列前，先看看会不会又超过上限
+        while cell_width < self._MIN_CELL_WIDTH and columns > 1:
+            next_columns = columns - 1
+            next_cell_width = usable // next_columns
+            if next_cell_width > self._MAX_CELL_WIDTH:
+                break
+            columns = next_columns
+            cell_width = next_cell_width
+
+        icon_extent = max(
+            self._MIN_ICON_EXTENT,
+            min(self._MAX_ICON_EXTENT, cell_width - self._ICON_HORIZONTAL_ALLOWANCE),
+        )
+        font_height = self.fontMetrics().height()
+        grid_size = QSize(cell_width, icon_extent + font_height + self._CELL_VERTICAL_ALLOWANCE)
+        icon_size = QSize(icon_extent, icon_extent)
+
+        if grid_size != self.gridSize():
+            self.setGridSize(grid_size)
+        if icon_size != self.iconSize():
+            self.setIconSize(icon_size)
+
+
 class ImportPage(QWidget):
     """数据导入页面"""
 
@@ -181,7 +276,7 @@ class ImportPage(QWidget):
 
         self.init_ui()
         self.refresh_view_filter_options()
-        self.update_project_bar()
+        self.update_project_controls()
         self.update_view_mode()
 
     def _remove_cached_thumbnails(self, storage_paths):
@@ -207,9 +302,9 @@ class ImportPage(QWidget):
         main_layout.setContentsMargins(24, 18, 24, 18)
         main_layout.setSpacing(14)
 
-        # 项目信息条：当前项目叫什么、要做哪种任务
-        self.project_bar = self.create_project_bar()
-        main_layout.addWidget(self.project_bar)
+        # 项目信息条没了：当前项目在左侧流程栏里选、也一直显示在那儿，
+        # 这里再放一张写着项目名和「01」的卡片，只是把同一件事说第二遍，
+        # 顺带把整整一行高度从图片区里拿走。任务类型改挂到工具栏右侧。
 
         # 工具栏：左边加数据，右边管数据
         self.toolbar = self.create_toolbar()
@@ -238,40 +333,13 @@ class ImportPage(QWidget):
         self.status_bar = self.create_status_bar()
         main_layout.addWidget(self.status_bar)
 
-    def create_project_bar(self) -> QFrame:
-        """项目信息条：项目名 + 任务类型 + 删除项目"""
-        bar = QFrame()
-        bar.setObjectName("card")
-
-        layout = QHBoxLayout(bar)
-        layout.setContentsMargins(16, 12, 16, 12)
-        layout.setSpacing(12)
-
-        self.project_name_label = QLabel("未选择项目")
-        self.project_name_label.setObjectName("h2")
-        # 名字可能很长，不能让它把任务类型 / 删除按钮挤出去，超出部分省略并放进 tooltip
-        self.project_name_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
-        self.project_name_label.setMaximumWidth(280)
-        layout.addWidget(self.project_name_label)
-
-        self.btn_task_type = QPushButton("任务类型：未设置")
-        self.btn_task_type.setToolTip("决定标注工具和训练方式，一般选「目标检测」")
-        self.btn_task_type.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.btn_task_type.clicked.connect(self.change_task_type)
-        layout.addWidget(self.btn_task_type)
-
-        layout.addStretch()
-
-        self.btn_delete_project = QPushButton("删除项目")
-        self.btn_delete_project.setObjectName("danger")
-        self.btn_delete_project.setToolTip("连同项目里的图片和标注一起删除，不可恢复")
-        self.btn_delete_project.clicked.connect(self.delete_current_project)
-        layout.addWidget(self.btn_delete_project)
-
-        return bar
-
     def create_toolbar(self) -> QFrame:
-        """创建工具栏"""
+        """工具栏：左边「把数据弄进来」，右边「这批数据怎么看、怎么管」。
+
+        右边一排以前是筛选 + 移动分组 + 删除选中 + 清空，四个按钮平铺，
+        「清空」和「导入文件夹」一样大——用一次的和每次都用的抢同样的注意力。
+        现在只留任务类型和筛选，其余收进「管理」菜单，破坏性的那两个单独成一段。
+        """
         toolbar = QFrame()
         toolbar.setObjectName("toolbar")
 
@@ -303,6 +371,13 @@ class ImportPage(QWidget):
 
         layout.addStretch()
 
+        # 任务类型：一个能点的胶囊，点开就是原来那个选择框
+        self.btn_task_type = QPushButton("任务：未设置")
+        self.btn_task_type.setToolTip("决定标注工具和训练方式，一般选「目标检测」")
+        self.btn_task_type.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_task_type.clicked.connect(self.change_task_type)
+        layout.addWidget(self.btn_task_type)
+
         filter_label = QLabel("筛选")
         filter_label.setObjectName("caption")
         layout.addWidget(filter_label)
@@ -312,22 +387,93 @@ class ImportPage(QWidget):
         self.view_combo.currentTextChanged.connect(self.filter_images)
         layout.addWidget(self.view_combo)
 
-        self.btn_move_group = QPushButton("移动分组")
-        self.btn_move_group.setToolTip("把选中图片移到指定分组")
-        self.btn_move_group.clicked.connect(self.move_selected_to_group)
-        layout.addWidget(self.btn_move_group)
-
-        self.btn_delete_selected = QPushButton("删除选中")
-        self.btn_delete_selected.clicked.connect(self.delete_selected_images)
-        layout.addWidget(self.btn_delete_selected)
-
-        self.btn_clear = QPushButton("清空")
-        self.btn_clear.setObjectName("danger")
-        self.btn_clear.setToolTip("删除当前项目里的全部图片")
-        self.btn_clear.clicked.connect(self.clear_all_images)
-        layout.addWidget(self.btn_clear)
+        layout.addWidget(self.create_manage_button())
 
         return toolbar
+
+    def create_manage_button(self) -> QToolButton:
+        """「管理 ▾」：不常用的和会删东西的都收在这里。
+
+        破坏性的两个（清空图片、删除项目）单独放在一段里，前面一个红点——
+        Qt 的菜单项没法单独染色（QAction 不是控件，样式表选不中它），
+        图标是唯一能把「这一条会删东西」标出来的位置。
+        """
+        self.btn_manage = QToolButton()
+        self.btn_manage.setText("管理 ▾")
+        self.btn_manage.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.btn_manage.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.btn_manage.setToolTip("移动分组、删除图片、删除项目")
+        # 文字里已经有 ▾ 了，别让 Qt 再画一个自带的箭头
+        self.btn_manage.setStyleSheet("""
+            QToolButton::menu-indicator { image: none; width: 0px; }
+        """)
+
+        self.manage_menu = QMenu(self)
+
+        self.action_move_group = self.manage_menu.addAction("移动分组")
+        self.action_move_group.setToolTip("把选中图片移到指定分组")
+        self.action_move_group.triggered.connect(self.move_selected_to_group)
+
+        self.action_delete_selected = self.manage_menu.addAction("删除选中的图片")
+        self.action_delete_selected.triggered.connect(self.delete_selected_images)
+
+        self.manage_menu.addSeparator()
+
+        # 一个点不动的标题，把下面两条框成「危险」的那一段
+        danger_caption = self.manage_menu.addAction("危险操作")
+        danger_caption.setEnabled(False)
+
+        self.action_clear = self.manage_menu.addAction(self._danger_icon(), "清空全部图片")
+        self.action_clear.setToolTip("删除当前项目里的全部图片")
+        self.action_clear.triggered.connect(self.clear_all_images)
+
+        self.action_delete_project = self.manage_menu.addAction(self._danger_icon(), "删除项目")
+        self.action_delete_project.setToolTip("连同项目里的图片和标注一起删除，不可恢复")
+        self.action_delete_project.triggered.connect(self.delete_current_project)
+
+        self.destructive_actions = [self.action_clear, self.action_delete_project]
+        for action in self.destructive_actions:
+            action.setProperty('destructive', True)
+
+        # 菜单弹出前再算一次：选中状态可能是在菜单关着的时候变的
+        self.manage_menu.aboutToShow.connect(self.update_manage_action_state)
+
+        self.btn_manage.setMenu(self.manage_menu)
+        return self.btn_manage
+
+    def update_manage_action_state(self):
+        """管理菜单里每一条现在能不能点。
+
+        「移动分组」和「删除选中的图片」没有选中图片时就是不能用的——
+        以前它们一直亮着，点下去只弹一句「还没选图片」，等于用一个弹窗
+        代替了本来一眼就该看出来的状态。「清空全部图片」同理：没有图片可清。
+        """
+        has_project = bool(self.current_project_id)
+        has_selection = bool(self.image_list.selectedItems())
+        has_images = bool(self.images)
+
+        self.action_move_group.setEnabled(has_project and has_selection)
+        self.action_delete_selected.setEnabled(has_project and has_selection)
+
+        # 破坏性的两个在导入进行中一律关掉：正在往里写图片的时候不能把项目端了。
+        # 移动/删除选中不受影响——那是对已有图片的操作，导入中照样可以做。
+        busy = self._import_busy
+        self.action_clear.setEnabled(has_project and has_images and not busy)
+        self.action_delete_project.setEnabled(has_project and not busy)
+
+    def _danger_icon(self) -> QIcon:
+        """破坏性菜单项前面那个红点。自己画的，不引第三方图标。"""
+        pixmap = QPixmap(10, 10)
+        pixmap.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor(COLORS['error_fill']))
+        painter.drawEllipse(1, 1, 8, 8)
+        painter.end()
+
+        return QIcon(pixmap)
 
     def create_import_status_bar(self) -> QFrame:
         """导入任务状态条：状态文字 + 进度条 + 取消按钮。
@@ -385,16 +531,17 @@ class ImportPage(QWidget):
 
     def create_image_grid(self) -> QListWidget:
         """图片缩略图网格。"""
-        self.image_list = QListWidget()
+        self.image_list = _ResponsiveThumbnailGrid()
         self.image_list.setViewMode(QListWidget.ViewMode.IconMode)
-        self.image_list.setIconSize(QSize(160, 160))
         self.image_list.setSpacing(10)
         self.image_list.setResizeMode(QListWidget.ResizeMode.Adjust)
         self.image_list.setMovement(QListWidget.Movement.Static)
         self.image_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
         self.image_list.setUniformItemSizes(True)
-        self.image_list.setGridSize(QSize(184, 208))
+        self.image_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.image_list.itemClicked.connect(self.on_image_clicked)
+        # 选中哪些图片，决定了「移动分组 / 删除选中」能不能点
+        self.image_list.itemSelectionChanged.connect(self.update_manage_action_state)
         # 注意：这里不写 item 的 background-color，
         # 让代码里 setBackground 设的「已标注」底色能显示出来
         self.image_list.setStyleSheet(f"""
@@ -405,6 +552,7 @@ class ImportPage(QWidget):
                 padding: 8px;
             }}
             QListWidget::item {{
+                margin: 4px;
                 border: 1px solid {COLORS['border']};
                 border-radius: 8px;
                 padding: 6px;
@@ -415,17 +563,36 @@ class ImportPage(QWidget):
         """)
         return self.image_list
 
+    def _refresh_image_display_names(self):
+        """整批算显示名：抽帧出来的图叫「帧 223」，重名的才补区分信息。
+
+        必须整批算——「这个帧号在这批图里是不是独一份」只有看全列表才知道。
+        """
+        aliases = display_names([img.get('filename', '') for img in self.images])
+        self._image_display_names = {
+            img['id']: alias for img, alias in zip(self.images, aliases)
+        }
+
+    def _image_display_name(self, image_data: Dict) -> str:
+        cached = getattr(self, '_image_display_names', {}).get(image_data.get('id'))
+        return cached or display_name(image_data.get('filename', ''))
+
     def _apply_item_status(self, item: QListWidgetItem, image_data: Dict):
-        """让「哪些图已经标过」在网格里一眼看得出来：勾号 + 绿字，不只靠颜色。"""
-        filename = image_data['filename']
+        """让「哪些图已经标过」在网格里一眼看得出来：勾号 + 绿字，不只靠颜色。
+
+        格子底下写的是显示名（完整文件名在 tooltip 里）：一网格全是
+        20260712_000602_575947_frame_000223.jpg 的话，每个格子只放得下前面那段
+        一模一样的时间戳，等于每张图都没有名字。
+        """
         annotated = image_data.get('status') == 'annotated'
+        alias = self._image_display_name(image_data)
 
         if annotated:
-            item.setText(f"✓ {filename}")
+            item.setText(f"✓ {alias}")
             item.setForeground(QColor(COLORS['success']))
             item.setBackground(QColor(COLORS['success_soft']))
         else:
-            item.setText(filename)
+            item.setText(alias)
             item.setForeground(QColor(COLORS['text_secondary']))
             item.setBackground(QColor(COLORS['panel']))
 
@@ -484,7 +651,7 @@ class ImportPage(QWidget):
         self.thumbnail_widgets.clear()
 
         self.refresh_view_filter_options()
-        self.update_project_bar()
+        self.update_project_controls()
 
         if project_id:
             self.load_project_images()
@@ -492,31 +659,25 @@ class ImportPage(QWidget):
             self.update_status_bar()
             self.update_view_mode()
 
-    def update_project_bar(self):
-        """刷新项目信息条与按钮可用性。"""
+    def update_project_controls(self):
+        """刷新任务类型胶囊与各处可用性（没有项目就全灰掉）。"""
         has_project = bool(self.current_project_id)
 
         project = db.get_project(self.current_project_id) if has_project else None
         if project:
-            name = project.get('name', '未命名项目')
-            self.btn_task_type.setText(f"任务类型：{task_type_label(project.get('type'))}")
+            self.btn_task_type.setText(f"任务：{short_task_label(project.get('type'))}")
         else:
-            name = "未选择项目"
-            self.btn_task_type.setText("任务类型：未设置")
+            self.btn_task_type.setText("任务：未设置")
 
-        metrics = QFontMetrics(self.project_name_label.font())
-        elided = metrics.elidedText(name, Qt.TextElideMode.ElideRight, self.project_name_label.maximumWidth())
-        self.project_name_label.setText(elided)
-        self.project_name_label.setToolTip(name)
-
-        for button in (
-            self.btn_task_type, self.btn_delete_project,
+        for control in (
+            self.btn_task_type,
             self.btn_import_folder, self.btn_import_images,
             self.btn_import_video, self.btn_import_annotations,
-            self.btn_move_group, self.btn_delete_selected, self.btn_clear,
-            self.btn_refresh_status, self.view_combo,
+            self.btn_manage, self.btn_refresh_status, self.view_combo,
         ):
-            button.setEnabled(has_project)
+            control.setEnabled(has_project)
+
+        self.update_manage_action_state()
 
         # 导入任务进行中：即使有项目，也不能再启动新导入或破坏当前项目
         if self._import_busy:
@@ -527,7 +688,6 @@ class ImportPage(QWidget):
         has_project = bool(self.current_project_id)
 
         # 没有项目时，工具栏和状态栏全是灰的、没意义，直接收起来，只留一句引导
-        self.project_bar.setVisible(has_project)
         self.toolbar.setVisible(has_project)
         self.status_bar.setVisible(has_project)
 
@@ -569,14 +729,18 @@ class ImportPage(QWidget):
             return
 
         db.update_project(self.current_project_id, type=task_type)
-        self.update_project_bar()
+        self.update_project_controls()
 
     def create_new_project(self):
         """创建新项目：先起名字，再选任务类型。"""
-        from PyQt6.QtWidgets import QInputDialog
-
-        name, ok = QInputDialog.getText(self, "新建项目", "给项目起个名字（比如「安全帽检测」）：")
-        if not ok or not name.strip():
+        name = ask_text(
+            self, "新建项目",
+            "给项目起个名字，之后图片、标注和训练结果都存在这个项目里。",
+            placeholder="比如：安全帽检测",
+            confirm_text="创建项目",
+        )
+        # 取消，或者名字是空的 / 只有空格：ask_text 都返回 None
+        if not name:
             return
 
         task_type = ask_task_type(self, current='detect', title="这个项目要做什么")
@@ -584,7 +748,7 @@ class ImportPage(QWidget):
             return
 
         project_id = db.create_project(
-            name=name.strip(),
+            name=name,
             description="",
             project_type=task_type,
             classes=[]
@@ -600,15 +764,13 @@ class ImportPage(QWidget):
         project = db.get_project(self.current_project_id)
         project_name = (project or {}).get('name', '')
 
-        reply = QMessageBox.question(
+        if not confirm_destructive(
             self,
-            "确认删除",
-            f"确定要删除项目「{project_name}」吗？\n\n"
-            "项目里的所有图片和标注都会一起删除，无法恢复。",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            QMessageBox.StandardButton.No
-        )
-        if reply != QMessageBox.StandardButton.Yes:
+            "删除项目",
+            f"项目「{project_name}」里的所有图片和标注都会一起删除，无法恢复。",
+            detail=f"当前项目有 {len(self.images)} 张图片。",
+            confirm_text="删除项目",
+        ):
             return
 
         try:
@@ -633,12 +795,12 @@ class ImportPage(QWidget):
             self._remove_cached_thumbnails(removed_storage_paths)
 
             self.update_status_bar()
-            self.update_project_bar()
+            self.update_project_controls()
             self.update_view_mode()
             self.projects_changed.emit(None)
 
         except Exception as e:
-            QMessageBox.critical(self, "错误", f"删除项目失败: {str(e)}")
+            show_warning(self, "删除项目失败", str(e))
 
     def load_project_images(self):
         """加载项目图像 - 使用多线程"""
@@ -660,6 +822,7 @@ class ImportPage(QWidget):
 
         # 从数据库获取图片列表（很快）
         self.images = db.get_project_images(self.current_project_id)
+        self._refresh_image_display_names()
         self.update_status_bar()
         self.update_view_mode()
 
@@ -816,6 +979,7 @@ class ImportPage(QWidget):
             return 0
 
         self.images.extend(new_images)
+        self._refresh_image_display_names()
 
         uncached_tasks = []
         for image_data in new_images:
@@ -830,6 +994,10 @@ class ImportPage(QWidget):
             else:
                 uncached_tasks.append((row_index, image_data))
 
+        # 新导入的图可能和已有的重名（另一段视频的同一个帧号），
+        # 那样老格子也得补上区分信息——所以整列表重刷一遍文字
+        self._refresh_item_labels()
+
         self.update_status_bar()
         self.update_view_mode()
         self.filter_images(self.view_combo.currentText())
@@ -840,6 +1008,15 @@ class ImportPage(QWidget):
             on_thumbnails_ready()
 
         return len(new_images)
+
+    def _refresh_item_labels(self):
+        """按当前的显示名，把所有格子的文字重刷一遍。"""
+        by_id = {img['id']: img for img in self.images}
+        for i in range(self.image_list.count()):
+            item = self.image_list.item(i)
+            image_data = by_id.get(item.data(Qt.ItemDataRole.UserRole))
+            if image_data:
+                self._apply_item_status(item, image_data)
 
     def refresh_view_filter_options(self):
         """刷新筛选下拉框（含分组列表）。"""
@@ -929,6 +1106,9 @@ class ImportPage(QWidget):
         self.status_annotated.setText(f"已标注 {annotated}")
         self.status_pending.setText(f"未标注 {pending}")
 
+        # 图片数变了：「清空全部图片」在没有图片时就该是灰的
+        self.update_manage_action_state()
+
         self.project_data_changed.emit()
 
     # ==================== 导入任务状态 ====================
@@ -940,9 +1120,13 @@ class ImportPage(QWidget):
         for button in (
             self.btn_import_folder, self.btn_import_images,
             self.btn_import_video, self.btn_import_annotations,
-            self.btn_delete_project, self.btn_clear,
         ):
             button.setEnabled(enabled)
+
+        # 破坏性的两个现在在「管理」菜单里：禁的是菜单项，不是整个菜单——
+        # 导入中仍然允许移动分组、删除选中的图片。具体谁能点由这里统一算，
+        # 它读的是 self._import_busy，所以调用顺序上必须先把 busy 标志改好。
+        self.update_manage_action_state()
 
     def _start_import_ui(self, message: str, indeterminate: bool = True):
         """进入「导入中」状态：用户点确认导入后，一个事件循环内就要看到这个。"""
@@ -996,7 +1180,7 @@ class ImportPage(QWidget):
         else:
             self.import_status_frame.setVisible(False)
 
-        self.update_project_bar()
+        self.update_project_controls()
 
     def _cancel_active_import(self):
         """取消按钮：请求后台线程停止，最迟在下一个文件/帧边界生效。"""
@@ -1024,12 +1208,14 @@ class ImportPage(QWidget):
 
     def _start_data_import(self, kind: str, source, group_id,
                             frame_interval: int = 1, initial_message: str = "",
-                            indeterminate: bool = True):
+                            indeterminate: bool = True,
+                            video_mode: str = VIDEO_MODE_INTERVAL,
+                            sample_count: int = None):
         """统一入口：文件夹 / 多图 / 视频导入都从这里起后台线程。"""
         if not self.current_project_id:
             return
         if self._import_busy:
-            QMessageBox.information(self, "提示", "已有导入任务在进行，请稍候")
+            show_info(self, "已有导入任务在进行", "等这一个跑完再开始下一个。")
             return
 
         self._import_generation += 1
@@ -1039,7 +1225,9 @@ class ImportPage(QWidget):
         self._start_import_ui(initial_message, indeterminate=indeterminate)
 
         thread = ImportWorkerThread(
-            self.current_project_id, group_id, kind, source, frame_interval=frame_interval
+            self.current_project_id, group_id, kind, source,
+            frame_interval=frame_interval,
+            video_mode=video_mode, sample_count=sample_count,
         )
         thread.progress_updated.connect(
             lambda progress, message, g=generation: self._on_import_progress(g, progress, message)
@@ -1075,7 +1263,7 @@ class ImportPage(QWidget):
 
         if not success:
             self._end_import_ui()
-            QMessageBox.critical(self, "导入失败", f"导入过程中发生错误:\n{error}")
+            show_warning(self, "导入失败", "导入过程中出错，没有改动项目里的图片。", detail=error)
             return
 
         prefix = "已取消" if cancelled else "导入完成"
@@ -1108,7 +1296,7 @@ class ImportPage(QWidget):
     def import_folder(self):
         """导入文件夹"""
         if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择或创建一个项目")
+            show_warning(self, "还没有项目", "先在左边选一个项目，或者新建一个。")
             return
         
         folder_path = QFileDialog.getExistingDirectory(
@@ -1125,7 +1313,7 @@ class ImportPage(QWidget):
     def import_images(self):
         """导入单张或多张图片"""
         if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择或创建一个项目")
+            show_warning(self, "还没有项目", "先在左边选一个项目，或者新建一个。")
             return
         
         file_paths, _ = QFileDialog.getOpenFileNames(
@@ -1142,7 +1330,7 @@ class ImportPage(QWidget):
     def import_video(self):
         """导入视频"""
         if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择或创建一个项目")
+            show_warning(self, "还没有项目", "先在左边选一个项目，或者新建一个。")
             return
         
         file_path, _ = QFileDialog.getOpenFileName(
@@ -1157,35 +1345,47 @@ class ImportPage(QWidget):
             self.process_video_import(file_path, group_id=group_id)
     
     def process_video_import(self, file_path: str, group_id: int = None):
-        """处理视频导入：抽帧间隔问完，后台线程负责剩下的一切。"""
+        """处理视频导入：抽帧方案问完，后台线程负责剩下的一切。
+
+        元信息（总帧数 / fps / 时长）在弹窗里就读好了——只读属性，不解码，
+        所以「打开一个大视频看看能抽几张」不会卡住界面，也不会先导入一堆帧。
+        """
         if not self.current_project_id:
             return
 
-        from PyQt6.QtWidgets import QInputDialog
-        interval, ok = QInputDialog.getInt(
-            self, "抽帧设置",
-            "请输入抽帧间隔（每隔多少帧抽取一帧）:",
-            value=30, min=1, max=1000
-        )
-
-        if not ok:
+        try:
+            plan = ask_video_extract_plan(self, file_path)
+        except ValueError as exc:
+            show_warning(self, "打不开这个视频", str(exc))
             return
 
+        if not plan:
+            return
+
+        name = Path(file_path).name
+        if plan['mode'] == VIDEO_MODE_RANDOM:
+            initial_message = f"正在打开视频: {name}（随机抽取 {plan['sample_count']} 张）"
+        else:
+            initial_message = f"正在打开视频: {name}（每 {plan['frame_interval']} 帧取 1 张）"
+
         self._start_data_import(
-            'video', file_path, group_id, frame_interval=interval,
-            initial_message=f"正在打开视频: {Path(file_path).name}",
+            'video', file_path, group_id,
+            frame_interval=plan['frame_interval'],
+            video_mode=plan['mode'],
+            sample_count=plan['sample_count'],
+            initial_message=initial_message,
         )
 
     def import_annotations(self):
         """导入已有标注"""
         if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择或创建一个项目")
+            show_warning(self, "还没有项目", "先在左边选一个项目，或者新建一个。")
             return
         
         # 检查项目是否有任务标签
         project = db.get_project(self.current_project_id)
         if not project:
-            QMessageBox.warning(self, "提示", "项目信息获取失败")
+            show_warning(self, "读不到项目信息", "项目可能已经被删除，换一个试试。")
             return
         
         task_type = project.get('type')
@@ -1194,7 +1394,7 @@ class ImportPage(QWidget):
             if not task_type:
                 return
             db.update_project(self.current_project_id, type=task_type)
-            self.update_project_bar()
+            self.update_project_controls()
 
         # 选择标注格式
         from PyQt6.QtWidgets import QRadioButton
@@ -1261,14 +1461,16 @@ class ImportPage(QWidget):
         if not labels_dir:
             return
         
-        reply = QMessageBox.question(
-            self, "选择图像文件夹",
-            "是否需要选择对应的图像文件夹？\n（如果标签文件和图像文件在同一目录，可选择否）",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        need_images_dir = confirm(
+            self, "图像文件夹",
+            "标签文件和图片不在同一个目录时，要另外指定图片所在的文件夹。",
+            detail="如果 .txt 和图片就放在一起，选「不用」。",
+            confirm_text="去选择",
+            cancel_text="不用",
         )
-        
+
         images_dir = None
-        if reply == QMessageBox.StandardButton.Yes:
+        if need_images_dir:
             images_dir = QFileDialog.getExistingDirectory(
                 self, "选择图像文件夹 (images)", "",
                 QFileDialog.Option.ShowDirsOnly
@@ -1286,13 +1488,13 @@ class ImportPage(QWidget):
         # 如果有标注，提示是否覆盖
         overwrite = False
         if has_annotations:
-            reply = QMessageBox.question(
-                self, "覆盖标注",
-                "项目中已经存在标注，是否覆盖？",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+            overwrite = confirm_destructive(
+                self, "覆盖已有标注",
+                "项目里已经有标注了。继续导入会用新文件里的标注覆盖它们，覆盖后无法恢复。",
+                detail="两种选择都会继续导入；选「保留现有标注」只是不动已经标好的那些图片。",
+                confirm_text="覆盖",
+                cancel_text="保留现有标注",
             )
-            if reply == QMessageBox.StandardButton.Yes:
-                overwrite = True
         
         # 显示加载动画
         self.loading_overlay = LoadingOverlay(self, "正在导入YOLO标注...")
@@ -1347,12 +1549,9 @@ class ImportPage(QWidget):
         
         # 显示结果
         if success:
-            QMessageBox.information(
-                self, "导入完成",
-                f"YOLO标注导入完成！\n成功导入: {imported} 个标注\n跳过: {skipped} 个"
-            )
+            show_info(self, "标注导入完成", f"导入了 {imported} 个标注，跳过 {skipped} 个。")
         else:
-            QMessageBox.critical(self, "导入失败", message)
+            show_warning(self, "标注导入失败", message)
     
     def import_coco_annotations(self, group_id: int = None):
         """导入COCO标注"""
@@ -1376,13 +1575,13 @@ class ImportPage(QWidget):
         # 如果有标注，提示是否覆盖
         overwrite = False
         if has_annotations:
-            reply = QMessageBox.question(
-                self, "覆盖标注",
-                "项目中已经存在标注，是否覆盖？",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+            overwrite = confirm_destructive(
+                self, "覆盖已有标注",
+                "项目里已经有标注了。继续导入会用新文件里的标注覆盖它们，覆盖后无法恢复。",
+                detail="两种选择都会继续导入；选「保留现有标注」只是不动已经标好的那些图片。",
+                confirm_text="覆盖",
+                cancel_text="保留现有标注",
             )
-            if reply == QMessageBox.StandardButton.Yes:
-                overwrite = True
         
         # 显示加载动画
         self.loading_overlay = LoadingOverlay(self, "正在导入COCO标注...")
@@ -1444,13 +1643,13 @@ class ImportPage(QWidget):
         # 如果有标注，提示是否覆盖
         overwrite = False
         if has_annotations:
-            reply = QMessageBox.question(
-                self, "覆盖标注",
-                "项目中已经存在标注，是否覆盖？",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+            overwrite = confirm_destructive(
+                self, "覆盖已有标注",
+                "项目里已经有标注了。继续导入会用新文件里的标注覆盖它们，覆盖后无法恢复。",
+                detail="两种选择都会继续导入；选「保留现有标注」只是不动已经标好的那些图片。",
+                confirm_text="覆盖",
+                cancel_text="保留现有标注",
             )
-            if reply == QMessageBox.StandardButton.Yes:
-                overwrite = True
         
         # 显示加载动画
         self.loading_overlay = LoadingOverlay(self, "正在导入VOC标注...")
@@ -1518,48 +1717,47 @@ class ImportPage(QWidget):
         if not self.images:
             return
         
-        reply = QMessageBox.question(
-            self, "确认清空",
-            f"确定要删除当前项目中的所有 {len(self.images)} 张图片吗？\n此操作不可恢复！",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
-        )
-        
-        if reply == QMessageBox.StandardButton.Yes:
-            self.stop_image_loading()
-            deleted = 0
-            failed = 0
-            
-            # 使用副本迭代，避免删除过程中修改原列表导致遍历异常
-            images_snapshot = list(self.images)
-            for image in images_snapshot:
-                if db.delete_image(image['id']):
-                    deleted += 1
-                else:
-                    failed += 1
+        total = len(self.images)
+        if not confirm_destructive(
+            self, "清空图片",
+            "当前项目里的图片会全部删除，标注也一起没了，无法恢复。",
+            detail=f"共 {total} 张图片。",
+            confirm_text=f"删除 {total} 张",
+        ):
+            return
 
-            # 全部删除成功时，直接本地清空，避免触发整页重载
-            if failed == 0:
-                removed_storage_paths = [img.get('storage_path', '') for img in self.images]
-                self.images.clear()
-                self.image_list.clear()
-                self.thumbnail_widgets.clear()
-                self._remove_cached_thumbnails(removed_storage_paths)
-                self.update_status_bar()
-                self.update_view_mode()
+        self.stop_image_loading()
+        deleted = 0
+        failed = 0
+
+        # 使用副本迭代，避免删除过程中修改原列表导致遍历异常
+        images_snapshot = list(self.images)
+        for image in images_snapshot:
+            if db.delete_image(image['id']):
+                deleted += 1
             else:
-                # 部分失败时回退到全量重载，确保UI与数据库一致
-                self.load_project_images()
-            
-            if failed == 0:
-                QMessageBox.information(self, "清空完成", f"已成功删除 {deleted} 张图片")
-            else:
-                QMessageBox.warning(self, "清空完成", f"成功删除 {deleted} 张，失败 {failed} 张")
+                failed += 1
+
+        # 全部删除成功时，直接本地清空，避免触发整页重载
+        if failed == 0:
+            removed_storage_paths = [img.get('storage_path', '') for img in self.images]
+            self.images.clear()
+            self.image_list.clear()
+            self.thumbnail_widgets.clear()
+            self._remove_cached_thumbnails(removed_storage_paths)
+            self.update_status_bar()
+            self.update_view_mode()
+            show_info(self, "已清空", f"删除了 {deleted} 张图片。")
+        else:
+            # 部分失败时回退到全量重载，确保UI与数据库一致
+            self.load_project_images()
+            show_warning(self, "没有全部删掉", f"成功删除 {deleted} 张，失败 {failed} 张。")
     
     def move_selected_to_group(self):
         """将选中图片移动到指定分组"""
         selected_items = self.image_list.selectedItems()
         if not selected_items:
-            QMessageBox.information(self, "提示", "请先选择要移动的图片")
+            show_info(self, "还没选图片", "先在下面的图片里选中要移动的那几张。")
             return
         if not self.current_project_id:
             return
@@ -1601,26 +1799,22 @@ class ImportPage(QWidget):
         self.refresh_view_filter_options()
         self.filter_images(self.view_combo.currentText())
 
-        QMessageBox.information(
-            self, "移动完成",
-            f"已将 {updated} 张图片移动到「{group_label}」"
-        )
+        show_info(self, "移动完成", f"已把 {updated} 张图片移到「{group_label}」。")
 
     def delete_selected_images(self):
         """删除选中的图片"""
         selected_items = self.image_list.selectedItems()
         if not selected_items:
-            QMessageBox.information(self, "提示", "请先选择要删除的图片")
+            show_info(self, "还没选图片", "先在下面的图片里选中要删除的那几张。")
             return
-        
+
         count = len(selected_items)
-        reply = QMessageBox.question(
-            self, "确认删除",
-            f"确定要删除选中的 {count} 张图片吗？\n此操作不可恢复！",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
-        )
-        
-        if reply != QMessageBox.StandardButton.Yes:
+        if not confirm_destructive(
+            self, "删除选中的图片",
+            "选中的图片和它们的标注都会删掉，无法恢复。",
+            detail=f"选中了 {count} 张图片。",
+            confirm_text=f"删除 {count} 张",
+        ):
             return
 
         self.stop_image_loading()
@@ -1666,6 +1860,6 @@ class ImportPage(QWidget):
             self.update_view_mode()
 
         if failed == 0:
-            QMessageBox.information(self, "删除完成", f"已成功删除 {deleted} 张图片")
+            show_info(self, "已删除", f"删除了 {deleted} 张图片。")
         else:
-            QMessageBox.warning(self, "删除完成", f"成功删除 {deleted} 张，失败 {failed} 张")
+            show_warning(self, "没有全部删掉", f"成功删除 {deleted} 张，失败 {failed} 张。")

--- a/gui/pages/result_page.py
+++ b/gui/pages/result_page.py
@@ -29,7 +29,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPixmap
 
-from gui.styles import COLORS, RADIUS_SM
+from gui.styles import COLORS, RADIUS_SM, set_menu_indicator
 from gui.workflow import APP_ROOT, find_project_runs
 from gui.widgets.workflow_widgets import EmptyState
 
@@ -770,6 +770,7 @@ class ResultPage(QWidget):
             action.setToolTip(tip)
             action.triggered.connect(lambda _checked, f=fmt: self.on_export_format(f))
         self.btn_export_model.setMenu(export_menu)
+        set_menu_indicator(self.btn_export_model)
         row.addWidget(self.btn_export_model)
 
         self.btn_export_folder = QPushButton("导出结果文件夹")

--- a/gui/pages/result_page.py
+++ b/gui/pages/result_page.py
@@ -1,23 +1,37 @@
 # -*- coding: utf-8 -*-
 """
-训练结果页面
-显示runs文件夹中的训练结果图
+结果分析页面（主流程第 4 步）
+
+页面按一条阅读顺序自上而下排：
+    ① 这次训练能不能用  —— 一句话结论，新手先看这个
+    ② 看哪一次训练      —— 一个项目可能训练过很多次
+    ③ 关键指标          —— 四个数，每个配一行大白话
+    ④ 训练曲线 / 预测示例 —— 图放在标签页里，一次只铺开一张
+    ⑤ 模型文件与导出    —— 主操作（导出模型）在这里
+
+训练目录的发现统一走 gui/workflow.find_project_runs，
+和侧边栏「已训练 N 次」、前置条件页用的是同一份事实，不各自去猜。
+指标仍然取 results.csv 最后一行，算法没有变。
 """
 
-from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QListWidget, 
-    QListWidgetItem, QPushButton, QSplitter, QScrollArea,
-    QGroupBox, QFormLayout, QGridLayout, QMessageBox, QFileDialog,
-    QDialog, QSpinBox, QDoubleSpinBox, QCheckBox, QComboBox, QLineEdit,
-    QTabWidget, QTextEdit
-)
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QPixmap, QImage
+import csv
 import os
-import cv2
-from typing import List, Dict
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
-from gui.styles import COLORS
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel, QPushButton,
+    QComboBox, QFrame, QScrollArea, QStackedWidget, QTabWidget, QSizePolicy,
+    QMessageBox, QFileDialog, QDialog, QGroupBox, QFormLayout, QSpinBox,
+    QDoubleSpinBox, QCheckBox, QLineEdit, QMenu, QApplication
+)
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap
+
+from gui.styles import COLORS, RADIUS_SM
+from gui.workflow import APP_ROOT, find_project_runs
+from gui.widgets.workflow_widgets import EmptyState
 
 
 class ONNXExportDialog(QDialog):
@@ -310,371 +324,780 @@ class TensorRTExportDialog(QDialog):
         return config
 
 
+# ==================== 文案表 ====================
+
+# 四个关键指标：名字 + 大数字，说明只在悬停时给。
+METRIC_SPECS = [
+    {
+        'key': 'mAP50',
+        'title': 'mAP50',
+        'tip': '把所有类别的准确度平均起来的总分。判定较宽松：预测框和真实框重叠一半以上就算认对。',
+    },
+    {
+        'key': 'mAP50_95',
+        'title': 'mAP50-95',
+        'tip': '同样是总分，但要求预测框从「大致套住」到「几乎重合」都表现好。它比 mAP50 低很多是常态。',
+    },
+    {
+        'key': '精确率',
+        'title': '精确率',
+        'tip': '英文 Precision。它高说明模型很少把背景或别的东西认成目标。',
+    },
+    {
+        'key': '召回率',
+        'title': '召回率',
+        'tip': '英文 Recall。它高说明模型很少漏掉目标。和精确率通常此消彼长。',
+    },
+]
+
+# 每张结果图是什么，一个短语说清楚
+IMAGE_CAPTIONS = [
+    ('results.', '训练全过程曲线'),
+    ('confusion_matrix', '混淆矩阵'),
+    ('PR_curve', '精确率-召回率曲线'),
+    ('P_curve', '精确率-置信度曲线'),
+    ('R_curve', '召回率-置信度曲线'),
+    ('F1_curve', 'F1 曲线'),
+    # 预测示例的两条要排在 labels 前面：val_batch0_labels.jpg 里也有 "labels"
+    ('_pred', '模型预测框'),
+    ('_labels', '标注真值（对照用）'),
+    ('train_batch', '训练批次样本（含数据增强）'),
+    ('labels_correlogram', '标注分布相关图'),
+    ('labels', '各类别标注数量'),
+]
+
+# 曲线/图表 tab 里的排序：先看总览，再看细节
+CHART_ORDER = [
+    'results.', 'confusion_matrix_normalized', 'confusion_matrix',
+    'PR_curve', 'F1_curve', 'P_curve', 'R_curve',
+    'labels_correlogram', 'labels',
+]
+
+IMAGE_EXTENSIONS = ('.png', '.jpg', '.jpeg')
+
+# 导出格式：一个主按钮 + 一个菜单，不再把四个按钮并排铺开
+EXPORT_FORMATS = [
+    ('pt', 'PyTorch（.pt）', '训练直接产出的权重，本软件的「模型测试」和 Python 代码都能用'),
+    ('onnx', 'ONNX（.onnx）', '通用部署格式，大多数推理框架都认'),
+    ('torchscript', 'TorchScript', 'C++ / 移动端部署常用'),
+    ('tensorrt', 'TensorRT（.engine）', 'NVIDIA 显卡上的加速格式，需要本机装好 TensorRT'),
+]
+
+
+def caption_for(filename: str) -> str:
+    """这张图是干什么的。"""
+    for keyword, text in IMAGE_CAPTIONS:
+        if keyword in filename:
+            return text
+    return ""
+
+
+def chart_rank(filename: str) -> int:
+    for i, keyword in enumerate(CHART_ORDER):
+        if keyword in filename:
+            return i
+    return len(CHART_ORDER)
+
+
+class PreviewPane(QWidget):
+    """一个「选一张图 + 看这张图」的面板：下拉选图、一句说明、随窗口缩放的大图。
+
+    结果图有十几张，一次全铺开只会让人不知道看哪张，
+    所以三类图（曲线 / 预测示例 / 其他）各用一个面板，放进标签页里。
+    """
+
+    def __init__(self, empty_text: str, parent=None):
+        super().__init__(parent)
+        self.empty_text = empty_text
+        self._pixmap: Optional[QPixmap] = None
+        self._images: List[Tuple[str, str]] = []
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(10)
+
+        top = QHBoxLayout()
+        top.setSpacing(10)
+
+        pick_label = QLabel("查看")
+        pick_label.setObjectName("caption")
+        top.addWidget(pick_label)
+
+        self.combo = QComboBox()
+        self.combo.setMinimumWidth(160)
+        self.combo.currentIndexChanged.connect(self._on_pick)
+        top.addWidget(self.combo)
+        top.addStretch()
+        layout.addLayout(top)
+
+        self.caption = QLabel()
+        self.caption.setObjectName("caption")
+        self.caption.setWordWrap(True)
+        layout.addWidget(self.caption)
+
+        self.image_label = QLabel()
+        self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.image_label.setMinimumHeight(280)
+        # Ignored：图片大小不再反过来撑大窗口，窗口才能自由缩小
+        self.image_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Ignored)
+        self.image_label.setStyleSheet(
+            f"background-color: {COLORS['inset']};"
+            f"border: 1px solid {COLORS['border']};"
+            f"border-radius: {RADIUS_SM}px;"
+            f"color: {COLORS['text_secondary']};"
+        )
+        layout.addWidget(self.image_label, 1)
+
+    def set_images(self, images: List[Tuple[str, str]]):
+        """images: [(显示名, 绝对路径)]，按调用方给的顺序显示。"""
+        self._images = images
+        self._pixmap = None
+
+        self.combo.blockSignals(True)
+        self.combo.clear()
+        for name, path in images:
+            self.combo.addItem(name, path)
+        self.combo.blockSignals(False)
+
+        if not images:
+            self.combo.setEnabled(False)
+            self.caption.setText("")
+            self.image_label.setText(self.empty_text)
+            return
+
+        self.combo.setEnabled(True)
+        self.combo.setCurrentIndex(0)
+        self._on_pick(0)
+
+    def _on_pick(self, index: int):
+        path = self.combo.itemData(index)
+        if not path:
+            return
+
+        self.caption.setText(caption_for(os.path.basename(path)))
+
+        if not os.path.exists(path):
+            self._pixmap = None
+            self.image_label.setText("这张图找不到了（文件可能被移动或删除）。点「刷新」重新扫描。")
+            return
+
+        self.image_label.setText("正在加载图像…")
+        QApplication.processEvents()
+
+        pixmap = QPixmap(path)
+        if pixmap.isNull():
+            self._pixmap = None
+            self.image_label.setText("这张图打不开，文件可能已损坏。")
+            return
+
+        self._pixmap = pixmap
+        self._render()
+
+    def _render(self):
+        """按当前可用空间重画。图比空间小就保持原样，不放大糊掉。"""
+        if self._pixmap is None:
+            return
+
+        area = self.image_label.size()
+        if area.width() < 40 or area.height() < 40:
+            return
+
+        if self._pixmap.width() > area.width() or self._pixmap.height() > area.height():
+            shown = self._pixmap.scaled(
+                area,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        else:
+            shown = self._pixmap
+
+        self.image_label.setPixmap(shown)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._render()
+
+
 class ResultPage(QWidget):
-    """训练结果页面"""
-    
+    """结果分析页面"""
+
     def __init__(self):
         super().__init__()
         self.current_project_id = None
-        self.current_images = []
-        self.current_image_idx = -1
-        
+        self.current_run: Optional[Path] = None
+        self.current_metrics: Dict[str, float] = {}
+
         self.init_ui()
         # 初始时不自动扫描，等待设置项目
-    
+
     def set_project(self, project_id: int):
-        """设置当前项目"""
+        """由主窗口调用：切换当前项目。"""
         self.current_project_id = project_id
         if project_id:
             print(f"[ResultPage] 已切换到项目: {project_id}")
             self.scan_runs_directory()
         else:
             print("[ResultPage] 项目已取消选择")
-            # 清空显示
-            self.image_list.clear()
-            self.current_images = []
-            self.image_label.setText("请先选择一个项目")
-            # 清空指标
-            for label in self.metric_labels.values():
-                label.setText("--")
-    
+            self.current_run = None
+            self.current_metrics = {}
+            self._show_empty(
+                "还没有选择项目",
+                "训练结果是跟着项目走的。先在左上角「当前项目」里选一个项目。",
+                show_action=False,
+            )
+
+    # ==================== 界面搭建 ====================
+
     def init_ui(self):
         """初始化界面"""
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("训练结果")
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+
+        # 内容 / 空状态 / 加载中，三选一
+        self.view_stack = QStackedWidget()
+        self.view_stack.addWidget(self.create_content_view())   # 0
+        self.view_stack.addWidget(self.create_empty_view())     # 1
+        self.view_stack.addWidget(self.create_loading_view())   # 2
+        root.addWidget(self.view_stack)
+
+        self._show_empty(
+            "还没有选择项目",
+            "训练结果是跟着项目走的。先在左上角「当前项目」里选一个项目。",
+            show_action=False,
+        )
+
+    def create_content_view(self) -> QWidget:
+        """整页放进滚动区：窗口再矮也能一路看下去。"""
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        inner = QWidget()
+        layout = QVBoxLayout(inner)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(14)
+
+        layout.addWidget(self.create_verdict_card())
+        layout.addWidget(self.create_run_card())
+        layout.addWidget(self.create_metrics_card())
+        layout.addWidget(self.create_gallery_card(), 1)
+        layout.addWidget(self.create_export_card())
+
+        scroll.setWidget(inner)
+        return scroll
+
+    def create_verdict_card(self) -> QFrame:
+        """① 一句话结论：这次训练能不能用。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(20, 16, 20, 16)
+        layout.setSpacing(8)
+
+        head = QHBoxLayout()
+        head.setSpacing(10)
+
+        self.verdict_badge = QLabel()
+        self.verdict_badge.setToolTip(
+            "按 mAP50 的粗略判断，实际效果以「模型测试」里跑新图片为准。"
+        )
+        head.addWidget(self.verdict_badge)
+
+        self.verdict_title = QLabel()
+        self.verdict_title.setObjectName("h2")
+        self.verdict_title.setWordWrap(True)
+        # 会换行的标签在 HBox 里必须拿到伸展权重，否则它只分到 sizeHint 那点宽度，
+        # 明明整行都空着，标题却在「可以/用」中间断开
+        head.addWidget(self.verdict_title, 1)
+        layout.addLayout(head)
+
+        self.verdict_detail = QLabel()
+        self.verdict_detail.setObjectName("subtitle")
+        self.verdict_detail.setWordWrap(True)
+        layout.addWidget(self.verdict_detail)
+
+        return card
+
+    def create_run_card(self) -> QFrame:
+        """② 看哪一次训练。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QHBoxLayout(card)
+        layout.setContentsMargins(20, 12, 20, 12)
+        layout.setSpacing(10)
+
+        label = QLabel("查看训练")
+        label.setObjectName("caption")
+        layout.addWidget(label)
+
+        self.run_combo = QComboBox()
+        self.run_combo.setMinimumWidth(180)
+        self.run_combo.setToolTip("同一个项目每训练一次，就多一条记录。默认看最新的一次")
+        self.run_combo.currentIndexChanged.connect(self.on_run_changed)
+        layout.addWidget(self.run_combo)
+
+        self.run_hint = QLabel()
+        self.run_hint.setObjectName("caption")
+        layout.addWidget(self.run_hint)
+
+        layout.addStretch()
+
+        self.btn_refresh = QPushButton("刷新")
+        self.btn_refresh.setObjectName("ghost")
+        self.btn_refresh.setToolTip("重新扫描训练结果目录")
+        self.btn_refresh.clicked.connect(self.scan_runs_directory)
+        layout.addWidget(self.btn_refresh)
+
+        return card
+
+    def create_metrics_card(self) -> QFrame:
+        """③ 四个关键指标，每个配一行人话。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(20, 16, 20, 16)
+        layout.setSpacing(12)
+
+        title = QLabel("关键指标")
         title.setObjectName("title")
-        title.setStyleSheet("font-size: 16px; font-weight: bold; margin-bottom: 8px;")
-        main_layout.addWidget(title)
-        
-        # 主分割器
-        splitter = QSplitter(Qt.Orientation.Horizontal)
-        
-        # 左侧：图像列表
-        left_panel = self.create_image_list_panel()
-        splitter.addWidget(left_panel)
-        
-        # 右侧：图像显示
-        right_panel = self.create_image_display_panel()
-        splitter.addWidget(right_panel)
-        
-        splitter.setSizes([300, 900])
-        main_layout.addWidget(splitter)
-        
-        # 底部：指标和导出
-        bottom_panel = self.create_metrics_export_panel()
-        main_layout.addWidget(bottom_panel)
-    
-    def create_image_list_panel(self) -> QWidget:
-        """创建图像列表面板"""
-        panel = QWidget()
-        layout = QVBoxLayout(panel)
-        
-        # 标题
-        list_title = QLabel("结果图像")
-        list_title.setStyleSheet("font-weight: bold; margin-bottom: 8px;")
-        layout.addWidget(list_title)
-        
-        # 刷新按钮
-        refresh_btn = QPushButton("🔄 刷新")
-        refresh_btn.clicked.connect(self.scan_runs_directory)
-        layout.addWidget(refresh_btn)
-        
-        # 图像列表
-        self.image_list = QListWidget()
-        self.image_list.setObjectName("image_list")
-        
-        # 简单样式
-        self.image_list.setStyleSheet('''
-            QListWidget {
-                background-color: #252526;
-                border: 1px solid #3e3e42;
-                border-radius: 6px;
-                padding: 4px;
-            }
-            QListWidget::item {
-                padding: 8px;
-                border-radius: 4px;
-            }
-            QListWidget::item:selected {
-                background-color: #007ACC;
-                color: white;
-            }
-        ''')
-        
-        self.image_list.itemClicked.connect(self.on_image_selected)
-        layout.addWidget(self.image_list)
-        
-        return panel
-    
-    def create_image_display_panel(self) -> QWidget:
-        """创建图像显示面板"""
-        panel = QWidget()
-        layout = QVBoxLayout(panel)
-        
-        # 标题
-        display_title = QLabel("图像预览")
-        display_title.setStyleSheet("font-weight: bold; margin-bottom: 8px;")
-        layout.addWidget(display_title)
-        
-        # 图像容器
-        self.image_container = QWidget()
-        self.image_container.setObjectName("image_container")
-        
-        self.image_container.setStyleSheet('''
-            QWidget {
-                background-color: #252526;
-                border: 1px solid #3e3e42;
-                border-radius: 6px;
-                min-height: 400px;
-            }
-        ''')
-        
-        self.image_layout = QVBoxLayout(self.image_container)
-        self.image_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
-        # 预览标签
-        self.image_label = QLabel("选择左侧图像查看预览")
-        self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.image_label.setStyleSheet("color: #858585;")
-        self.image_layout.addWidget(self.image_label)
-        
-        scroll_area = QScrollArea()
-        scroll_area.setWidget(self.image_container)
-        scroll_area.setWidgetResizable(True)
-        layout.addWidget(scroll_area)
-        
-        return panel
-    
-    def create_metrics_export_panel(self) -> QWidget:
-        """创建指标和导出面板"""
-        panel = QGroupBox("训练指标与导出")
-        
-        panel.setStyleSheet('''
-            QGroupBox {
-                border: 1px solid #3e3e42;
-                border-radius: 6px;
-                padding: 10px;
-                margin-top: 10px;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px;
-            }
-        ''')
-        
-        layout = QVBoxLayout(panel)
-        
-        # 指标网格
-        metrics_grid = QGridLayout()
-        metrics_grid.setSpacing(10)
-        
-        # 指标标签
-        metrics = ['mAP50', 'mAP50_95', '精确率', '召回率']
+        layout.addWidget(title)
+
+        grid = QGridLayout()
+        grid.setSpacing(10)
+
         self.metric_labels = {}
-        
-        for i, metric in enumerate(metrics):
-            label = QLabel(metric + ':')
-            value_label = QLabel('--')
-            value_label.setObjectName(f"metric_{metric.lower()}")
-            value_label.setStyleSheet("font-weight: bold;")
-            self.metric_labels[metric] = value_label
-            
-            metrics_grid.addWidget(label, i, 0)
-            metrics_grid.addWidget(value_label, i, 1)
-        
-        layout.addLayout(metrics_grid)
-        
-        # 导出按钮
-        export_layout = QHBoxLayout()
-        
-        self.btn_export_onnx = QPushButton("导出为ONNX")
-        self.btn_export_onnx.clicked.connect(lambda: self.export_model('onnx'))
-        export_layout.addWidget(self.btn_export_onnx)
-        
-        self.btn_export_tensorrt = QPushButton("导出为TensorRT")
-        self.btn_export_tensorrt.clicked.connect(lambda: self.export_model('tensorrt'))
-        export_layout.addWidget(self.btn_export_tensorrt)
-        
-        self.btn_export_torchscript = QPushButton("导出为TorchScript")
-        self.btn_export_torchscript.clicked.connect(lambda: self.export_model('torchscript'))
-        export_layout.addWidget(self.btn_export_torchscript)
-        
-        self.btn_export_pt = QPushButton("导出为pt")
-        self.btn_export_pt.clicked.connect(self.export_model_pt)
-        export_layout.addWidget(self.btn_export_pt)
-        
-        # 导出结果文件夹按钮（使用不同颜色）
+        for i, spec in enumerate(METRIC_SPECS):
+            tile = QFrame()
+            # 选择器必须写死在 QFrame#metric_tile 上：不带选择器的属性会顺着
+            # 继承链落到里面的两个 QLabel，指标名和数值各自套一个框，白底上一眼就看出来
+            tile.setObjectName("metric_tile")
+            tile.setStyleSheet(
+                f"QFrame#metric_tile {{"
+                f"  background-color: {COLORS['background']};"
+                f"  border: 1px solid {COLORS['border']};"
+                f"  border-radius: {RADIUS_SM}px;"
+                f"}}"
+            )
+            tile.setToolTip(spec['tip'])
+
+            tile_layout = QVBoxLayout(tile)
+            tile_layout.setContentsMargins(14, 10, 14, 10)
+            tile_layout.setSpacing(2)
+
+            name = QLabel(spec['title'])
+            name.setObjectName("caption")
+            tile_layout.addWidget(name)
+
+            value = QLabel("--")
+            value.setObjectName("value")
+            self.metric_labels[spec['key']] = value
+            tile_layout.addWidget(value)
+
+            grid.addWidget(tile, 0, i)
+            grid.setColumnStretch(i, 1)
+
+        # 一行四个，不是 2×2：四个指标是并列的，横着排一眼扫完。
+        # 排成 2×2 之后，宽屏下每块要被拉到 570px 宽，里面只有一个小标题和一个数字，
+        # 剩下的全是空白——看起来不是「留白」，是「没做完」。
+        layout.addLayout(grid)
+
+        self.metrics_source = QLabel()
+        self.metrics_source.setObjectName("caption")
+        self.metrics_source.setWordWrap(True)
+        layout.addWidget(self.metrics_source)
+
+        return card
+
+    def create_gallery_card(self) -> QFrame:
+        """④ 曲线 / 预测示例 / 其他图，一次只铺开一张。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(20, 16, 20, 16)
+        layout.setSpacing(10)
+
+        title = QLabel("训练过程与预测示例")
+        title.setObjectName("title")
+        layout.addWidget(title)
+
+        self.tabs = QTabWidget()
+
+        self.chart_pane = PreviewPane("这次训练没有生成曲线图。训练可能中途停了。")
+        self.tabs.addTab(self.chart_pane, "训练曲线")
+
+        self.pred_pane = PreviewPane("这次训练没有留下预测示例图。")
+        self.tabs.addTab(self.pred_pane, "预测示例")
+
+        self.other_pane = PreviewPane("没有其他图像。")
+        self.tabs.addTab(self.other_pane, "其他图像")
+
+        layout.addWidget(self.tabs, 1)
+        return card
+
+    def create_export_card(self) -> QFrame:
+        """⑤ 模型文件在哪、能不能导出。主操作就这一个。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(20, 16, 20, 16)
+        layout.setSpacing(10)
+
+        title = QLabel("模型文件与导出")
+        title.setObjectName("title")
+        layout.addWidget(title)
+
+        self.model_info = QLabel()
+        self.model_info.setObjectName("subtitle")
+        self.model_info.setWordWrap(True)
+        layout.addWidget(self.model_info)
+
+        row = QHBoxLayout()
+        row.setSpacing(10)
+
+        self.btn_export_model = QPushButton("导出模型")
+        self.btn_export_model.setObjectName("primary")
+        self.btn_export_model.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_export_model.setMinimumHeight(34)
+
+        export_menu = QMenu(self)
+        for fmt, text, tip in EXPORT_FORMATS:
+            action = export_menu.addAction(text)
+            action.setToolTip(tip)
+            action.triggered.connect(lambda _checked, f=fmt: self.on_export_format(f))
+        self.btn_export_model.setMenu(export_menu)
+        row.addWidget(self.btn_export_model)
+
         self.btn_export_folder = QPushButton("导出结果文件夹")
-        self.btn_export_folder.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {COLORS['primary']};
-                color: white;
-                font-weight: bold;
-            }}
-        """)
+        self.btn_export_folder.setToolTip("把这次训练的整个目录（曲线图、指标、权重）复制到别处")
         self.btn_export_folder.clicked.connect(self.export_result_folder)
-        export_layout.addWidget(self.btn_export_folder)
-        
-        export_layout.addStretch()
-        layout.addLayout(export_layout)
-        
-        return panel
-    
+        row.addWidget(self.btn_export_folder)
+
+        row.addStretch()
+        layout.addLayout(row)
+
+        self.export_status = QLabel()
+        self.export_status.setObjectName("caption")
+        self.export_status.setWordWrap(True)
+        layout.addWidget(self.export_status)
+
+        return card
+
+    def create_empty_view(self) -> EmptyState:
+        state = EmptyState("", "")
+        self.btn_recheck = state.add_action("重新检查", self.scan_runs_directory, primary=True)
+        self.empty_state = state
+        return state
+
+    def create_loading_view(self) -> QWidget:
+        holder = QWidget()
+        layout = QVBoxLayout(holder)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        label = QLabel("正在读取训练结果…")
+        label.setObjectName("subtitle")
+        label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(label)
+
+        return holder
+
+    # ==================== 页面状态 ====================
+
+    def _show_empty(self, title: str, message: str, show_action: bool = True):
+        self.empty_state.set_text(title, message)
+        self.btn_recheck.setVisible(show_action)
+        self.view_stack.setCurrentIndex(1)
+
+    def _show_loading(self):
+        self.view_stack.setCurrentIndex(2)
+        QApplication.processEvents()
+
+    # ==================== 训练记录 ====================
+
     def scan_runs_directory(self):
-        """扫描runs目录"""
-        self.image_list.clear()
-        
-        # 递归搜索runs目录下的所有训练结果文件夹
-        runs_dir = "runs"
-        
-        if not os.path.exists(runs_dir):
-            QMessageBox.warning(self, "提示", "runs目录不存在")
-            return
-        
-        # 递归查找所有包含weights文件夹的目录（这些是训练结果目录）
-        projects = []
-        for root, dirs, files in os.walk(runs_dir):
-            if 'weights' in dirs:
-                # 提取目录名（相对于runs目录）
-                rel_path = os.path.relpath(root, runs_dir)
-                projects.append(rel_path)
-        
-        # 过滤出与当前项目对应的结果（格式为exp_项目ID）
-        project_runs = []
-        for project in projects:
-            if project.startswith(f"exp_{self.current_project_id}"):
-                project_runs.append(project)
-        
-        # 如果没有找到对应项目的结果，查找包含项目ID的文件夹
-        if not project_runs:
-            for project in projects:
-                if str(self.current_project_id) in project:
-                    project_runs.append(project)
-        
-        # 如果还是没有，显示所有结果但标记为非对应
-        if not project_runs:
-            project_runs = projects
-            QMessageBox.information(self, "提示", f"未找到与项目 {self.current_project_id} 对应的训练结果，显示所有可用结果")
-        
-        if not project_runs:
-            QMessageBox.warning(self, "提示", "没有找到训练项目")
-            return
-        
-        # 选择最新的项目结果
-        latest_project = sorted(project_runs)[-1]
-        project_dir = os.path.join(runs_dir, latest_project)
-        
-        # 找到所有图像文件
-        image_extensions = ['.png', '.jpg', '.jpeg']
-        image_files = []
-        
-        for root, _, files in os.walk(project_dir):
-            for file in files:
-                if any(file.endswith(ext) for ext in image_extensions):
-                    image_files.append((file, os.path.join(root, file)))
-        
-        # 清空列表并添加图像
-        self.image_list.clear()
-        self.current_images = image_files
-        
-        for filename, filepath in image_files:
-            item = QListWidgetItem(filename)
-            item.setData(Qt.ItemDataRole.UserRole, filepath)
-            self.image_list.addItem(item)
-        
-        # 更新标题
-        self.setWindowTitle(f"训练结果 - 项目 {self.current_project_id} - {latest_project}")
-        
-        # 读取训练指标
-        self.read_training_metrics(project_dir)
-    
-    def on_image_selected(self, item):
-        """选择图像"""
-        filepath = item.data(Qt.ItemDataRole.UserRole)
-        if filepath and os.path.exists(filepath):
-            self.display_image(filepath)
-    
-    def display_image(self, filepath):
-        """显示图像"""
-        try:
-            # 使用OpenCV读取图像
-            img = cv2.imread(filepath)
-            if img is None:
-                self.image_label.setText("无法加载图像")
-                return
-            
-            # 转换为RGB
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            height, width, channel = img.shape
-            
-            # 创建QImage
-            qimg = QImage(img.data, width, height, width * channel, QImage.Format.Format_RGB888)
-            pixmap = QPixmap.fromImage(qimg)
-            
-            # 调整大小以适应容器
-            container_width = self.image_container.width() - 40
-            container_height = self.image_container.height() - 40
-            
-            if pixmap.width() > container_width or pixmap.height() > container_height:
-                pixmap = pixmap.scaled(
-                    container_width, container_height,
-                    Qt.AspectRatioMode.KeepAspectRatio,
-                    Qt.TransformationMode.SmoothTransformation
-                )
-            
-            # 更新标签
-            self.image_label.setPixmap(pixmap)
-            self.image_label.setText("")
-            
-        except Exception as e:
-            self.image_label.setText(f"加载失败: {str(e)}")
-    
-    def export_model(self, format_type):
-        """导出模型"""
+        """扫描当前项目的训练记录。
+
+        目录发现走 gui/workflow.find_project_runs，与侧边栏、前置条件页同源。
+        """
         if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择一个项目")
+            self.current_run = None
+            self._show_empty(
+                "还没有选择项目",
+                "训练结果是跟着项目走的。先在左上角「当前项目」里选一个项目。",
+                show_action=False,
+            )
             return
-        
-        runs_dir = "runs"
-        
-        if not os.path.exists(runs_dir):
-            QMessageBox.warning(self, "提示", "runs目录不存在")
+
+        self._show_loading()
+        runs = find_project_runs(self.current_project_id)
+
+        if not runs:
+            self.current_run = None
+            self.current_metrics = {}
+            self._show_empty(
+                "这个项目还没有训练记录",
+                "训练完成后，点「重新检查」就能看到。",
+            )
             return
-        
-        # 递归查找所有包含weights文件夹的目录
-        projects = []
-        for root, dirs, files in os.walk(runs_dir):
-            if 'weights' in dirs:
-                rel_path = os.path.relpath(root, runs_dir)
-                projects.append(rel_path)
-        
-        # 过滤出与当前项目对应的结果
-        project_runs = []
-        for project in projects:
-            if project.startswith(f"exp_{self.current_project_id}") or str(self.current_project_id) in project:
-                project_runs.append(project)
-        
-        if not project_runs:
-            project_runs = projects
-        
-        if not project_runs:
-            QMessageBox.warning(self, "提示", "没有找到训练项目")
+
+        # 最新的一次放在最上面，默认就看它
+        runs = list(reversed(runs))
+
+        self.run_combo.blockSignals(True)
+        self.run_combo.clear()
+        for i, run in enumerate(runs):
+            text = f"{run.name}（最新）" if i == 0 else run.name
+            self.run_combo.addItem(text, str(run))
+        self.run_combo.setCurrentIndex(0)
+        self.run_combo.blockSignals(False)
+
+        self.run_hint.setText(f"共 {len(runs)} 次训练")
+        self.view_stack.setCurrentIndex(0)
+        self.load_run(runs[0])
+
+    def on_run_changed(self, index: int):
+        path = self.run_combo.itemData(index)
+        if path:
+            self.load_run(Path(path))
+
+    def load_run(self, run_dir: Path):
+        """把一次训练的指标、图、模型文件都摆出来。"""
+        self.current_run = run_dir
+        self._set_export_status("")
+
+        self.read_training_metrics(str(run_dir))
+        self._load_images(run_dir)
+        self._update_model_info(run_dir)
+
+    # ==================== 指标 ====================
+
+    def read_training_metrics(self, project_dir) -> Optional[Dict[str, float]]:
+        """从 results.csv 读取训练指标（取最后一轮，算法与原来一致）。"""
+        results_csv = os.path.join(str(project_dir), "results.csv")
+        self.current_metrics = {}
+        self.metrics_source.setToolTip("")
+
+        if not os.path.exists(results_csv):
+            self._clear_metrics()
+            self.metrics_source.setText("这次训练目录里没有 results.csv，读不到指标。")
+            self.metrics_source.setToolTip(
+                "训练很可能中途停了。下面的图和模型文件如果存在，仍然可以看、可以导出。"
+            )
+            self._apply_verdict(None)
+            return None
+
+        try:
+            with open(results_csv, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+
+            if not rows:
+                self._clear_metrics()
+                self.metrics_source.setText("results.csv 是空的，读不到指标。")
+                self._apply_verdict(None)
+                return None
+
+            # 有些 ultralytics 版本会在表头列名前后留空格
+            last_row = {
+                (key or '').strip(): value
+                for key, value in rows[-1].items()
+            }
+
+            metrics = {
+                'mAP50': float(last_row.get('metrics/mAP50(B)', 0)),
+                'mAP50_95': float(last_row.get('metrics/mAP50-95(B)', 0)),
+                '精确率': float(last_row.get('metrics/precision(B)', 0)),
+                '召回率': float(last_row.get('metrics/recall(B)', 0)),
+            }
+
+            self.current_metrics = metrics
+            self.update_metrics(metrics)
+            self.metrics_source.setText(
+                f"最后一轮在验证集上的成绩 · 共 {len(rows)} 轮"
+            )
+            return metrics
+
+        except Exception as e:
+            print(f"读取指标失败: {e}")
+            self._clear_metrics()
+            self.metrics_source.setText(f"读取 results.csv 失败：{e}")
+            self._apply_verdict(None)
+            return None
+
+    def update_metrics(self, metrics: Dict):
+        """更新指标显示。"""
+        for metric, value in metrics.items():
+            if metric in self.metric_labels:
+                self.metric_labels[metric].setText(f"{value:.4f}")
+        self._apply_verdict(metrics.get('mAP50'))
+
+    def _clear_metrics(self):
+        for label in self.metric_labels.values():
+            label.setText("--")
+
+    def _apply_verdict(self, map50: Optional[float]):
+        """把 mAP50 翻译成一句新手能直接用的结论。"""
+        if map50 is None:
+            state, mark, title = 'unknown', '?', "读不到这次训练的成绩"
+            detail = "没有找到指标文件，无法判断这次训练好不好。"
+            tip = "训练可能中途停了，可以回到「模型训练」重新跑一次。"
+        elif map50 >= 0.7:
+            state, mark, title = 'success', '✓', "这次训练看起来可以用"
+            detail = f"mAP50 {map50:.2f}，在验证集上表现不错。"
+            tip = "导出前可以先去「模型测试」用几张新图片确认一下。"
+        elif map50 >= 0.4:
+            state, mark, title = 'warning', '!', "勉强能用，但还有明显提升空间"
+            detail = f"mAP50 {map50:.2f}，模型能认出不少目标，但漏检和误报还比较多。"
+            tip = "想更好：多标一些图片，或把训练轮数调高再训一次。"
+        else:
+            state, mark, title = 'error', '×', "效果偏弱，先别急着用"
+            detail = f"mAP50 {map50:.2f}，模型还没学明白。"
+            tip = "最常见原因：标注太少、类别标得不一致、训练轮数太少。"
+
+        self.verdict_detail.setToolTip(tip)
+
+        color = {
+            'success': COLORS['success'],
+            'warning': COLORS['warning'],
+            'error': COLORS['error'],
+            'unknown': COLORS['text_secondary'],
+        }[state]
+
+        # 不只靠颜色区分：符号 + 文字本身也说明了结论
+        self.verdict_badge.setText(mark)
+        self.verdict_badge.setStyleSheet(
+            f"color: {color};"
+            f"border: 1px solid {color};"
+            f"border-radius: 11px;"
+            f"min-width: 22px; max-width: 22px;"
+            f"min-height: 22px; max-height: 22px;"
+            f"font-weight: 600;"
+        )
+        self.verdict_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.verdict_title.setText(title)
+        self.verdict_detail.setText(detail)
+
+    # ==================== 图像 ====================
+
+    def _load_images(self, run_dir: Path):
+        """把结果图按「曲线 / 预测示例 / 其他」分到三个标签页。"""
+        charts: List[Tuple[str, str]] = []
+        preds: List[Tuple[str, str]] = []
+        others: List[Tuple[str, str]] = []
+
+        for root, _, files in os.walk(run_dir):
+            for filename in sorted(files):
+                if not filename.lower().endswith(IMAGE_EXTENSIONS):
+                    continue
+                path = os.path.join(root, filename)
+                if filename.startswith(('val_batch', 'train_batch')):
+                    preds.append((filename, path))
+                elif chart_rank(filename) < len(CHART_ORDER):
+                    charts.append((filename, path))
+                else:
+                    others.append((filename, path))
+
+        charts.sort(key=lambda item: chart_rank(item[0]))
+
+        self.chart_pane.set_images(charts)
+        self.pred_pane.set_images(preds)
+        self.other_pane.set_images(others)
+
+        self.tabs.setTabEnabled(2, bool(others))
+
+    # ==================== 模型文件与导出 ====================
+
+    def _best_model(self) -> Optional[Path]:
+        if not self.current_run:
+            return None
+        best = self.current_run / "weights" / "best.pt"
+        return best if best.exists() else None
+
+    def _update_model_info(self, run_dir: Path):
+        """模型文件在不在、多大、在哪。不在就把导出按钮禁掉并说明原因。"""
+        best = self._best_model()
+
+        if best:
+            size_mb = best.stat().st_size / (1024 * 1024)
+            self.model_info.setText(
+                f"best.pt · {size_mb:.1f} MB · {self._display_path(best.parent)}"
+            )
+            self.model_info.setToolTip("best.pt 是这次训练中表现最好的一轮权重，导出、测试用的都是它。")
+            self.model_info.setStyleSheet("")
+            self.btn_export_model.setEnabled(True)
+            self.btn_export_model.setToolTip(
+                "选择一种格式导出这次训练的 best.pt；ONNX / TensorRT 转换可能要几十秒，期间界面会没有响应。"
+            )
+        else:
+            self.model_info.setText(f"没有在 {self._display_path(run_dir / 'weights')} 找到 best.pt。")
+            self.model_info.setToolTip("训练可能中途被停掉了，没来得及保存权重。回到「模型训练」重新跑一次即可。")
+            self.model_info.setStyleSheet(f"color: {COLORS['warning']};")
+            self.btn_export_model.setEnabled(False)
+            self.btn_export_model.setToolTip("没有 best.pt，没有可导出的模型")
+
+        self.btn_export_folder.setEnabled(run_dir.exists())
+
+    def _display_path(self, path: Path) -> str:
+        """尽量显示成 runs/train/exp_1 这样的短路径。
+
+        基准是应用根目录，不是当前工作目录：打包成 EzYOLO.app 双击启动时 cwd 是 /，
+        以前这里会退回去显示一长串绝对路径。
+        """
+        try:
+            return str(path.relative_to(APP_ROOT))
+        except ValueError:
+            return str(path)
+
+    def _set_export_status(self, text: str, state: str = 'idle'):
+        color = {
+            'idle': COLORS['text_secondary'],
+            'busy': COLORS['text_secondary'],
+            'success': COLORS['success'],
+            'error': COLORS['error'],
+        }[state]
+        self.export_status.setText(text)
+        self.export_status.setToolTip("")
+        self.export_status.setStyleSheet(f"color: {color};")
+
+    def _begin_export(self, text: str):
+        self.btn_export_model.setEnabled(False)
+        self.btn_export_folder.setEnabled(False)
+        self._set_export_status(text, 'busy')
+        QApplication.processEvents()
+
+    def _end_export(self, text: str, state: str):
+        self.btn_export_model.setEnabled(self._best_model() is not None)
+        self.btn_export_folder.setEnabled(bool(self.current_run))
+        self._set_export_status(text, state)
+
+    def _end_export_success(self, path: str):
+        """导出成功，路径可能很长：卡片里只显示省略后的样子，完整路径放 tooltip。"""
+        prefix = "导出成功："
+        metrics = self.export_status.fontMetrics()
+        available = max(self.export_status.width() - metrics.horizontalAdvance(prefix) - 8, 160)
+        elided = metrics.elidedText(path, Qt.TextElideMode.ElideMiddle, available)
+        self._end_export(f"{prefix}{elided}", 'success')
+        self.export_status.setToolTip(path)
+
+    def on_export_format(self, format_type: str):
+        if format_type == 'pt':
+            self.export_model_pt()
+        else:
+            self.export_model(format_type)
+
+    def export_model(self, format_type):
+        """导出模型（onnx / torchscript / tensorrt）。"""
+        best_model = self._best_model()
+        if not best_model:
+            QMessageBox.warning(self, "提示", "这次训练没有 best.pt，无法导出")
             return
-        
-        latest_project = sorted(project_runs)[-1]
-        project_dir = os.path.join(runs_dir, latest_project)
-        
-        # 找到best.pt文件
-        best_model = os.path.join(project_dir, "weights", "best.pt")
-        if not os.path.exists(best_model):
-            QMessageBox.warning(self, "提示", "未找到best.pt模型文件")
-            return
-        
+
+        project_dir = str(self.current_run)
+
         # 显示导出配置对话框
         export_config = {}
         if format_type == 'onnx':
@@ -687,7 +1110,7 @@ class ResultPage(QWidget):
             if dialog.exec() != QDialog.DialogCode.Accepted:
                 return
             export_config = dialog.get_config()
-        
+
         # 选择导出路径
         file_filter = ""
         if format_type == 'onnx':
@@ -696,41 +1119,43 @@ class ResultPage(QWidget):
             file_filter = "TensorRT files (*.engine)"
         elif format_type == 'torchscript':
             file_filter = "TorchScript files (*.pt)"
-        
+
         default_name = f"best.{format_type}"
         if format_type == 'tensorrt':
             default_name = "best.engine"
-        
+
         save_path, _ = QFileDialog.getSaveFileName(
-            self, f"导出为{format_type.upper()}", 
+            self, f"导出为{format_type.upper()}",
             os.path.join(project_dir, default_name),
             file_filter
         )
-        
+
         if not save_path:
             return
-        
+
+        self._begin_export(f"正在导出 {format_type.upper()}…")
+
         try:
             from ultralytics import YOLO
-            
+
             # 加载模型
-            model = YOLO(best_model)
-            
+            model = YOLO(str(best_model))
+
             # 构建导出参数（Ultralytics 的 TensorRT 导出格式名是 engine）
             export_format = 'engine' if format_type == 'tensorrt' else format_type
             export_kwargs = {'format': export_format}
-            
+
             # 添加配置参数（针对ONNX和TensorRT）
             if format_type in ['onnx', 'tensorrt']:
                 export_kwargs.update(export_config)
                 # 过滤掉None值
                 export_kwargs = {k: v for k, v in export_kwargs.items() if v is not None}
-            
+
             print(f"[导出] 参数: {export_kwargs}")
-            
+
             # 导出
             model.export(**export_kwargs)
-            
+
             # 移动文件
             if format_type == 'onnx':
                 export_path = os.path.join(project_dir, "weights", "best.onnx")
@@ -738,188 +1163,94 @@ class ResultPage(QWidget):
                 export_path = os.path.join(project_dir, "weights", "best.engine")
             elif format_type == 'torchscript':
                 export_path = os.path.join(project_dir, "weights", "best.torchscript.pt")
-            
+
             if os.path.exists(export_path):
-                import shutil
                 shutil.move(export_path, save_path)
+                self._end_export_success(save_path)
                 QMessageBox.information(self, "成功", f"模型已导出为 {save_path}")
             else:
+                self._end_export("导出失败：没有生成模型文件，详情见控制台日志。", 'error')
                 QMessageBox.warning(self, "失败", "导出失败，请检查日志")
-                
+
         except Exception as e:
+            self._end_export(f"导出失败：{e}", 'error')
             QMessageBox.warning(self, "错误", f"导出出错: {str(e)}")
-    
+
     def export_model_pt(self):
-        """导出为pt文件"""
-        if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择一个项目")
+        """导出为pt文件（直接复制 best.pt）。"""
+        best_model = self._best_model()
+        if not best_model:
+            QMessageBox.warning(self, "提示", "这次训练没有 best.pt，无法导出")
             return
-        
-        runs_dir = "runs"
-        
-        if not os.path.exists(runs_dir):
-            QMessageBox.warning(self, "提示", "runs目录不存在")
-            return
-        
-        # 递归查找所有包含weights文件夹的目录
-        projects = []
-        for root, dirs, files in os.walk(runs_dir):
-            if 'weights' in dirs:
-                rel_path = os.path.relpath(root, runs_dir)
-                projects.append(rel_path)
-        
-        # 过滤出与当前项目对应的结果
-        project_runs = []
-        for project in projects:
-            if project.startswith(f"exp_{self.current_project_id}") or str(self.current_project_id) in project:
-                project_runs.append(project)
-        
-        if not project_runs:
-            project_runs = projects
-        
-        if not project_runs:
-            QMessageBox.warning(self, "提示", "没有找到训练项目")
-            return
-        
-        latest_project = sorted(project_runs)[-1]
-        project_dir = os.path.join(runs_dir, latest_project)
-        
-        # 找到best.pt文件
-        best_model = os.path.join(project_dir, "weights", "best.pt")
-        if not os.path.exists(best_model):
-            QMessageBox.warning(self, "提示", "未找到best.pt模型文件")
-            return
-        
-        # 选择导出路径
+
         save_path, _ = QFileDialog.getSaveFileName(
-            self, "导出为pt", 
-            os.path.join(project_dir, "best.pt"),
+            self, "导出为pt",
+            os.path.join(str(self.current_run), "best.pt"),
             "PyTorch files (*.pt)"
         )
-        
+
         if not save_path:
             return
-        
+
+        self._begin_export("正在导出 PyTorch 权重…")
+
         try:
-            import shutil
-            # 复制文件
-            shutil.copy2(best_model, save_path)
+            shutil.copy2(str(best_model), save_path)
+            self._end_export_success(save_path)
             QMessageBox.information(self, "成功", f"模型已导出为 {save_path}")
-            
+
         except Exception as e:
+            self._end_export(f"导出失败：{e}", 'error')
             QMessageBox.warning(self, "错误", f"导出出错: {str(e)}")
-    
+
     def export_result_folder(self):
-        """导出结果文件夹"""
-        if not self.current_project_id:
-            QMessageBox.warning(self, "提示", "请先选择一个项目")
+        """导出整个结果文件夹。"""
+        if not self.current_run or not self.current_run.exists():
+            QMessageBox.warning(self, "提示", "没有可导出的训练结果")
             return
-        
-        runs_dir = "runs"
-        
-        if not os.path.exists(runs_dir):
-            QMessageBox.warning(self, "提示", "runs目录不存在")
-            return
-        
-        # 递归查找所有包含weights文件夹的目录
-        projects = []
-        for root, dirs, files in os.walk(runs_dir):
-            if 'weights' in dirs:
-                rel_path = os.path.relpath(root, runs_dir)
-                projects.append(rel_path)
-        
-        # 过滤出与当前项目对应的结果
-        project_runs = []
-        for project in projects:
-            if project.startswith(f"exp_{self.current_project_id}") or str(self.current_project_id) in project:
-                project_runs.append(project)
-        
-        if not project_runs:
-            project_runs = projects
-        
-        if not project_runs:
-            QMessageBox.warning(self, "提示", "没有找到训练项目")
-            return
-        
-        latest_project = sorted(project_runs)[-1]
-        project_dir = os.path.join(runs_dir, latest_project)
-        
+
+        run_dir = self.current_run
+
         # 选择目标文件夹
         save_dir = QFileDialog.getExistingDirectory(
-            self, "选择导出目标文件夹", 
-            os.path.dirname(project_dir)
+            self, "选择导出目标文件夹",
+            str(run_dir.parent)
         )
-        
+
         if not save_dir:
             return
-        
+
+        target_dir = os.path.join(save_dir, run_dir.name)
+
+        # 会覆盖同名文件夹，先说清楚再动手
+        if os.path.exists(target_dir):
+            confirm = QMessageBox.question(
+                self, "目标文件夹已存在",
+                f"{target_dir}\n\n这个文件夹已经存在，继续会先删除它再写入。要继续吗？",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if confirm != QMessageBox.StandardButton.Yes:
+                return
+
+        self._begin_export("正在复制结果文件夹…")
+
         try:
-            import shutil
-            # 目标文件夹路径
-            target_dir = os.path.join(save_dir, latest_project)
-            
-            # 如果目标文件夹已存在，删除它
             if os.path.exists(target_dir):
                 shutil.rmtree(target_dir)
-            
-            # 复制整个文件夹
-            shutil.copytree(project_dir, target_dir)
+
+            shutil.copytree(str(run_dir), target_dir)
+            self._end_export_success(target_dir)
             QMessageBox.information(self, "成功", f"结果文件夹已导出到 {target_dir}")
-            
+
         except Exception as e:
+            self._end_export(f"导出失败：{e}", 'error')
             QMessageBox.warning(self, "错误", f"导出出错: {str(e)}")
-    
-    def update_metrics(self, metrics: Dict):
-        """更新指标"""
-        for metric, value in metrics.items():
-            if metric in self.metric_labels:
-                self.metric_labels[metric].setText(f"{value:.4f}")
-    
-    def read_training_metrics(self, project_dir):
-        """从results.csv读取训练指标"""
-        results_csv = os.path.join(project_dir, "results.csv")
-        
-        if not os.path.exists(results_csv):
-            # 没有results.csv文件
-            return
-        
-        try:
-            import csv
-            
-            with open(results_csv, 'r', encoding='utf-8') as f:
-                reader = csv.DictReader(f)
-                rows = list(reader)
-                
-                if not rows:
-                    return
-                
-                # 读取最后一行数据
-                last_row = rows[-1]
-                
-                # 提取指标
-                precision = float(last_row.get('metrics/precision(B)', 0))
-                recall = float(last_row.get('metrics/recall(B)', 0))
-                map50 = float(last_row.get('metrics/mAP50(B)', 0))
-                map50_95 = float(last_row.get('metrics/mAP50-95(B)', 0))
-                
-                # 更新指标显示
-                if 'mAP50' in self.metric_labels:
-                    self.metric_labels['mAP50'].setText(f"{map50:.4f}")
-                if 'mAP50_95' in self.metric_labels:
-                    self.metric_labels['mAP50_95'].setText(f"{map50_95:.4f}")
-                if '精确率' in self.metric_labels:
-                    self.metric_labels['精确率'].setText(f"{precision:.4f}")
-                if '召回率' in self.metric_labels:
-                    self.metric_labels['召回率'].setText(f"{recall:.4f}")
-                    
-        except Exception as e:
-            print(f"读取指标失败: {e}")
 
 
 if __name__ == "__main__":
-    from PyQt6.QtWidgets import QApplication
     import sys
-    
+
     app = QApplication(sys.argv)
     window = ResultPage()
     window.show()

--- a/gui/pages/settings_page.py
+++ b/gui/pages/settings_page.py
@@ -1,304 +1,490 @@
 # -*- coding: utf-8 -*-
 """
 设置页面
+
+辅助页，不属于主流程，所以视觉上比流程页轻：没有大标题（页头已给），
+只有三组内容 + 一条底部操作栏。
+
+    常用设置      —— 自动保存、预训练模型路径
+    AI 与自动标注 —— 自动标注用的是什么模型，就地打开配置
+    标注快捷键    —— 键位，改完立即生效
+
+保存规则写在界面上，不让用户猜：
+    快捷键改完立即写入；路径和自动保存要点「保存设置」才写入。
 """
 
+import json
+from pathlib import Path
+from typing import Optional
+
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-    QGroupBox, QFormLayout, QComboBox, QSlider, QSpinBox,
-    QFileDialog, QMessageBox, QCheckBox
+    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
+    QLabel, QPushButton, QGroupBox, QSpinBox, QCheckBox,
+    QScrollArea, QFrame, QFileDialog, QInputDialog,
 )
 from PyQt6.QtCore import Qt, QSettings, pyqtSignal
+from PyQt6.QtGui import QKeySequence
 
 from gui.styles import COLORS
+from gui.widgets.elided_label import ElidedLabel
+
+APP_ROOT = Path(__file__).parent.parent.parent
+DEFAULT_PRETRAINED_PATH = APP_ROOT / "pretrained"
+SAM_CONFIG_FILE = APP_ROOT / "config" / "sam_config.json"
+LLM_CONFIG_FILE = APP_ROOT / "config" / "llm_config.json"
+
+# 应用当前固定用浅色主题，仍按原键写回 QSettings
+THEME_NAME = "浅色主题"
+
+# (设置键, 显示名, 默认键位)
+SHORTCUTS = [
+    ("rect_tool_shortcut", "矩形工具", "W"),
+    ("poly_tool_shortcut", "多边形工具", "P"),
+    ("move_tool_shortcut", "移动工具", "V"),
+    ("prev_image_shortcut", "上一张图片", "A"),
+    ("next_image_shortcut", "下一张图片", "D"),
+    ("delete_shortcut", "删除标注", "DELETE"),
+    ("reset_view_shortcut", "重置视图", "R"),
+]
+
+HINT_IDLE = "路径和自动保存的改动，点「保存设置」后才写入。"
+
+
+def normalize_shortcut(text: str) -> str:
+    """把用户输入的键位整理成配置里存的那一个字符串，认不出来就返回空串。
+
+    单个字母/数字照旧转成大写；DELETE、BACKSPACE、SPACE、UP 这类键名交给 Qt 判断，
+    这样默认的 DELETE 被改掉之后还能再输回来。
+    组合键（Ctrl+S）不收：读快捷键的地方是拿单个键位的文本去比对的。
+    """
+    key = " ".join(text.split()).upper()
+    if not key or "+" in key:
+        return ""
+    if len(key) == 1:
+        return key
+
+    seq = QKeySequence.fromString(key)
+    if seq.count() != 1 or seq[0].key() == Qt.Key.Key_unknown:
+        return ""
+    return key
+
+
+def shortcut_key_code(text: str) -> Optional[int]:
+    """把存下来的键位字符串解析成 Qt 键码，认不出来返回 None。"""
+    key = normalize_shortcut(text)
+    if not key:
+        return None
+
+    seq = QKeySequence.fromString(key)
+    if seq.count() != 1:
+        return None
+
+    code = seq[0].key()
+    return None if code == Qt.Key.Key_unknown else code
+
+
+def event_matches_shortcut(event, text: str) -> bool:
+    """这次按键是不是这个快捷键。
+
+    比的是键码，不是 event.text()。DELETE / SPACE / 方向键根本没有可打印字符
+    （event.text() 分别是 '\x7f'、' '、''），拿文本去比永远匹配不上——设置页
+    会照样存下来并显示「已经生效」，实际上键是哑的。
+    单键快捷键带上 Ctrl/Alt/Meta 就不算，免得和 Ctrl+Z 这类组合键抢。
+    """
+    code = shortcut_key_code(text)
+    if code is None or event.key() != code:
+        return False
+
+    blocked = (
+        Qt.KeyboardModifier.ControlModifier
+        | Qt.KeyboardModifier.AltModifier
+        | Qt.KeyboardModifier.MetaModifier
+    )
+    return not (event.modifiers() & blocked)
+
+
+def read_config(path: Path) -> dict:
+    """读配置文件，只用于显示当前状态；读不到就当没配置过。"""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 class SettingsPage(QWidget):
     """设置页面"""
-    
+
     # 主题变化信号
     theme_changed = pyqtSignal(str)  # 发送新的主题名称
-    
+
+    # 请求打开自动标注配置：''=默认页，'sam'=SAM 分割，'llm'=LLM 视觉
+    # 设置页自己不认识 AutoLabelDialog，由主窗口接住并打开标注页那一个实例
+    auto_label_config_requested = pyqtSignal(str)
+
     def __init__(self):
         super().__init__()
         self.settings = QSettings("EzYOLO", "Settings")
+        self.shortcut_buttons = {}
         self.init_ui()
-    
+
     def init_ui(self):
         """初始化界面"""
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("设置")
-        title.setObjectName("title")
-        title.setStyleSheet("font-size: 20px; font-weight: bold;")
-        main_layout.addWidget(title)
-        
-        # 主题设置
-        theme_group = self.create_theme_group()
-        main_layout.addWidget(theme_group)
-        
-        # 路径设置
-        path_group = self.create_path_group()
-        main_layout.addWidget(path_group)
-        
-        # 自动保存设置
-        auto_save_group = self.create_auto_save_group()
-        main_layout.addWidget(auto_save_group)
-        
-        # 快捷键设置（预留）
-        shortcut_group = self.create_shortcut_group()
-        main_layout.addWidget(shortcut_group)
-        
-        # 底部按钮
-        btn_layout = QHBoxLayout()
-        
-        self.btn_save = QPushButton("💾 保存设置")
-        self.btn_save.clicked.connect(self.save_settings)
-        btn_layout.addWidget(self.btn_save)
-        
-        self.btn_reset = QPushButton("🔄 恢复默认")
-        self.btn_reset.clicked.connect(self.reset_settings)
-        btn_layout.addWidget(self.btn_reset)
-        
-        btn_layout.addStretch()
-        main_layout.addLayout(btn_layout)
-    
-    def create_theme_group(self) -> QGroupBox:
-        """创建主题设置组"""
-        group = QGroupBox("主题设置")
-        
-        layout = QFormLayout(group)
-        
-        # 主题选择（只保留深色主题）
-        self.theme_combo = QComboBox()
-        self.theme_combo.addItem("深色主题")
-        # 固定为深色主题
-        self.theme_combo.setCurrentIndex(0)
-        # 禁用下拉框，防止用户修改
-        self.theme_combo.setEnabled(False)
-        layout.addRow("主题:", self.theme_combo)
-        
-        return group
-    
-    def create_path_group(self) -> QGroupBox:
-        """创建路径设置组"""
-        group = QGroupBox("路径设置")
-        
-        layout = QFormLayout(group)
-        
-        # 预训练模型路径
-        path_layout = QHBoxLayout()
-        from pathlib import Path
-        app_root = Path(__file__).parent.parent.parent  # 向上三级到EzYOLO根目录
-        default_pretrained_path = app_root / "pretrained"
-        self.pretrained_path = QLabel(self.settings.value("pretrained_path", str(default_pretrained_path)))
-        self.pretrained_path.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        path_layout.addWidget(self.pretrained_path)
-        
-        btn_browse = QPushButton("浏览")
-        btn_browse.clicked.connect(lambda: self.browse_path("pretrained_path", "选择预训练模型目录"))
-        path_layout.addWidget(btn_browse)
-        
-        layout.addRow("预训练模型路径:", path_layout)
-        
-        return group
-    
-    def create_auto_save_group(self) -> QGroupBox:
-        """创建自动保存设置组"""
-        group = QGroupBox("自动保存设置")
-        
-        layout = QFormLayout(group)
-        
-        # 自动保存间隔
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+
+        body = QWidget()
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(24, 20, 24, 8)
+        body_layout.setSpacing(14)
+
+        # 设置项本身很窄，让分组框铺满一整屏只会把几行字摊成一片空白。
+        # 固定一列内容宽度（宽屏时留白在右侧），窄屏时照常缩。
+        column = QWidget()
+        column.setMaximumWidth(760)
+        column_layout = QVBoxLayout(column)
+        column_layout.setContentsMargins(0, 0, 0, 0)
+        column_layout.setSpacing(14)
+        column_layout.addWidget(self.create_common_group())
+        column_layout.addWidget(self.create_ai_group())
+        column_layout.addWidget(self.create_shortcut_group())
+
+        body_layout.addWidget(column)
+        body_layout.addStretch()
+
+        scroll.setWidget(body)
+        outer.addWidget(scroll, 1)
+
+        divider = QFrame()
+        divider.setObjectName("divider")
+        outer.addWidget(divider)
+        outer.addWidget(self.create_action_bar())
+
+    # ==================== 分组 ====================
+
+    @staticmethod
+    def _caption(text: str) -> QLabel:
+        """行首说明列，右对齐，贴 macOS 表单习惯。"""
+        label = QLabel(text)
+        label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        return label
+
+    def create_common_group(self) -> QGroupBox:
+        """常用设置：自动保存 + 预训练模型路径
+
+        不用 QFormLayout：QMacStyle 下它的值列宽度按 sizeHint 走，长值不跟着
+        分组框伸缩，路径这类内容会过早截断。显式网格 + 列拉伸没有这个问题。
+        """
+        group = QGroupBox("常用设置")
+
+        grid = QGridLayout(group)
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(10)
+        grid.setColumnStretch(1, 1)
+
+        self.auto_save_enabled = QCheckBox("标注过程中自动保存")
+        self.auto_save_enabled.setChecked(
+            self.settings.value("auto_save_enabled", True, type=bool)
+        )
+        self.auto_save_enabled.toggled.connect(self.on_auto_save_toggled)
+        grid.addWidget(self._caption("自动保存:"), 0, 0)
+        grid.addWidget(self.auto_save_enabled, 0, 1, 1, 2)
+
         self.auto_save_interval = QSpinBox()
         self.auto_save_interval.setRange(1, 60)
+        self.auto_save_interval.setSuffix(" 分钟")
         self.auto_save_interval.setValue(int(self.settings.value("auto_save_interval", 5)))
-        layout.addRow("自动保存间隔 (分钟):", self.auto_save_interval)
-        
-        # 启用自动保存
-        self.auto_save_enabled = QCheckBox("启用自动保存")
-        self.auto_save_enabled.setChecked(self.settings.value("auto_save_enabled", True, type=bool))
-        layout.addRow(self.auto_save_enabled)
-        
+        self.auto_save_interval.setEnabled(self.auto_save_enabled.isChecked())
+        self.auto_save_interval.setMaximumWidth(260)
+        self.auto_save_interval.valueChanged.connect(self.mark_dirty)
+        grid.addWidget(self._caption("保存间隔:"), 1, 0)
+        grid.addWidget(self.auto_save_interval, 1, 1, 1, 2,
+                       Qt.AlignmentFlag.AlignLeft)
+
+        self._pretrained_path_value = str(
+            self.settings.value("pretrained_path", str(DEFAULT_PRETRAINED_PATH))
+        )
+        self.pretrained_path = ElidedLabel(mode=Qt.TextElideMode.ElideMiddle)
+        self._refresh_pretrained_path_display()
+        grid.addWidget(self._caption("预训练模型:"), 2, 0)
+        grid.addWidget(self.pretrained_path, 2, 1)
+
+        btn_browse = QPushButton("浏览…")
+        btn_browse.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn_browse.clicked.connect(
+            lambda: self.browse_path("pretrained_path", "选择预训练模型目录")
+        )
+        grid.addWidget(btn_browse, 2, 2)
+
         return group
-    
+
+    def _refresh_pretrained_path_display(self):
+        """路径可能很长：标签按可用宽度中部省略，完整路径和用途说明放 tooltip。"""
+        self.pretrained_path.setText(self._pretrained_path_value)
+        self.pretrained_path.setToolTip(
+            f"{self._pretrained_path_value}\n训练时从这个目录读取 YOLO 预训练权重（.pt 文件）。"
+        )
+
+    def create_ai_group(self) -> QGroupBox:
+        """AI 与自动标注：显示当前用的是什么，并且就地打开配置
+
+        状态值单行显示、装不下省略并给 tooltip——QMacStyle 下 QFormLayout
+        配换行标签会算错行高，文字折行后裁切、上下重叠，所以不走表单布局。
+
+        原来这里只有一句「配置入口在数据标注 → 自动标注」：用户看得到状态，
+        却要自己走到另一个页面、在工具栏里找那个按钮。现在按钮就在状态旁边，
+        点了直接开同一个配置窗口（AutoLabelDialog），关掉后状态跟着刷新。
+        """
+        group = QGroupBox("AI 与自动标注")
+
+        layout = QVBoxLayout(group)
+        layout.setSpacing(10)
+
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(10)
+        grid.setColumnStretch(1, 1)
+
+        self.sam_status = ElidedLabel()
+        grid.addWidget(self._caption("分割模型:"), 0, 0)
+        grid.addWidget(self.sam_status, 0, 1)
+
+        self.btn_config_sam = QPushButton("配置…")
+        self.btn_config_sam.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_config_sam.setToolTip("打开自动标注配置，直接跳到 SAM 分割那一页")
+        self.btn_config_sam.clicked.connect(
+            lambda: self.auto_label_config_requested.emit('sam')
+        )
+        grid.addWidget(self.btn_config_sam, 0, 2)
+
+        self.llm_status = ElidedLabel()
+        grid.addWidget(self._caption("视觉大模型:"), 1, 0)
+        grid.addWidget(self.llm_status, 1, 1)
+
+        self.btn_config_llm = QPushButton("配置…")
+        self.btn_config_llm.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_config_llm.setToolTip("打开自动标注配置，直接跳到 LLM 视觉那一页（填 API Key）")
+        self.btn_config_llm.clicked.connect(
+            lambda: self.auto_label_config_requested.emit('llm')
+        )
+        grid.addWidget(self.btn_config_llm, 1, 2)
+
+        layout.addLayout(grid)
+
+        btn_row = QHBoxLayout()
+        btn_row.setContentsMargins(0, 0, 0, 0)
+        btn_row.setSpacing(8)
+
+        self.btn_open_auto_label = QPushButton("打开自动标注配置")
+        self.btn_open_auto_label.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_open_auto_label.setToolTip(
+            "YOLO 预标注、SAM 分割、LLM 视觉都在这个窗口里配"
+        )
+        self.btn_open_auto_label.clicked.connect(
+            lambda: self.auto_label_config_requested.emit('')
+        )
+        btn_row.addWidget(self.btn_open_auto_label)
+
+        hint = QLabel("和「数据标注 → 自动标注」打开的是同一个配置窗口。")
+        hint.setObjectName("caption")
+        hint.setWordWrap(True)
+        btn_row.addWidget(hint, 1)
+
+        layout.addLayout(btn_row)
+
+        self.refresh_ai_status()
+        return group
+
     def create_shortcut_group(self) -> QGroupBox:
-        """创建快捷键设置组"""
-        group = QGroupBox("快捷键设置")
-        
-        layout = QFormLayout(group)
-        
-        # 重置视图快捷键
-        shortcut_layout = QHBoxLayout()
-        self.reset_view_shortcut = QLabel(self.settings.value("reset_view_shortcut", "R"))
-        self.reset_view_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        shortcut_layout.addWidget(self.reset_view_shortcut)
-        
-        btn_set_shortcut = QPushButton("设置")
-        btn_set_shortcut.clicked.connect(lambda: self.set_shortcut("reset_view_shortcut", self.reset_view_shortcut))
-        shortcut_layout.addWidget(btn_set_shortcut)
-        
-        layout.addRow("重置视图:", shortcut_layout)
-        
-        # 矩形工具快捷键
-        rect_layout = QHBoxLayout()
-        self.rect_tool_shortcut = QLabel(self.settings.value("rect_tool_shortcut", "W"))
-        self.rect_tool_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        rect_layout.addWidget(self.rect_tool_shortcut)
-        
-        btn_set_rect = QPushButton("设置")
-        btn_set_rect.clicked.connect(lambda: self.set_shortcut("rect_tool_shortcut", self.rect_tool_shortcut))
-        rect_layout.addWidget(btn_set_rect)
-        
-        layout.addRow("矩形工具:", rect_layout)
-        
-        # 多边形工具快捷键
-        poly_layout = QHBoxLayout()
-        self.poly_tool_shortcut = QLabel(self.settings.value("poly_tool_shortcut", "P"))
-        self.poly_tool_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        poly_layout.addWidget(self.poly_tool_shortcut)
-        
-        btn_set_poly = QPushButton("设置")
-        btn_set_poly.clicked.connect(lambda: self.set_shortcut("poly_tool_shortcut", self.poly_tool_shortcut))
-        poly_layout.addWidget(btn_set_poly)
-        
-        layout.addRow("多边形工具:", poly_layout)
-        
-        # 移动工具快捷键
-        move_layout = QHBoxLayout()
-        self.move_tool_shortcut = QLabel(self.settings.value("move_tool_shortcut", "V"))
-        self.move_tool_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        move_layout.addWidget(self.move_tool_shortcut)
-        
-        btn_set_move = QPushButton("设置")
-        btn_set_move.clicked.connect(lambda: self.set_shortcut("move_tool_shortcut", self.move_tool_shortcut))
-        move_layout.addWidget(btn_set_move)
-        
-        layout.addRow("移动工具:", move_layout)
-        
-        # 上一张图片快捷键
-        prev_layout = QHBoxLayout()
-        self.prev_image_shortcut = QLabel(self.settings.value("prev_image_shortcut", "A"))
-        self.prev_image_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        prev_layout.addWidget(self.prev_image_shortcut)
-        
-        btn_set_prev = QPushButton("设置")
-        btn_set_prev.clicked.connect(lambda: self.set_shortcut("prev_image_shortcut", self.prev_image_shortcut))
-        prev_layout.addWidget(btn_set_prev)
-        
-        layout.addRow("上一张图片:", prev_layout)
-        
-        # 下一张图片快捷键
-        next_layout = QHBoxLayout()
-        self.next_image_shortcut = QLabel(self.settings.value("next_image_shortcut", "D"))
-        self.next_image_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        next_layout.addWidget(self.next_image_shortcut)
-        
-        btn_set_next = QPushButton("设置")
-        btn_set_next.clicked.connect(lambda: self.set_shortcut("next_image_shortcut", self.next_image_shortcut))
-        next_layout.addWidget(btn_set_next)
-        
-        layout.addRow("下一张图片:", next_layout)
-        
-        # 删除标注快捷键
-        delete_layout = QHBoxLayout()
-        self.delete_shortcut = QLabel(self.settings.value("delete_shortcut", "DELETE"))
-        self.delete_shortcut.setStyleSheet("background-color: #252526; padding: 4px; border-radius: 4px;")
-        delete_layout.addWidget(self.delete_shortcut)
-        
-        btn_set_delete = QPushButton("设置")
-        btn_set_delete.clicked.connect(lambda: self.set_shortcut("delete_shortcut", self.delete_shortcut))
-        delete_layout.addWidget(btn_set_delete)
-        
-        layout.addRow("删除标注:", delete_layout)
-        
+        """标注快捷键：自己一组。
+
+        原来它是「外观与其他」卡片里再套一个标题——卡片里嵌一个二级标题，
+        层级读不出来。外观那一组只剩一行「主题：浅色主题」，既改不了也不用看，
+        一并去掉；应用固定浅色这件事不需要一行常驻文字来说。
+        """
+        group = QGroupBox("标注快捷键")
+
+        layout = QVBoxLayout(group)
+        layout.setSpacing(10)
+
+        shortcut_hint = QLabel("点键位修改，立即生效。")
+        shortcut_hint.setObjectName("caption")
+        shortcut_hint.setWordWrap(True)
+        layout.addWidget(shortcut_hint)
+
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(14)
+        grid.setVerticalSpacing(8)
+
+        for i, (setting_key, name, default) in enumerate(SHORTCUTS):
+            row, col = divmod(i, 2)
+
+            label = QLabel(name)
+            grid.addWidget(label, row, col * 3)
+
+            button = QPushButton(str(self.settings.value(setting_key, default)))
+            button.setCursor(Qt.CursorShape.PointingHandCursor)
+            button.setMinimumWidth(88)
+            button.setToolTip("点击修改快捷键")
+            button.clicked.connect(
+                lambda _checked, key=setting_key: self.set_shortcut(key)
+            )
+            grid.addWidget(button, row, col * 3 + 1)
+
+            grid.setColumnStretch(col * 3 + 2, 1)
+            self.shortcut_buttons[setting_key] = button
+
+        layout.addLayout(grid)
         return group
-    
-    def set_shortcut(self, setting_key: str, label: QLabel):
-        """设置快捷键"""
-        from PyQt6.QtWidgets import QInputDialog
-        
-        key, ok = QInputDialog.getText(self, "设置快捷键", f"请输入新的快捷键 (单个字母或数字):")
-        if ok and key:
-            # 只取第一个字符
-            new_key = key.upper()[0]
-            self.settings.setValue(setting_key, new_key)
-            label.setText(new_key)
-            QMessageBox.information(self, "设置成功", f"快捷键已设置为: {new_key}")
-    
+
+    def create_action_bar(self) -> QWidget:
+        """底部操作栏：状态说明 + 两个按钮"""
+        bar = QWidget()
+
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(24, 12, 24, 16)
+        layout.setSpacing(10)
+
+        self.status_label = QLabel(HINT_IDLE)
+        self.status_label.setObjectName("caption")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label, 1)
+
+        self.btn_reset = QPushButton("恢复默认")
+        self.btn_reset.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_reset.clicked.connect(self.reset_settings)
+        layout.addWidget(self.btn_reset)
+
+        self.btn_save = QPushButton("保存设置")
+        self.btn_save.setObjectName("primary")
+        self.btn_save.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_save.clicked.connect(self.save_settings)
+        layout.addWidget(self.btn_save)
+
+        return bar
+
+    # ==================== 状态 ====================
+
+    def showEvent(self, event):
+        """每次进设置页都重新读一次自动标注配置，显示的状态才是真的。"""
+        super().showEvent(event)
+        self.refresh_ai_status()
+
+    def refresh_ai_status(self):
+        """把自动标注当前用的模型显示出来（只读，不写配置）。"""
+        sam = read_config(SAM_CONFIG_FILE)
+        if sam:
+            model_file = sam.get("model_file") or "未指定权重"
+            self.sam_status.setText(f"{sam.get('sam_type', 'SAM')} · {model_file}")
+            self.sam_status.setStyleSheet(f"color: {COLORS['text_primary']};")
+        else:
+            self.sam_status.setText("还没配置过，首次自动标注时用默认设置")
+            self.sam_status.setStyleSheet(f"color: {COLORS['text_secondary']};")
+
+        llm = read_config(LLM_CONFIG_FILE)
+        model_name = llm.get("model_name") or ""
+        if not model_name:
+            self.llm_status.setText("还没配置过")
+            self.llm_status.setStyleSheet(f"color: {COLORS['text_secondary']};")
+        elif llm.get("api_key"):
+            self.llm_status.setText(f"{model_name} · 已填写 API Key")
+            self.llm_status.setStyleSheet(f"color: {COLORS['text_primary']};")
+        else:
+            self.llm_status.setText(f"{model_name} · 还没填 API Key，用它标注前要先填")
+            self.llm_status.setStyleSheet(f"color: {COLORS['warning']};")
+
+    def set_status(self, text: str, tone: str = 'muted'):
+        """底部那行字：说清楚现在是「改了没存」还是「已经存了」。"""
+        color = {
+            'success': COLORS['success'],
+            'warning': COLORS['warning'],
+        }.get(tone, COLORS['text_secondary'])
+
+        self.status_label.setText(text)
+        self.status_label.setStyleSheet(f"font-size: 12px; color: {color};")
+
+    def mark_dirty(self, *_args):
+        self.set_status("有改动还没保存，点「保存设置」写入。", 'warning')
+
+    def on_auto_save_toggled(self, checked: bool):
+        self.auto_save_interval.setEnabled(checked)
+        self.mark_dirty()
+
+    # ==================== 读写 ====================
+
+    def set_shortcut(self, setting_key: str):
+        """设置快捷键（立即写入）"""
+        button = self.shortcut_buttons[setting_key]
+
+        key, ok = QInputDialog.getText(
+            self, "设置快捷键",
+            "请输入新的快捷键：\n单个字母或数字（如 W、3），"
+            "或键位名（如 DELETE、BACKSPACE、SPACE、UP）",
+            text=button.text(),
+        )
+        if not (ok and key):
+            return
+
+        new_key = normalize_shortcut(key)
+        if not new_key:
+            if "+" in key:
+                reason = "标注快捷键只收单个键，不支持组合键"
+            else:
+                reason = "不是认得的键位"
+            self.set_status(f"「{key}」{reason}，快捷键没改。", 'warning')
+            return
+
+        self.settings.setValue(setting_key, new_key)
+        button.setText(new_key)
+        self.set_status(f"快捷键已改为 {new_key}，已经生效。", 'success')
+
     def browse_path(self, setting_key: str, dialog_title: str):
         """浏览路径"""
-        from PyQt6.QtWidgets import QFileDialog
-        
         path = QFileDialog.getExistingDirectory(
-            self, dialog_title, 
+            self, dialog_title,
             self.settings.value(setting_key, ""),
             QFileDialog.Option.ShowDirsOnly
         )
-        
+
         if path:
             if setting_key == "pretrained_path":
-                self.pretrained_path.setText(path)
-    
+                self._pretrained_path_value = path
+                self._refresh_pretrained_path_display()
+                self.mark_dirty()
+
     def save_settings(self):
         """保存设置"""
-        # 保存主题
-        new_theme = self.theme_combo.currentText()
-        self.settings.setValue("theme", new_theme)
-        
-        # 发送主题变化信号
-        theme_key = 'light' if new_theme == '浅色主题' else 'dark'
-        self.theme_changed.emit(theme_key)
-        
+        # 保存主题（固定浅色）
+        self.settings.setValue("theme", THEME_NAME)
+        self.theme_changed.emit('light')
+
         # 保存路径
-        self.settings.setValue("pretrained_path", self.pretrained_path.text())
-        
+        self.settings.setValue("pretrained_path", self._pretrained_path_value)
+
         # 保存自动保存设置
         self.settings.setValue("auto_save_interval", self.auto_save_interval.value())
         self.settings.setValue("auto_save_enabled", self.auto_save_enabled.isChecked())
-        
-        QMessageBox.information(self, "保存成功", "设置已保存！")
-    
+
+        self.set_status("设置已保存。", 'success')
+
     def reset_settings(self):
         """恢复默认设置"""
-        # 恢复默认值
-        self.theme_combo.setCurrentText("深色主题")
-        from pathlib import Path
-        app_root = Path(__file__).parent.parent.parent  # 向上三级到EzYOLO根目录
-        default_pretrained_path = app_root / "pretrained"
-        self.pretrained_path.setText(str(default_pretrained_path))
-        self.auto_save_interval.setValue(5)
         self.auto_save_enabled.setChecked(True)
-        
-        # 恢复默认快捷键
-        if hasattr(self, 'reset_view_shortcut'):
-            self.reset_view_shortcut.setText("R")
-        if hasattr(self, 'rect_tool_shortcut'):
-            self.rect_tool_shortcut.setText("W")
-        if hasattr(self, 'poly_tool_shortcut'):
-            self.poly_tool_shortcut.setText("P")
-        if hasattr(self, 'move_tool_shortcut'):
-            self.move_tool_shortcut.setText("V")
-        if hasattr(self, 'prev_image_shortcut'):
-            self.prev_image_shortcut.setText("A")
-        if hasattr(self, 'next_image_shortcut'):
-            self.next_image_shortcut.setText("D")
-        if hasattr(self, 'delete_shortcut'):
-            self.delete_shortcut.setText("DELETE")
-        
-        # 保存默认快捷键设置
-        self.settings.setValue("reset_view_shortcut", "R")
-        self.settings.setValue("rect_tool_shortcut", "W")
-        self.settings.setValue("poly_tool_shortcut", "P")
-        self.settings.setValue("move_tool_shortcut", "V")
-        self.settings.setValue("prev_image_shortcut", "A")
-        self.settings.setValue("next_image_shortcut", "D")
-        self.settings.setValue("delete_shortcut", "DELETE")
-        
-        # 发送主题变化信号（默认是深色主题）
-        self.theme_changed.emit('dark')
-        
-        QMessageBox.information(self, "恢复默认", "已恢复默认设置！")
+        self.auto_save_interval.setValue(5)
+        self._pretrained_path_value = str(DEFAULT_PRETRAINED_PATH)
+        self._refresh_pretrained_path_display()
+
+        # 快捷键和别处一样：改完立即写入
+        for setting_key, _name, default in SHORTCUTS:
+            self.settings.setValue(setting_key, default)
+            self.shortcut_buttons[setting_key].setText(default)
+
+        self.theme_changed.emit('light')
+
+        self.set_status("已恢复默认值，路径和自动保存点「保存设置」后写入。", 'warning')

--- a/gui/pages/test_page.py
+++ b/gui/pages/test_page.py
@@ -1,30 +1,52 @@
 # -*- coding: utf-8 -*-
 """
-测试页面 - 模型推理测试
-支持图片、图片文件夹、视频的推理测试
+测试页面 - 模型推理测试（流程第 5 步）
+
+页面按新手能读懂的顺序排：
+    ① 选择训练好的模型 → ② 选择图片/视频 → ③ 设置（高级项折叠）
+    → 开始测试 → 右侧看结果、知道结果存到哪
+支持图片、图片文件夹、视频的推理测试。
 """
 
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QComboBox, QDoubleSpinBox, QGroupBox, QFormLayout,
+    QComboBox, QDoubleSpinBox, QFormLayout,
     QProgressBar, QTextEdit, QSplitter, QFileDialog, QMessageBox,
-    QScrollArea, QFrame, QSpinBox, QCheckBox, QSlider, QListWidget,
-    QListWidgetItem, QStackedWidget, QTabWidget
+    QScrollArea, QFrame, QSpinBox, QCheckBox, QListWidget,
+    QListWidgetItem, QStackedWidget, QTabWidget, QSizePolicy
 )
-from PyQt6.QtCore import Qt, pyqtSignal, QThread, QTimer
-from PyQt6.QtGui import QPixmap, QImage, QPainter, QPen, QColor
+from PyQt6.QtCore import Qt, pyqtSignal, QThread, QTimer, QUrl, QEvent
+from PyQt6.QtGui import QPixmap, QImage, QPainter, QPen, QColor, QDesktopServices, QFontMetrics
 from pathlib import Path
 import os
 import json
-import shutil
 import cv2
 import numpy as np
 from typing import Dict, List, Optional, Tuple
 
-from gui.styles import COLORS
+from gui.styles import COLORS, mono_font_family_css
+from gui.widgets.workflow_widgets import EmptyState
+from gui.workflow import find_project_weights
 from models.database import db
 
 UNGROUPED_GROUP_ID = 0
+
+# 推理输出的命名规则：图片 → test_images/<stem>_annotated.jpg，视频 → test_videos/<stem>_annotated.mp4。
+# 写入和清理都按这一份规则算目标文件，两边不会漂移。
+VIDEO_EXTENSIONS = ('.mp4', '.avi', '.mov', '.mkv', '.flv', '.wmv')
+
+
+def is_video_path(path: str) -> bool:
+    """按扩展名判断是不是视频（与推理线程的分支同源）。"""
+    return str(path).lower().endswith(VIDEO_EXTENSIONS)
+
+
+def annotated_output_path(source_path: str, image_dir: Path, video_dir: Path) -> Path:
+    """这次推理会为某个输入写到哪个文件。"""
+    stem = Path(source_path).stem
+    if is_video_path(source_path):
+        return video_dir / f"{stem}_annotated.mp4"
+    return image_dir / f"{stem}_annotated.jpg"
 
 # 从train_page导入模型配置
 from gui.pages.train_page import ULTRALYTICS_MODELS, TASK_NAMES, SIZE_NAMES
@@ -154,10 +176,7 @@ class InferenceThread(QThread):
                 
                 try:
                     # 检查是否为视频文件
-                    video_extensions = ['.mp4', '.avi', '.mov', '.mkv', '.flv', '.wmv']
-                    is_video = any(data_path.lower().endswith(ext) for ext in video_extensions)
-                    
-                    if is_video:
+                    if is_video_path(data_path):
                         # 视频推理
                         self.process_video(data_path, conf, iou, imgsz, device)
                     else:
@@ -216,7 +235,9 @@ class InferenceThread(QThread):
 
         # 创建输出视频（边推理边写盘，避免帧缓存导致内存暴涨）
         app_root = Path(__file__).parent.parent.parent
-        output_video_path = self.video_output_dir / f"{Path(video_path).stem}_annotated.mp4"
+        output_video_path = annotated_output_path(
+            video_path, self.image_output_dir, self.video_output_dir
+        )
         writer = cv2.VideoWriter(
             str(output_video_path),
             cv2.VideoWriter_fourcc(*"mp4v"),
@@ -368,7 +389,9 @@ class InferenceThread(QThread):
         if hasattr(result, 'plot'):
             annotated_img = result.plot()
             if annotated_img is not None:
-                output_path = self.image_output_dir / f"{Path(source_path).stem}_annotated.jpg"
+                output_path = annotated_output_path(
+                    source_path, self.image_output_dir, self.video_output_dir
+                )
                 cv2.imwrite(str(output_path), annotated_img)
                 result_data['annotated_image_path'] = str(output_path)
         
@@ -405,7 +428,7 @@ class ImageViewer(QWidget):
                 border-radius: 4px;
             }}
         """)
-        self.image_label.setMinimumSize(400, 300)
+        self.image_label.setMinimumSize(240, 180)
         self.layout.addWidget(self.image_label, 0, Qt.AlignmentFlag.AlignCenter)
         
         # 信息标签
@@ -515,7 +538,7 @@ class VideoPlayer(QWidget):
                 border-radius: 4px;
             }}
         """)
-        self.video_label.setMinimumSize(400, 300)
+        self.video_label.setMinimumSize(240, 180)
         self.layout.addWidget(self.video_label, 0, Qt.AlignmentFlag.AlignCenter)
         
         # 控制按钮
@@ -709,9 +732,89 @@ class VideoPlayer(QWidget):
         self.video_label.setFixedSize(max(1, target_w), max(1, target_h))
 
 
+class CollapsibleSection(QWidget):
+    """次要设置的折叠区：默认收起，点标题行才展开，避免一上来就是一堵参数墙。"""
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        self._title = title
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.toggle = QPushButton(f"▸ {title}")
+        self.toggle.setObjectName("link")
+        self.toggle.setCheckable(True)
+        self.toggle.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.toggle.toggled.connect(self._on_toggled)
+        layout.addWidget(self.toggle, 0, Qt.AlignmentFlag.AlignLeft)
+
+        self.body = QWidget()
+        self.body.setVisible(False)
+        self.content = QVBoxLayout(self.body)
+        self.content.setContentsMargins(0, 0, 0, 0)
+        self.content.setSpacing(10)
+        layout.addWidget(self.body)
+
+    def _on_toggled(self, checked: bool):
+        self.body.setVisible(checked)
+        self.toggle.setText(f"{'▾' if checked else '▸'} {self._title}")
+
+
+def make_card(title: str, hint: str = "") -> Tuple[QFrame, QVBoxLayout]:
+    """一张卡片：标题 + 可选的一句说明。返回卡片本身和它的内容区布局。"""
+    card = QFrame()
+    card.setObjectName("card")
+
+    outer = QVBoxLayout(card)
+    outer.setContentsMargins(16, 14, 16, 16)
+    outer.setSpacing(10)
+
+    title_row = QHBoxLayout()
+    title_row.setContentsMargins(0, 0, 0, 0)
+    title_row.setSpacing(8)
+
+    title_label = QLabel(title)
+    title_label.setObjectName("h2")
+    title_row.addWidget(title_label)
+    title_row.addStretch()
+    outer.addLayout(title_row)
+
+    if hint:
+        hint_label = QLabel(hint)
+        hint_label.setObjectName("caption")
+        hint_label.setWordWrap(True)
+        outer.addWidget(hint_label)
+
+    body = QVBoxLayout()
+    body.setContentsMargins(0, 0, 0, 0)
+    body.setSpacing(10)
+    outer.addLayout(body)
+
+    return card, body
+
+
+def elide_label_text(label: QLabel, text: str, width_hint: int = 0) -> str:
+    """按标签宽度做尾部省略，避免长文件名/路径把卡片撑宽或挤成多行。
+
+    width_hint 用于标签还没参与过真实布局的场合（比如对话框 exec() 之前，
+    label.width() 拿到的不是最终宽度）——这时用一个够用的估计宽度兜底。
+    """
+    metrics = QFontMetrics(label.font())
+    width = width_hint or label.width()
+    return metrics.elidedText(text, Qt.TextElideMode.ElideRight, max(width, 1))
+
+
 class TestPage(QWidget):
-    """测试页面"""
-    
+    """测试页面
+
+    页面按新手能读懂的顺序排：
+        ① 选择训练好的模型 → ② 选择图片/视频 → ③ 常用设置（高级项折叠）
+        → 开始测试（左下角常驻，唯一主操作）→ 右侧看结果、知道存到哪
+    推理逻辑、线程、参数语义都沿用原来的，这里只重排界面和状态提示。
+    """
+
     def __init__(self):
         super().__init__()
         self.current_project_id = None
@@ -724,205 +827,696 @@ class TestPage(QWidget):
         self.video_frames = []  # 视频帧缓存
         self.class_mapping = {}  # 类别映射
         self.model_classes = []  # 模型类别列表
+        self.is_running = False
+        self._stopping = False
+        self._model_note = ""  # 模型来源那一行的补充说明
+        self._model_user_chosen = False  # 用户自己挑过模型文件，别再被默认值盖掉
         self.output_root = Path(__file__).parent.parent.parent / "outputs"
-        self._clear_test_outputs_on_startup()
-        
+        self.image_output_dir = self.output_root / "test_images"
+        self.video_output_dir = self.output_root / "test_videos"
+
         self.init_ui()
 
-    def _clear_test_outputs_on_startup(self):
-        """页面启动时清空测试输出文件。"""
-        for folder in ("test_images", "test_videos"):
-            path = self.output_root / folder
-            if path.exists():
-                shutil.rmtree(path, ignore_errors=True)
-            path.mkdir(parents=True, exist_ok=True)
-    
+    def _clear_outputs_for_run(self, data_paths):
+        """只删掉这次测试将要覆盖的那几个输出文件。
+
+        以前这里是构造页面时 rmtree 整个 outputs/test_images 和 outputs/test_videos——
+        应用一启动（MainWindow 会构造所有页面）用户上次的测试结果就没了，而且用户根本
+        没点过「开始测试」。现在只在用户真的点了「开始测试」之后，按本次输入算出目标
+        文件名删掉，别人的结果一个都不碰。
+        """
+        for source_path in data_paths:
+            target = annotated_output_path(
+                source_path, self.image_output_dir, self.video_output_dir
+            )
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                self.log_message(f"清理旧结果失败（忽略）: {target} - {exc}")
+
+    def eventFilter(self, obj, event):
+        """模型路径那一行自己变宽变窄时，重算省略号。
+
+        省略要按标签的真实宽度算。只在设值的时候算一次是不行的：那会儿页面还没布局，
+        拿到的是默认宽度，1100 宽下那行路径就会又断行又带省略号。
+        也不能挂在页面的 resizeEvent 上——页面收到 resize 时，里面的标签还没被重新
+        布局，读到的仍是旧宽度，省出来的文字比实际能画的宽，尾巴上的 .pt 被切掉。
+        只有标签自己的 Resize 事件到达时，它的 width() 才是最终值。
+        """
+        if (
+            event.type() == QEvent.Type.Resize
+            and obj is getattr(self, 'model_source_label', None)
+        ):
+            self._update_model_summary()
+        return super().eventFilter(obj, event)
+
     def set_project(self, project_id: int):
-        """设置当前项目"""
+        """设置当前项目。
+
+        每次切回测试页，主窗口都会把当前项目再设一遍。所以「同一个项目重设」
+        必须是无损的：正在跑的测试不能被打断，用户自己挑好的模型也不能被
+        悄悄换回项目默认的那个（换项目才重新推荐）。
+        """
+        project_changed = project_id != self.current_project_id
+        if project_changed:
+            self._model_user_chosen = False
+
         self.current_project_id = project_id
         if project_id:
             self.current_project = db.get_project(project_id)
             if self.current_project:
                 project_name = self.current_project.get('name', 'Unknown') if isinstance(self.current_project, dict) else self.current_project.name
                 print(f"[TestPage] 已切换到项目: {project_name} (ID: {project_id})")
-                # 自动设置默认模型路径
-                self.set_default_model_path()
-                self.refresh_data_group_combo()
+                # 自动选用这个项目训练出来的模型
+                if not self.is_running and not self._model_user_chosen:
+                    self.set_default_model_path()
         else:
             self.current_project = None
+            self.model_path = None
+            self._model_note = "还没有选择项目"
+            self._update_model_summary()
             print("[TestPage] 项目已取消选择")
-            self.refresh_data_group_combo()
-    
+
+        self.refresh_data_group_combo()
+        self._update_ready_state()
+
     def set_default_model_path(self):
-        """设置默认模型路径（项目训练文件夹中的best.pt）"""
+        """选用本项目训练产出的模型（runs/**/exp_<id>/weights/best.pt）。"""
         if not self.current_project_id:
+            self.model_path = None
+            self._model_note = "还没有选择项目"
+            self._update_model_summary()
+            self._update_ready_state()
             return
-        
-        # 构建默认模型路径
-        app_root = Path(__file__).parent.parent.parent
-        default_path = app_root / "runs" / "train" / f"exp_{self.current_project_id}" / "weights" / "best.pt"
-        
-        if default_path.exists():
-            self.model_path = str(default_path)
-            self.model_path_label.setText(f"模型: {self.model_path}")
-            self.log_message(f"自动加载模型: {self.model_path}")
+
+        weights = find_project_weights(self.current_project_id)
+        if weights:
+            self.model_path = str(weights)
+            self._model_note = "来自本项目最近一次训练"
+            self.log_message(f"已选用本项目训练好的模型: {self.model_path}")
         else:
             self.model_path = None
-            self.model_path_label.setText("模型: 未选择 (将使用默认模型)")
-    
+            self._model_note = "这个项目还没有训练结果"
+
+        self._update_model_summary()
+        self._update_ready_state()
+
+    # ==================== 界面 ====================
+
     def init_ui(self):
-        """初始化界面"""
+        """初始化界面：左边按顺序设置，右边看结果。"""
         main_layout = QHBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-        main_layout.setSpacing(16)
-        
-        # 创建分割器
+        main_layout.setContentsMargins(20, 16, 20, 16)
+        main_layout.setSpacing(12)
+
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        
-        # 左侧：配置面板
-        left_panel = self.create_config_panel()
-        splitter.addWidget(left_panel)
-        
-        # 右侧：可视化面板
-        right_panel = self.create_visualization_panel()
-        splitter.addWidget(right_panel)
-        
-        # 设置分割比例
-        splitter.setSizes([400, 800])
-        
+        splitter.setChildrenCollapsible(False)
+
+        setup_panel = self.create_setup_panel()
+        setup_panel.setMinimumWidth(300)
+        splitter.addWidget(setup_panel)
+
+        result_panel = self.create_result_panel()
+        result_panel.setMinimumWidth(320)
+        splitter.addWidget(result_panel)
+
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([320, 520])
+
         main_layout.addWidget(splitter)
+
         self.refresh_data_group_combo()
-    
-    def create_config_panel(self) -> QWidget:
-        """创建配置面板"""
+        self._update_model_summary()
+        self._update_ready_state()
+
+    def create_setup_panel(self) -> QWidget:
+        """左栏：三步设置（可滚动）+ 常驻的运行区。"""
         panel = QWidget()
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("⑤ 测试")
-        title.setObjectName("title")
-        title.setStyleSheet("font-size: 20px; font-weight: bold;")
-        layout.addWidget(title)
-        
-        # 创建滚动区域
+        layout.setSpacing(12)
+
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
-        
-        scroll_content = QWidget()
-        scroll_layout = QVBoxLayout(scroll_content)
-        scroll_layout.setSpacing(16)
-        
-        # 模型选择组
-        model_group = self.create_model_group()
-        scroll_layout.addWidget(model_group)
-        
-        # 模型路径组
-        model_path_group = self.create_model_path_group()
-        scroll_layout.addWidget(model_path_group)
-        
-        # 类别映射组
-        class_mapping_group = self.create_class_mapping_group()
-        scroll_layout.addWidget(class_mapping_group)
-        
-        # 推理参数组
-        params_group = self.create_params_group()
-        scroll_layout.addWidget(params_group)
-        
-        # 数据加载组
-        data_group = self.create_data_group()
-        scroll_layout.addWidget(data_group)
-        
-        # 控制按钮组
-        control_group = self.create_control_group()
-        scroll_layout.addWidget(control_group)
-        
-        # 日志组
-        log_group = self.create_log_group()
-        scroll_layout.addWidget(log_group)
-        
-        scroll_layout.addStretch()
-        scroll.setWidget(scroll_content)
-        layout.addWidget(scroll)
-        
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        content = QWidget()
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 4, 0)
+        content_layout.setSpacing(12)
+
+        content_layout.addWidget(self.create_model_card())
+        content_layout.addWidget(self.create_source_card())
+        content_layout.addWidget(self.create_options_card())
+        content_layout.addWidget(self.create_log_section())
+        content_layout.addStretch()
+
+        scroll.setWidget(content)
+        layout.addWidget(scroll, 1)
+
+        # 运行区不进滚动区：窗口再小，主操作、进度和状态也一直在
+        layout.addWidget(self.create_run_card())
+
         return panel
-    
-    def get_group_style(self) -> str:
-        """获取分组框样式"""
-        return f"""
-            QGroupBox {{
-                font-weight: bold;
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                margin-top: 12px;
-                padding-top: 10px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px;
-            }}
-        """
-    
-    def create_model_group(self) -> QGroupBox:
-        """创建模型选择组"""
-        group = QGroupBox("模型选择")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QFormLayout(group)
-        layout.setSpacing(10)
-        
-        # YOLO版本选择
+
+    def create_model_card(self) -> QFrame:
+        """① 用哪个模型。"""
+        card, body = make_card("选择训练好的模型")
+
+        self.model_name_label = QLabel("未选择模型")
+        self.model_name_label.setObjectName("title")
+        self.model_name_label.setWordWrap(True)
+        body.addWidget(self.model_name_label)
+
+        # 模型路径这一行不许换行：路径本来就长，一换行就变成
+        # 「/Users/huyi/dev/」+「EzYOLO/r…」两截，既断行又带省略号，最难看。
+        # 只留一行，装不下就在中间省略（路径的头和尾都是信息，中间才是废话），
+        # 完整路径放 tooltip。宽度策略给 Ignored，免得这行的理想宽度反过来把卡片撑宽。
+        self.model_source_label = QLabel("")
+        self.model_source_label.setObjectName("caption")
+        self.model_source_label.setWordWrap(False)
+        self.model_source_label.setSizePolicy(
+            QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred
+        )
+        self.model_source_label.installEventFilter(self)
+        body.addWidget(self.model_source_label)
+
+        btn_row = QHBoxLayout()
+        btn_row.setContentsMargins(0, 0, 0, 0)
+        btn_row.setSpacing(8)
+
+        self.btn_default_model = QPushButton("用本项目训练的模型")
+        self.btn_default_model.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_default_model.clicked.connect(self.set_default_model_path)
+        btn_row.addWidget(self.btn_default_model)
+
+        self.btn_select_model = QPushButton("选择模型文件…")
+        self.btn_select_model.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_select_model.clicked.connect(self.select_model)
+        btn_row.addWidget(self.btn_select_model)
+
+        btn_row.addStretch()
+        body.addLayout(btn_row)
+
+        return card
+
+    def create_source_card(self) -> QFrame:
+        """② 拿什么去测。"""
+        card, body = make_card("选择图片或视频")
+
+        btn_row = QHBoxLayout()
+        btn_row.setContentsMargins(0, 0, 0, 0)
+        btn_row.setSpacing(8)
+
+        self.btn_load_image = QPushButton("图片")
+        self.btn_load_image.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_load_image.clicked.connect(lambda: self.load_data("image"))
+        btn_row.addWidget(self.btn_load_image)
+
+        self.btn_load_folder = QPushButton("文件夹")
+        self.btn_load_folder.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_load_folder.clicked.connect(lambda: self.load_data("folder"))
+        btn_row.addWidget(self.btn_load_folder)
+
+        self.btn_load_video = QPushButton("视频")
+        self.btn_load_video.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_load_video.clicked.connect(lambda: self.load_data("video"))
+        btn_row.addWidget(self.btn_load_video)
+
+        btn_row.addStretch()
+        body.addLayout(btn_row)
+
+        # 也可以直接取项目里已有的图片分组
+        group_row = QHBoxLayout()
+        group_row.setContentsMargins(0, 0, 0, 0)
+        group_row.setSpacing(8)
+
+        group_label = QLabel("或用项目里的分组:")
+        group_label.setObjectName("caption")
+        group_row.addWidget(group_label)
+
+        self.group_combo = QComboBox()
+        self.group_combo.setMinimumWidth(120)
+        group_row.addWidget(self.group_combo, 1)
+
+        self.btn_load_group = QPushButton("加载")
+        self.btn_load_group.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_load_group.clicked.connect(self.load_project_group)
+        group_row.addWidget(self.btn_load_group)
+        body.addLayout(group_row)
+
+        self.data_list = QListWidget()
+        self.data_list.setMaximumHeight(132)
+        body.addWidget(self.data_list)
+
+        count_row = QHBoxLayout()
+        count_row.setContentsMargins(0, 0, 0, 0)
+        count_row.setSpacing(8)
+
+        self.data_count_label = QLabel("还没有选择文件")
+        self.data_count_label.setObjectName("caption")
+        count_row.addWidget(self.data_count_label)
+        count_row.addStretch()
+
+        self.btn_clear_data = QPushButton("清空")
+        self.btn_clear_data.setObjectName("ghost")
+        self.btn_clear_data.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_clear_data.clicked.connect(self.clear_data)
+        count_row.addWidget(self.btn_clear_data)
+        body.addLayout(count_row)
+
+        return card
+
+    def create_options_card(self) -> QFrame:
+        """③ 常用两项在外面，其余折叠。"""
+        card, body = make_card("设置")
+
+        form = QFormLayout()
+        form.setContentsMargins(0, 0, 0, 0)
+        form.setSpacing(8)
+
+        self.conf_threshold = QDoubleSpinBox()
+        self.conf_threshold.setRange(0.01, 1.0)
+        self.conf_threshold.setValue(0.25)
+        self.conf_threshold.setDecimals(2)
+        self.conf_threshold.setSingleStep(0.05)
+        self.conf_threshold.setToolTip("调低会检出更多目标，误检也更多")
+        form.addRow("识别门槛:", self.conf_threshold)
+
+        self.inference_device = QComboBox()
+        self.inference_device.addItems(["自动选择", "CPU", "CUDA:0", "CUDA:1", "CUDA:2", "CUDA:3"])
+        self.inference_device.setToolTip("保持「自动选择」即可")
+        form.addRow("运行设备:", self.inference_device)
+
+        body.addLayout(form)
+
+        advanced = CollapsibleSection("高级设置")
+
+        adv_form = QFormLayout()
+        adv_form.setContentsMargins(0, 0, 0, 0)
+        adv_form.setSpacing(8)
+
+        self.iou_threshold = QDoubleSpinBox()
+        self.iou_threshold.setRange(0.1, 1.0)
+        self.iou_threshold.setValue(0.45)
+        self.iou_threshold.setDecimals(2)
+        self.iou_threshold.setSingleStep(0.05)
+        adv_form.addRow("重叠框合并 (NMS IoU):", self.iou_threshold)
+
+        self.inference_size = QSpinBox()
+        self.inference_size.setRange(320, 1280)
+        self.inference_size.setValue(640)
+        self.inference_size.setSingleStep(32)
+        adv_form.addRow("推理尺寸:", self.inference_size)
+
+        advanced.content.addLayout(adv_form)
+
+        pretrained_form = QFormLayout()
+        pretrained_form.setContentsMargins(0, 0, 0, 0)
+        pretrained_form.setSpacing(8)
+
         self.model_version = QComboBox()
         self.model_version.addItems(sorted(ULTRALYTICS_MODELS.keys()))
+        self.model_version.setToolTip("没有选模型时会退回这里选的官方预训练模型")
         self.model_version.currentTextChanged.connect(self.on_version_changed)
-        layout.addRow("版本:", self.model_version)
-        
-        # 模型型号选择
+        pretrained_form.addRow("版本:", self.model_version)
+
         self.model_size = QComboBox()
-        layout.addRow("型号:", self.model_size)
-        
-        # 任务类型
+        pretrained_form.addRow("型号:", self.model_size)
+
         self.task_type = QComboBox()
-        layout.addRow("任务:", self.task_type)
-        
-        # 立即初始化型号和任务列表
+        self.task_type.setToolTip("决定 ONNX / TensorRT 模型怎么加载")
+        pretrained_form.addRow("任务:", self.task_type)
+
+        advanced.content.addLayout(pretrained_form)
+
+        # 先填好型号/任务，再接「选择变了就刷新模型说明」的信号，避免初始化时反复触发
         self._init_model_lists()
-        
-        return group
-    
+        self.model_version.currentTextChanged.connect(self._on_pretrained_changed)
+        self.model_size.currentIndexChanged.connect(self._on_pretrained_changed)
+        self.task_type.currentIndexChanged.connect(self._on_pretrained_changed)
+
+        advanced.content.addWidget(self.create_class_mapping_block())
+
+        body.addWidget(advanced)
+
+        return card
+
+    def create_class_mapping_block(self) -> QWidget:
+        """类别映射：模型的类别号 → 项目里的类别。属于高级项，默认藏起来。"""
+        block = QWidget()
+        layout = QVBoxLayout(block)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.chk_enable_mapping = QCheckBox("把模型的类别对应到项目类别")
+        self.chk_enable_mapping.setChecked(False)
+        self.chk_enable_mapping.stateChanged.connect(self.on_enable_mapping_changed)
+        layout.addWidget(self.chk_enable_mapping)
+
+        load_row = QHBoxLayout()
+        load_row.setContentsMargins(0, 0, 0, 0)
+        load_row.setSpacing(8)
+
+        self.btn_load_classes = QPushButton("加载模型 classes.txt")
+        self.btn_load_classes.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_load_classes.clicked.connect(self.load_model_classes)
+        self.btn_load_classes.setEnabled(False)
+        load_row.addWidget(self.btn_load_classes)
+
+        self.model_classes_label = QLabel("未加载")
+        self.model_classes_label.setObjectName("caption")
+        load_row.addWidget(self.model_classes_label)
+        load_row.addStretch()
+        layout.addLayout(load_row)
+
+        self.class_mapping_list = QListWidget()
+        self.class_mapping_list.setMaximumHeight(96)
+        layout.addWidget(self.class_mapping_list)
+
+        self.btn_edit_mapping = QPushButton("编辑类别映射")
+        self.btn_edit_mapping.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_edit_mapping.clicked.connect(self.edit_class_mapping)
+        self.btn_edit_mapping.setEnabled(False)
+        layout.addWidget(self.btn_edit_mapping, 0, Qt.AlignmentFlag.AlignLeft)
+
+        return block
+
+    def create_log_section(self) -> QWidget:
+        """运行日志：默认收起，出问题时才展开。"""
+        section = CollapsibleSection("运行日志")
+
+        self.log_text = QTextEdit()
+        self.log_text.setReadOnly(True)
+        self.log_text.setMaximumHeight(160)
+        mono = mono_font_family_css()
+        self.log_text.setStyleSheet(
+            (f"font-family: {mono}; " if mono else "") + "font-size: 12px;"
+        )
+        section.content.addWidget(self.log_text)
+
+        btn_row = QHBoxLayout()
+        btn_row.setContentsMargins(0, 0, 0, 0)
+        btn_row.setSpacing(8)
+
+        self.btn_clear_log = QPushButton("清空日志")
+        self.btn_clear_log.setObjectName("ghost")
+        self.btn_clear_log.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_clear_log.clicked.connect(self.clear_log)
+        btn_row.addWidget(self.btn_clear_log)
+
+        self.btn_save_log = QPushButton("保存日志")
+        self.btn_save_log.setObjectName("ghost")
+        self.btn_save_log.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_save_log.clicked.connect(self.save_log)
+        btn_row.addWidget(self.btn_save_log)
+
+        btn_row.addStretch()
+        section.content.addLayout(btn_row)
+
+        return section
+
+    def create_run_card(self) -> QFrame:
+        """运行区：现在能不能跑、跑到哪了、怎么停。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+
+        self.status_label = QLabel("先选好模型和图片")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        btn_row = QHBoxLayout()
+        btn_row.setContentsMargins(0, 0, 0, 0)
+        btn_row.setSpacing(8)
+
+        self.btn_start_inference = QPushButton("开始测试")
+        self.btn_start_inference.setObjectName("primary")
+        self.btn_start_inference.setMinimumHeight(40)
+        self.btn_start_inference.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_start_inference.clicked.connect(self.start_inference)
+        btn_row.addWidget(self.btn_start_inference, 1)
+
+        self.btn_stop_inference = QPushButton("停止")
+        self.btn_stop_inference.setObjectName("danger")
+        self.btn_stop_inference.setMinimumHeight(40)
+        self.btn_stop_inference.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_stop_inference.clicked.connect(self.stop_inference)
+        self.btn_stop_inference.setVisible(False)
+        btn_row.addWidget(self.btn_stop_inference)
+
+        layout.addLayout(btn_row)
+
+        return card
+
+    def create_result_panel(self) -> QWidget:
+        """右栏：结果、结果存在哪。"""
+        panel = QWidget()
+        layout = QVBoxLayout(panel)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        head = QHBoxLayout()
+        head.setContentsMargins(0, 0, 0, 0)
+        head.setSpacing(8)
+
+        title = QLabel("测试结果")
+        title.setObjectName("h2")
+        head.addWidget(title)
+        head.addStretch()
+
+        self.btn_open_output = QPushButton("打开结果文件夹")
+        self.btn_open_output.setObjectName("ghost")
+        self.btn_open_output.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_open_output.setToolTip(str(self.output_root))
+        self.btn_open_output.clicked.connect(self.open_output_dir)
+        head.addWidget(self.btn_open_output)
+        layout.addLayout(head)
+
+        self.result_stack = QStackedWidget()
+
+        self.result_empty = EmptyState(
+            "还没有测试结果",
+            "选好模型和图片后点「开始测试」。",
+        )
+        self.result_stack.addWidget(self.result_empty)      # 0：空状态
+        self.result_stack.addWidget(self.create_result_view())  # 1：有结果
+
+        layout.addWidget(self.result_stack, 1)
+
+        return panel
+
+    def create_result_view(self) -> QWidget:
+        """有结果时显示：图像/视频 + 这一张检出了什么 + 翻页和导出。"""
+        view = QWidget()
+        layout = QVBoxLayout(view)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        self.result_tabs = QTabWidget()
+
+        self.image_tab = QWidget()
+        image_layout = QVBoxLayout(self.image_tab)
+        self.image_viewer = ImageViewer()
+        image_layout.addWidget(self.image_viewer)
+        self.result_tabs.addTab(self.image_tab, "图像")
+
+        self.video_tab = QWidget()
+        video_layout = QVBoxLayout(self.video_tab)
+        self.video_player = VideoPlayer()
+        video_layout.addWidget(self.video_player)
+        self.result_tabs.addTab(self.video_tab, "视频")
+
+        layout.addWidget(self.result_tabs, 1)
+
+        # 检出详情：内容多时自己滚，不把下面的按钮挤出屏幕
+        self.result_info = QLabel("等待推理…")
+        self.result_info.setWordWrap(True)
+        self.result_info.setAlignment(
+            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft
+        )
+        self.result_info.setContentsMargins(12, 10, 12, 10)
+
+        info_scroll = QScrollArea()
+        info_scroll.setWidgetResizable(True)
+        info_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        info_scroll.setWidget(self.result_info)
+        info_scroll.setMinimumHeight(90)
+        info_scroll.setMaximumHeight(150)
+        info_scroll.setStyleSheet(
+            f"QScrollArea {{ background-color: {COLORS['panel']};"
+            f" border: 1px solid {COLORS['border']}; border-radius: 6px; }}"
+        )
+        layout.addWidget(info_scroll)
+
+        nav_layout = QHBoxLayout()
+        nav_layout.setContentsMargins(0, 0, 0, 0)
+        nav_layout.setSpacing(8)
+
+        self.btn_prev = QPushButton("◀ 上一个")
+        self.btn_prev.setObjectName("ghost")
+        self.btn_prev.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_prev.clicked.connect(self.show_previous_result)
+        self.btn_prev.setEnabled(False)
+        nav_layout.addWidget(self.btn_prev)
+
+        self.result_count_label = QLabel("0 / 0")
+        self.result_count_label.setObjectName("caption")
+        self.result_count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.result_count_label.setMinimumWidth(60)
+        nav_layout.addWidget(self.result_count_label)
+
+        self.btn_next = QPushButton("下一个 ▶")
+        self.btn_next.setObjectName("ghost")
+        self.btn_next.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_next.clicked.connect(self.show_next_result)
+        self.btn_next.setEnabled(False)
+        nav_layout.addWidget(self.btn_next)
+
+        nav_layout.addStretch()
+
+        self.btn_export = QPushButton("导出结果")
+        self.btn_export.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_export.clicked.connect(self.export_results)
+        self.btn_export.setEnabled(False)
+        nav_layout.addWidget(self.btn_export)
+
+        layout.addLayout(nav_layout)
+
+        return view
+
+    # ==================== 当前选择与状态 ====================
+
+    def _pretrained_model_name(self) -> str:
+        """没有自选模型时会退回的官方预训练权重名（与实际推理用的一致）。"""
+        version = self.model_version.currentText()
+        model_size = self.model_size.currentData()
+        task = self.task_type.currentData()
+
+        if not version or not model_size or version not in ULTRALYTICS_MODELS:
+            return ""
+
+        prefix = ULTRALYTICS_MODELS[version]['prefix']
+        if task == 'detect' or not task:
+            return f"{prefix}{model_size}.pt"
+
+        task_suffix_map = {"segment": "seg", "classify": "cls", "pose": "pose", "world": "world"}
+        suffix = task_suffix_map.get(task, task)
+        return f"{prefix}{model_size}-{suffix}.pt"
+
+    def _on_pretrained_changed(self, *_args):
+        """高级设置里换了预训练模型：把「现在会用哪个模型」这句话跟着改。"""
+        self._update_model_summary()
+        self._update_ready_state()
+
+    def _update_model_summary(self):
+        """把「现在会用哪个模型、它是哪来的」写清楚。"""
+        if not hasattr(self, 'model_name_label'):
+            return
+
+        if self.model_path:
+            path = Path(self.model_path)
+            self.model_name_label.setText(elide_label_text(self.model_name_label, path.name))
+            self.model_name_label.setToolTip(path.name)
+            self.model_name_label.setStyleSheet("")
+            source = self._model_note or "手动选择"
+            # 路径要省略到「这一行减去前缀」还剩下的宽度里，否则前缀把它挤到第二行，
+            # 结果就是又断行、又带省略号。省略号打在中间：路径的头（在哪个盘/哪个项目）
+            # 和尾（哪个 run 的 best.pt）都是用户要认的，中间的目录才是可以省的。
+            metrics = self.model_source_label.fontMetrics()
+            prefix_width = metrics.horizontalAdvance(f"{source}　")
+            # 留 4px：算得刚好等于宽度时，最后一个字符会贴着边缘被切掉半个
+            budget = max(80, self.model_source_label.width() - prefix_width - 4)
+            elided_path = metrics.elidedText(
+                str(path), Qt.TextElideMode.ElideMiddle, budget
+            )
+            self.model_source_label.setText(f"{source}　{elided_path}")
+            self.model_source_label.setToolTip(str(path))
+            return
+
+        fallback = self._pretrained_model_name() or "官方预训练模型"
+        self.model_name_label.setText("未选择模型")
+        hint = f"未选模型时使用 {fallback}"
+        if self._model_note:
+            hint = f"{self._model_note}；{hint}"
+        self.model_source_label.setText(hint)
+        self.model_source_label.setToolTip(
+            "官方预训练模型首次运行会自动下载，只认通用类别，不是你训练的模型"
+        )
+
+    def _set_status(self, text: str, kind: str = "normal"):
+        """运行区那行状态：就绪 / 运行中 / 成功 / 失败，用颜色区分。"""
+        color = {
+            "normal": COLORS['text_secondary'],
+            "running": COLORS['accent_text'],
+            "success": COLORS['success'],
+            "error": COLORS['error'],
+        }.get(kind, COLORS['text_secondary'])
+        self.status_label.setText(text)
+        self.status_label.setStyleSheet(f"color: {color}; font-size: 13px;")
+
+    def _update_ready_state(self):
+        """主操作能不能点、还差什么——一句话说清。"""
+        if not hasattr(self, 'btn_start_inference') or self.is_running:
+            return
+
+        self.btn_start_inference.setEnabled(bool(self.data_paths))
+
+        if not self.data_paths:
+            self._set_status("还差一步：选择要测试的图片、文件夹或视频")
+            return
+
+        count = len(self.data_paths)
+        if self.model_path:
+            self._set_status(f"准备就绪：用 {Path(self.model_path).name} 测试 {count} 个文件")
+        else:
+            fallback = self._pretrained_model_name() or "官方预训练模型"
+            self._set_status(f"准备就绪：用官方预训练模型 {fallback} 测试 {count} 个文件")
+
+    # ==================== 模型 ====================
+
     def _init_model_lists(self):
         """初始化型号和任务列表"""
         version = self.model_version.currentText()
-        
+
         if not version:
             version = sorted(ULTRALYTICS_MODELS.keys())[0]
             self.model_version.setCurrentText(version)
-        
+
         if version in ULTRALYTICS_MODELS:
             model_info = ULTRALYTICS_MODELS[version]
-            
+
             # 初始化型号列表
             self.model_size.clear()
             for size in model_info['sizes']:
                 display_name = SIZE_NAMES.get(size, size)
                 self.model_size.addItem(display_name, size)
-            
+
             # 初始化任务列表
             self.task_type.clear()
             for task in model_info['tasks']:
                 display_name = TASK_NAMES.get(task, task)
                 self.task_type.addItem(display_name, task)
-    
+
     def on_version_changed(self, version: str):
         """版本改变时更新型号和任务"""
         if not version or version not in ULTRALYTICS_MODELS:
             return
-        
+
         model_info = ULTRALYTICS_MODELS[version]
-        
+
         # 更新型号列表
         try:
             self.model_size.clear()
@@ -931,7 +1525,7 @@ class TestPage(QWidget):
                 self.model_size.addItem(display_name, size)
         except RuntimeError:
             return
-        
+
         # 更新任务列表
         try:
             self.task_type.clear()
@@ -940,546 +1534,7 @@ class TestPage(QWidget):
                 self.task_type.addItem(display_name, task)
         except RuntimeError:
             return
-    
-    def create_model_path_group(self) -> QGroupBox:
-        """创建模型路径组"""
-        group = QGroupBox("模型路径")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        layout.setSpacing(10)
-        
-        # 模型路径标签
-        self.model_path_label = QLabel("模型: 未选择")
-        self.model_path_label.setWordWrap(True)
-        self.model_path_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
-        layout.addWidget(self.model_path_label)
-        
-        # 按钮布局
-        btn_layout = QHBoxLayout()
-        
-        # 选择模型按钮
-        self.btn_select_model = QPushButton("📁 选择模型")
-        self.btn_select_model.clicked.connect(self.select_model)
-        btn_layout.addWidget(self.btn_select_model)
-        
-        # 使用默认模型按钮
-        self.btn_default_model = QPushButton("🔄 使用默认")
-        self.btn_default_model.clicked.connect(self.set_default_model_path)
-        btn_layout.addWidget(self.btn_default_model)
-        
-        layout.addLayout(btn_layout)
-        
-        return group
-    
-    def create_class_mapping_group(self) -> QGroupBox:
-        """创建类别映射组"""
-        group = QGroupBox("类别映射")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        layout.setSpacing(10)
-        
-        # 启用映射选项
-        enable_mapping_layout = QHBoxLayout()
-        self.chk_enable_mapping = QCheckBox("启用类别映射")
-        self.chk_enable_mapping.setChecked(False)
-        self.chk_enable_mapping.stateChanged.connect(self.on_enable_mapping_changed)
-        enable_mapping_layout.addWidget(self.chk_enable_mapping)
-        enable_mapping_layout.addStretch()
-        layout.addLayout(enable_mapping_layout)
-        
-        # 模型类别文件加载
-        model_class_file_layout = QHBoxLayout()
-        self.btn_load_classes = QPushButton("📄 加载模型classes.txt")
-        self.btn_load_classes.clicked.connect(self.load_model_classes)
-        self.btn_load_classes.setEnabled(False)
-        model_class_file_layout.addWidget(self.btn_load_classes)
-        
-        # 显示已加载的类别数
-        self.model_classes_label = QLabel("未加载")
-        self.model_classes_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
-        model_class_file_layout.addWidget(self.model_classes_label)
-        model_class_file_layout.addStretch()
-        layout.addLayout(model_class_file_layout)
-        
-        # 类别映射显示
-        self.class_mapping_list = QListWidget()
-        self.class_mapping_list.setMaximumHeight(100)
-        self.class_mapping_list.setStyleSheet(f"""
-            QListWidget {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-            }}
-        """)
-        layout.addWidget(self.class_mapping_list)
-        
-        # 编辑映射按钮
-        self.btn_edit_mapping = QPushButton("✏️ 编辑类别映射")
-        self.btn_edit_mapping.clicked.connect(self.edit_class_mapping)
-        self.btn_edit_mapping.setEnabled(False)
-        layout.addWidget(self.btn_edit_mapping)
-        
-        return group
-    
-    def on_enable_mapping_changed(self, state):
-        """启用映射选项改变"""
-        enabled = state == Qt.CheckState.Checked.value
-        self.btn_load_classes.setEnabled(enabled)
-        self.btn_edit_mapping.setEnabled(enabled and len(self.model_classes) > 0)
-    
-    def load_model_classes(self):
-        """加载模型classes.txt文件"""
-        file_path, _ = QFileDialog.getOpenFileName(
-            self, "选择模型classes.txt文件", 
-            "", "Text files (*.txt)"
-        )
-        if file_path:
-            try:
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    classes = [line.strip() for line in f if line.strip()]
-                if classes:
-                    self.model_classes = classes
-                    self.model_classes_label.setText(f"已加载 {len(classes)} 个类别")
-                    
-                    # 自动创建默认映射（一对一）
-                    self.class_mapping = {i: i for i in range(len(classes))}
-                    self.update_class_mapping_list()
-                    
-                    self.btn_edit_mapping.setEnabled(True)
-                    self.log_message(f"✓ 成功加载类别文件: {file_path}")
-                    self.log_message(f"  类别: {', '.join(classes[:5])}{'...' if len(classes) > 5 else ''}")
-                else:
-                    QMessageBox.warning(self, "警告", "classes.txt文件为空")
-            except Exception as e:
-                QMessageBox.critical(self, "错误", f"加载classes.txt文件失败: {str(e)}")
-    
-    def update_class_mapping_list(self):
-        """更新类别映射列表显示"""
-        self.class_mapping_list.clear()
-        
-        if not self.model_classes:
-            return
-        
-        # 获取项目类别
-        project_classes = []
-        if self.current_project:
-            classes_json = self.current_project.get('classes', '[]') if isinstance(self.current_project, dict) else '[]'
-            project_classes = json.loads(classes_json) if classes_json else []
-        
-        project_class_names = {cls['id']: cls['name'] for cls in project_classes}
-        
-        for model_id, project_id in self.class_mapping.items():
-            if model_id < len(self.model_classes):
-                model_name = self.model_classes[model_id]
-                project_name = project_class_names.get(project_id, f"ID:{project_id}")
-                item_text = f"{model_id}: {model_name} → {project_id}: {project_name}"
-                self.class_mapping_list.addItem(item_text)
-    
-    def edit_class_mapping(self):
-        """编辑类别映射"""
-        if not self.model_classes:
-            QMessageBox.warning(self, "警告", "请先加载模型classes.txt文件")
-            return
-        
-        # 获取项目类别
-        project_classes = []
-        if self.current_project:
-            classes_json = self.current_project.get('classes', '[]') if isinstance(self.current_project, dict) else '[]'
-            project_classes = json.loads(classes_json) if classes_json else []
-        
-        if not project_classes:
-            QMessageBox.warning(self, "警告", "当前项目没有类别，请先设置项目类别")
-            return
-        
-        # 创建对话框
-        from PyQt6.QtWidgets import QDialog, QComboBox
-        
-        dialog = QDialog(self)
-        dialog.setWindowTitle("编辑类别映射")
-        dialog.setMinimumSize(400, 300)
-        
-        layout = QVBoxLayout(dialog)
-        
-        # 说明标签
-        info_label = QLabel("将模型类别映射到项目类别:")
-        layout.addWidget(info_label)
-        
-        # 创建映射选择
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll_content = QWidget()
-        scroll_layout = QVBoxLayout(scroll_content)
-        
-        mapping_widgets = []
-        
-        for i, model_class in enumerate(self.model_classes):
-            row_layout = QHBoxLayout()
-            
-            # 模型类别标签
-            model_label = QLabel(f"{i}: {model_class}")
-            model_label.setMinimumWidth(150)
-            row_layout.addWidget(model_label)
-            
-            row_layout.addWidget(QLabel("→"))
-            
-            # 项目类别选择
-            project_combo = QComboBox()
-            for cls in project_classes:
-                project_combo.addItem(f"{cls['id']}: {cls['name']}", cls['id'])
-            
-            # 设置当前映射
-            current_mapping = self.class_mapping.get(i, i)
-            index = project_combo.findData(current_mapping)
-            if index >= 0:
-                project_combo.setCurrentIndex(index)
-            
-            row_layout.addWidget(project_combo)
-            mapping_widgets.append((i, project_combo))
-            
-            scroll_layout.addLayout(row_layout)
-        
-        scroll_layout.addStretch()
-        scroll.setWidget(scroll_content)
-        layout.addWidget(scroll)
-        
-        # 按钮
-        btn_layout = QHBoxLayout()
-        btn_ok = QPushButton("确定")
-        btn_ok.clicked.connect(dialog.accept)
-        btn_layout.addWidget(btn_ok)
-        
-        btn_cancel = QPushButton("取消")
-        btn_cancel.clicked.connect(dialog.reject)
-        btn_layout.addWidget(btn_cancel)
-        
-        layout.addLayout(btn_layout)
-        
-        # 显示对话框
-        if dialog.exec() == QDialog.DialogCode.Accepted:
-            # 更新映射
-            for model_id, combo in mapping_widgets:
-                project_id = combo.currentData()
-                self.class_mapping[model_id] = project_id
-            
-            self.update_class_mapping_list()
-            self.log_message(f"✓ 类别映射已更新: {self.class_mapping}")
-    
-    def create_params_group(self) -> QGroupBox:
-        """创建推理参数组"""
-        group = QGroupBox("推理参数")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QFormLayout(group)
-        layout.setSpacing(10)
-        
-        # 置信度阈值
-        self.conf_threshold = QDoubleSpinBox()
-        self.conf_threshold.setRange(0.01, 1.0)
-        self.conf_threshold.setValue(0.25)
-        self.conf_threshold.setDecimals(2)
-        self.conf_threshold.setSingleStep(0.05)
-        layout.addRow("置信度阈值:", self.conf_threshold)
-        
-        # NMS IoU阈值
-        self.iou_threshold = QDoubleSpinBox()
-        self.iou_threshold.setRange(0.1, 1.0)
-        self.iou_threshold.setValue(0.45)
-        self.iou_threshold.setDecimals(2)
-        self.iou_threshold.setSingleStep(0.05)
-        layout.addRow("NMS IoU阈值:", self.iou_threshold)
-        
-        # 图像尺寸
-        self.inference_size = QSpinBox()
-        self.inference_size.setRange(320, 1280)
-        self.inference_size.setValue(640)
-        self.inference_size.setSingleStep(32)
-        layout.addRow("推理尺寸:", self.inference_size)
-        
-        # 设备选择
-        self.inference_device = QComboBox()
-        self.inference_device.addItems(["自动选择", "CPU", "CUDA:0", "CUDA:1", "CUDA:2", "CUDA:3"])
-        layout.addRow("设备:", self.inference_device)
-        
-        # 保存结果选项
-        self.save_results = QCheckBox("保存推理结果")
-        self.save_results.setChecked(True)
-        layout.addRow(self.save_results)
-        
-        # 显示标签选项
-        self.show_labels = QCheckBox("显示标签")
-        self.show_labels.setChecked(True)
-        layout.addRow(self.show_labels)
-        
-        return group
-    
-    def create_data_group(self) -> QGroupBox:
-        """创建数据加载组"""
-        group = QGroupBox("数据加载")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        layout.setSpacing(10)
-        
-        # 数据列表
-        self.data_list = QListWidget()
-        self.data_list.setMaximumHeight(150)
-        self.data_list.setStyleSheet(f"""
-            QListWidget {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-            }}
-            QListWidget::item {{
-                padding: 4px 8px;
-                border-bottom: 1px solid {COLORS['border']};
-            }}
-        """)
-        layout.addWidget(self.data_list)
-        
-        # 数据数量标签
-        self.data_count_label = QLabel("已加载: 0 个文件")
-        self.data_count_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
-        layout.addWidget(self.data_count_label)
 
-        # 项目分组加载
-        group_row = QHBoxLayout()
-        group_row.addWidget(QLabel("项目分组:"))
-        self.group_combo = QComboBox()
-        self.group_combo.setMinimumWidth(140)
-        group_row.addWidget(self.group_combo, 1)
-        self.btn_load_group = QPushButton("📂 加载分组")
-        self.btn_load_group.clicked.connect(self.load_project_group)
-        group_row.addWidget(self.btn_load_group)
-        layout.addLayout(group_row)
-        
-        # 按钮布局
-        btn_layout = QHBoxLayout()
-        
-        # 加载图片按钮
-        self.btn_load_image = QPushButton("🖼️ 图片")
-        self.btn_load_image.clicked.connect(lambda: self.load_data("image"))
-        btn_layout.addWidget(self.btn_load_image)
-        
-        # 加载文件夹按钮
-        self.btn_load_folder = QPushButton("📁 文件夹")
-        self.btn_load_folder.clicked.connect(lambda: self.load_data("folder"))
-        btn_layout.addWidget(self.btn_load_folder)
-        
-        # 加载视频按钮
-        self.btn_load_video = QPushButton("🎬 视频")
-        self.btn_load_video.clicked.connect(lambda: self.load_data("video"))
-        btn_layout.addWidget(self.btn_load_video)
-        
-        # 清空按钮
-        self.btn_clear_data = QPushButton("🗑️ 清空")
-        self.btn_clear_data.clicked.connect(self.clear_data)
-        btn_layout.addWidget(self.btn_clear_data)
-        
-        layout.addLayout(btn_layout)
-        
-        return group
-    
-    def create_control_group(self) -> QGroupBox:
-        """创建控制按钮组"""
-        group = QGroupBox("推理控制")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        layout.setSpacing(10)
-        
-        # 进度条
-        self.progress_bar = QProgressBar()
-        self.progress_bar.setVisible(False)
-        self.progress_bar.setStyleSheet(f"""
-            QProgressBar {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                text-align: center;
-                color: white;
-                height: 20px;
-            }}
-            QProgressBar::chunk {{
-                background-color: {COLORS['primary']};
-                border-radius: 3px;
-            }}
-        """)
-        layout.addWidget(self.progress_bar)
-        
-        # 状态标签
-        self.status_label = QLabel("就绪")
-        self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.status_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
-        layout.addWidget(self.status_label)
-        
-        # 按钮布局
-        btn_layout = QHBoxLayout()
-        
-        # 开始推理按钮
-        self.btn_start_inference = QPushButton("▶ 开始推理")
-        self.btn_start_inference.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {COLORS['success']};
-                color: white;
-                font-weight: bold;
-                padding: 12px 30px;
-                font-size: 14px;
-            }}
-        """)
-        self.btn_start_inference.clicked.connect(self.start_inference)
-        btn_layout.addWidget(self.btn_start_inference)
-        
-        # 停止按钮
-        self.btn_stop_inference = QPushButton("⏹ 停止")
-        self.btn_stop_inference.setEnabled(False)
-        self.btn_stop_inference.clicked.connect(self.stop_inference)
-        btn_layout.addWidget(self.btn_stop_inference)
-        
-        layout.addLayout(btn_layout)
-        
-        return group
-    
-    def create_log_group(self) -> QGroupBox:
-        """创建日志组"""
-        group = QGroupBox("日志")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        layout.setSpacing(10)
-        
-        # 日志文本框
-        self.log_text = QTextEdit()
-        self.log_text.setReadOnly(True)
-        self.log_text.setMaximumHeight(150)
-        self.log_text.setStyleSheet(f"""
-            QTextEdit {{
-                background-color: {COLORS['sidebar']};
-                color: {COLORS['text_primary']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                padding: 10px;
-                font-family: 'Consolas', 'Monaco', monospace;
-                font-size: 12px;
-            }}
-        """)
-        layout.addWidget(self.log_text)
-        
-        # 日志按钮
-        btn_layout = QHBoxLayout()
-        
-        self.btn_clear_log = QPushButton("🗑 清空日志")
-        self.btn_clear_log.clicked.connect(self.clear_log)
-        btn_layout.addWidget(self.btn_clear_log)
-        
-        self.btn_save_log = QPushButton("💾 保存日志")
-        self.btn_save_log.clicked.connect(self.save_log)
-        btn_layout.addWidget(self.btn_save_log)
-        
-        btn_layout.addStretch()
-        layout.addLayout(btn_layout)
-        
-        return group
-    
-    def create_visualization_panel(self) -> QWidget:
-        """创建可视化面板"""
-        panel = QWidget()
-        layout = QVBoxLayout(panel)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("推理结果")
-        title.setObjectName("title")
-        title.setStyleSheet("font-size: 20px; font-weight: bold;")
-        layout.addWidget(title)
-        
-        # 创建标签页
-        self.result_tabs = QTabWidget()
-        self.result_tabs.setStyleSheet(f"""
-            QTabWidget::pane {{
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                background-color: {COLORS['panel']};
-            }}
-            QTabBar::tab {{
-                background-color: {COLORS['sidebar']};
-                color: {COLORS['text_secondary']};
-                padding: 8px 16px;
-                margin-right: 4px;
-                border-top-left-radius: 4px;
-                border-top-right-radius: 4px;
-            }}
-            QTabBar::tab:selected {{
-                background-color: {COLORS['primary']};
-                color: white;
-            }}
-        """)
-        
-        # 图像结果标签页
-        self.image_tab = QWidget()
-        image_layout = QVBoxLayout(self.image_tab)
-        self.image_viewer = ImageViewer()
-        image_layout.addWidget(self.image_viewer)
-        self.result_tabs.addTab(self.image_tab, "🖼️ 图像")
-        
-        # 视频结果标签页
-        self.video_tab = QWidget()
-        video_layout = QVBoxLayout(self.video_tab)
-        self.video_player = VideoPlayer()
-        video_layout.addWidget(self.video_player)
-        self.result_tabs.addTab(self.video_tab, "🎬 视频")
-        
-        layout.addWidget(self.result_tabs)
-        
-        # 结果信息面板
-        self.result_info = QLabel("等待推理...")
-        self.result_info.setStyleSheet(f"""
-            QLabel {{
-                background-color: {COLORS['panel']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                padding: 10px;
-                font-size: 12px;
-            }}
-        """)
-        self.result_info.setWordWrap(True)
-        self.result_info.setMinimumHeight(100)
-        layout.addWidget(self.result_info)
-        
-        # 导航和导出按钮
-        nav_layout = QHBoxLayout()
-        
-        # 上一个按钮
-        self.btn_prev = QPushButton("◀ 上一个")
-        self.btn_prev.clicked.connect(self.show_previous_result)
-        self.btn_prev.setEnabled(False)
-        nav_layout.addWidget(self.btn_prev)
-        
-        # 结果计数
-        self.result_count_label = QLabel("0 / 0")
-        self.result_count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        nav_layout.addWidget(self.result_count_label)
-        
-        # 下一个按钮
-        self.btn_next = QPushButton("下一个 ▶")
-        self.btn_next.clicked.connect(self.show_next_result)
-        self.btn_next.setEnabled(False)
-        nav_layout.addWidget(self.btn_next)
-        
-        nav_layout.addStretch()
-        
-        # 导出按钮
-        self.btn_export = QPushButton("💾 导出结果")
-        self.btn_export.clicked.connect(self.export_results)
-        self.btn_export.setEnabled(False)
-        nav_layout.addWidget(self.btn_export)
-        
-        layout.addLayout(nav_layout)
-        
-        return panel
-    
     def select_model(self):
         """选择模型文件"""
         file_path, _ = QFileDialog.getOpenFileName(
@@ -1490,18 +1545,174 @@ class TestPage(QWidget):
             "TensorRT模型 (*.engine *.trt);;"
             "所有文件 (*.*)"
         )
-        
+
         if file_path:
             self.model_path = file_path
-            self.model_path_label.setText(f"模型: {file_path}")
+            self._model_note = "手动选择的模型文件"
+            self._model_user_chosen = True
+            self._update_model_summary()
+            self._update_ready_state()
             self.log_message(f"已选择模型: {file_path}")
-            
+
             # 根据模型类型给出提示
             if file_path.endswith('.onnx'):
                 self.log_message("ℹ 已选择ONNX模型，确保已安装onnxruntime或onnxruntime-gpu")
             elif file_path.endswith('.engine') or file_path.endswith('.trt'):
                 self.log_message("ℹ 已选择TensorRT模型，确保已安装tensorrt并配置正确")
-    
+
+    # ==================== 类别映射（高级） ====================
+
+    def on_enable_mapping_changed(self, state):
+        """启用映射选项改变"""
+        enabled = state == Qt.CheckState.Checked.value
+        self.btn_load_classes.setEnabled(enabled)
+        self.btn_edit_mapping.setEnabled(enabled and len(self.model_classes) > 0)
+
+    def load_model_classes(self):
+        """加载模型classes.txt文件"""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self, "选择模型classes.txt文件",
+            "", "Text files (*.txt)"
+        )
+        if file_path:
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    classes = [line.strip() for line in f if line.strip()]
+                if classes:
+                    self.model_classes = classes
+                    self.model_classes_label.setText(f"已加载 {len(classes)} 个类别")
+
+                    # 自动创建默认映射（一对一）
+                    self.class_mapping = {i: i for i in range(len(classes))}
+                    self.update_class_mapping_list()
+
+                    self.btn_edit_mapping.setEnabled(True)
+                    self.log_message(f"✓ 成功加载类别文件: {file_path}")
+                    self.log_message(f"  类别: {', '.join(classes[:5])}{'...' if len(classes) > 5 else ''}")
+                else:
+                    QMessageBox.warning(self, "警告", "classes.txt文件为空")
+            except Exception as e:
+                QMessageBox.critical(self, "错误", f"加载classes.txt文件失败: {str(e)}")
+
+    def update_class_mapping_list(self):
+        """更新类别映射列表显示"""
+        self.class_mapping_list.clear()
+
+        if not self.model_classes:
+            return
+
+        # 获取项目类别
+        project_classes = []
+        if self.current_project:
+            classes_json = self.current_project.get('classes', '[]') if isinstance(self.current_project, dict) else '[]'
+            project_classes = json.loads(classes_json) if classes_json else []
+
+        project_class_names = {cls['id']: cls['name'] for cls in project_classes}
+
+        for model_id, project_id in self.class_mapping.items():
+            if model_id < len(self.model_classes):
+                model_name = self.model_classes[model_id]
+                project_name = project_class_names.get(project_id, f"ID:{project_id}")
+                item_text = f"{model_id}: {model_name} → {project_id}: {project_name}"
+                self.class_mapping_list.addItem(item_text)
+
+    def edit_class_mapping(self):
+        """编辑类别映射"""
+        if not self.model_classes:
+            QMessageBox.warning(self, "警告", "请先加载模型classes.txt文件")
+            return
+
+        # 获取项目类别
+        project_classes = []
+        if self.current_project:
+            classes_json = self.current_project.get('classes', '[]') if isinstance(self.current_project, dict) else '[]'
+            project_classes = json.loads(classes_json) if classes_json else []
+
+        if not project_classes:
+            QMessageBox.warning(self, "警告", "当前项目没有类别，请先设置项目类别")
+            return
+
+        # 创建对话框
+        from PyQt6.QtWidgets import QDialog
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle("编辑类别映射")
+        dialog.setMinimumSize(400, 300)
+
+        layout = QVBoxLayout(dialog)
+
+        # 说明标签
+        info_label = QLabel("将模型类别映射到项目类别:")
+        layout.addWidget(info_label)
+
+        # 创建映射选择
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_content = QWidget()
+        scroll_layout = QVBoxLayout(scroll_content)
+
+        mapping_widgets = []
+
+        for i, model_class in enumerate(self.model_classes):
+            row_layout = QHBoxLayout()
+
+            # 模型类别标签
+            full_label_text = f"{i}: {model_class}"
+            model_label = QLabel()
+            model_label.setMinimumWidth(150)
+            model_label.setText(elide_label_text(model_label, full_label_text, width_hint=190))
+            model_label.setToolTip(full_label_text)
+            row_layout.addWidget(model_label)
+
+            row_layout.addWidget(QLabel("→"))
+
+            # 项目类别选择
+            project_combo = QComboBox()
+            for cls in project_classes:
+                project_combo.addItem(f"{cls['id']}: {cls['name']}", cls['id'])
+
+            # 设置当前映射
+            current_mapping = self.class_mapping.get(i, i)
+            index = project_combo.findData(current_mapping)
+            if index >= 0:
+                project_combo.setCurrentIndex(index)
+
+            row_layout.addWidget(project_combo)
+            mapping_widgets.append((i, project_combo))
+
+            scroll_layout.addLayout(row_layout)
+
+        scroll_layout.addStretch()
+        scroll.setWidget(scroll_content)
+        layout.addWidget(scroll)
+
+        # 按钮
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        btn_cancel = QPushButton("取消")
+        btn_cancel.clicked.connect(dialog.reject)
+        btn_layout.addWidget(btn_cancel)
+
+        btn_ok = QPushButton("确定")
+        btn_ok.setObjectName("primary")
+        btn_ok.clicked.connect(dialog.accept)
+        btn_layout.addWidget(btn_ok)
+
+        layout.addLayout(btn_layout)
+
+        # 显示对话框
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            # 更新映射
+            for model_id, combo in mapping_widgets:
+                project_id = combo.currentData()
+                self.class_mapping[model_id] = project_id
+
+            self.update_class_mapping_list()
+            self.log_message(f"✓ 类别映射已更新: {self.class_mapping}")
+
+    # ==================== 数据来源 ====================
+
     def load_data(self, data_type: str):
         """加载数据"""
         if data_type == "image":
@@ -1512,7 +1723,7 @@ class TestPage(QWidget):
             if file_paths:
                 self.data_paths.extend(file_paths)
                 self.log_message(f"已加载 {len(file_paths)} 张图片")
-        
+
         elif data_type == "folder":
             folder_path = QFileDialog.getExistingDirectory(self, "选择图片文件夹")
             if folder_path:
@@ -1522,11 +1733,13 @@ class TestPage(QWidget):
                 for ext in image_extensions:
                     image_files.extend(Path(folder_path).glob(f"*{ext}"))
                     image_files.extend(Path(folder_path).glob(f"*{ext.upper()}"))
-                
+
                 file_paths = [str(f) for f in image_files]
                 self.data_paths.extend(file_paths)
                 self.log_message(f"已从文件夹加载 {len(file_paths)} 张图片")
-        
+                if not file_paths:
+                    QMessageBox.information(self, "提示", "这个文件夹里没有找到图片")
+
         elif data_type == "video":
             file_path, _ = QFileDialog.getOpenFileName(
                 self, "选择视频", "",
@@ -1535,7 +1748,7 @@ class TestPage(QWidget):
             if file_path:
                 self.data_paths.append(file_path)
                 self.log_message(f"已加载视频: {file_path}")
-        
+
         # 更新数据列表显示
         self.update_data_list()
 
@@ -1615,7 +1828,7 @@ class TestPage(QWidget):
         self.log_message(f"已从分组「{group_label}」加载 {added} 张图片")
         if skipped > 0:
             self.log_message(f"  跳过 {skipped} 个（不存在、非图片或已加载）")
-    
+
     def update_data_list(self):
         """更新数据列表显示"""
         self.data_list.clear()
@@ -1623,37 +1836,41 @@ class TestPage(QWidget):
             item = QListWidgetItem(os.path.basename(path))
             item.setToolTip(path)
             self.data_list.addItem(item)
-        
-        self.data_count_label.setText(f"已加载: {len(self.data_paths)} 个文件")
-    
+
+        count = len(self.data_paths)
+        self.data_count_label.setText(f"已选 {count} 个文件" if count else "还没有选择文件")
+        self._update_ready_state()
+
     def clear_data(self):
         """清空数据"""
         self.data_paths.clear()
-        self.data_list.clear()
-        self.data_count_label.setText("已加载: 0 个文件")
-        self.log_message("已清空数据列表")
-    
+        self.update_data_list()
+        self.log_message("已清空待测试的文件")
+
+    # ==================== 运行 ====================
+
     def start_inference(self):
         """开始推理"""
         # 检查是否有数据
         if not self.data_paths:
-            QMessageBox.warning(self, "错误", "请先加载数据")
+            QMessageBox.warning(self, "还不能开始", "请先选择要测试的图片、文件夹或视频")
             return
-        
-        # 清空之前的结果
+
+        # 清空之前的结果（内存里的，以及本次会覆盖的那几个输出文件）
         self.inference_results.clear()
         self.current_data_index = 0
         self.video_player.clear()
-        
+        self._clear_outputs_for_run(self.data_paths)
+
         # 获取项目类别信息
         project_classes = []
         if self.current_project:
             classes_json = self.current_project.get('classes', '[]') if isinstance(self.current_project, dict) else '[]'
             project_classes = json.loads(classes_json) if classes_json else []
-        
+
         # 获取任务类型
         task = self.task_type.currentData()
-        
+
         # 收集配置
         config = {
             'conf': self.conf_threshold.value(),
@@ -1662,30 +1879,19 @@ class TestPage(QWidget):
             'device': self.inference_device.currentText(),
             'task': task,  # 添加任务类型到配置
         }
-        
-        # 确定模型路径
+
+        # 确定模型路径：没有自选模型时退回官方预训练权重
         model_path = self.model_path
         if not model_path:
-            # 使用预训练模型
-            version = self.model_version.currentText()
-            model_size = self.model_size.currentData()
-            
-            if version and model_size:
-                model_prefix = ULTRALYTICS_MODELS[version]['prefix']
-                if task == 'detect':
-                    model_name = f"{model_prefix}{model_size}.pt"
-                else:
-                    task_suffix_map = {"segment": "seg", "classify": "cls", "pose": "pose", "world": "world"}
-                    suffix = task_suffix_map.get(task, task)
-                    model_name = f"{model_prefix}{model_size}-{suffix}.pt"
-                model_path = model_name
+            model_path = self._pretrained_model_name() or None
+            if model_path:
                 self.log_message(f"使用预训练模型: {model_path}")
-        
+
         # 获取类别映射
         class_mapping = {}
         if self.chk_enable_mapping.isChecked():
             class_mapping = self.class_mapping
-        
+
         # 创建推理线程
         self.inference_thread = InferenceThread(
             model_path=model_path,
@@ -1699,101 +1905,152 @@ class TestPage(QWidget):
         self.inference_thread.log_message.connect(self.on_log_message)
         self.inference_thread.result_ready.connect(self.on_result_ready)
         self.inference_thread.frame_ready.connect(self.on_frame_ready)
-        
-        # 更新UI状态
+
+        # 更新UI状态：主操作让位给「停止」，进度和状态都在同一张卡里
+        self.is_running = True
+        self._stopping = False
         self.btn_start_inference.setEnabled(False)
+        self.btn_start_inference.setText("测试中…")
+        self.btn_stop_inference.setVisible(True)
         self.btn_stop_inference.setEnabled(True)
         self.progress_bar.setVisible(True)
         self.progress_bar.setMaximum(len(self.data_paths))
         self.progress_bar.setValue(0)
-        self.status_label.setText("推理中...")
-        self.status_label.setStyleSheet(f"color: {COLORS['primary']}; font-size: 12px;")
-        
+        self._set_status(f"正在测试… 0/{len(self.data_paths)}", "running")
+
+        # 结果区先回到空状态，第一个结果出来会自动切过去
+        self.result_empty.set_text("正在测试…", "第一个结果出来后就会显示在这里。")
+        self.result_stack.setCurrentIndex(0)
+        self.result_count_label.setText("0 / 0")
+        self.btn_export.setEnabled(False)
+        self.btn_prev.setEnabled(False)
+        self.btn_next.setEnabled(False)
+
         # 启动推理
         self.inference_thread.start()
-        
+
         self.log_message("=" * 50)
-        self.log_message("开始推理！")
+        self.log_message("开始测试！")
         self.log_message(f"数据数量: {len(self.data_paths)}")
         if class_mapping:
-            self.log_message(f"类别映射: 已启用")
+            self.log_message("类别映射: 已启用")
         self.log_message("=" * 50)
-    
+
     def stop_inference(self):
-        """停止推理"""
-        if self.inference_thread:
-            self.inference_thread.stop()
-            self.inference_thread.wait()
-        
-        self.reset_ui_state()
-        self.log_message("推理已停止")
-    
+        """停止推理：只发出停止请求，不在界面线程里等。
+
+        原来这里是 stop() 之后直接 wait()——推理线程正卡在一张大图或一段视频上时，
+        wait() 会把界面线程一起冻住：窗口画不动、按钮点不了，看起来就像卡死。
+        现在只置停止标志、把按钮改成「正在停止…」，线程自己跑完当前这张就退出，
+        收尾交给 inference_finished 回调（那条路径本来就会把状态复位）。
+        """
+        thread = self.inference_thread
+        if thread is None or not thread.isRunning():
+            self.reset_ui_state()
+            self._set_status("已停止", "normal")
+            return
+
+        self._stopping = True
+        self.btn_stop_inference.setEnabled(False)
+        self.btn_stop_inference.setText("正在停止…")
+        self._set_status("正在停止…", "running")
+        self.log_message("正在停止测试…（当前这张跑完就停）")
+        thread.stop()
+
     def reset_ui_state(self):
-        """重置UI状态"""
-        self.btn_start_inference.setEnabled(True)
+        """回到「可以再跑一次」的状态。"""
+        self.is_running = False
+        self.btn_start_inference.setText("开始测试")
+        self.btn_stop_inference.setText("停止")
+        self.btn_stop_inference.setVisible(False)
         self.btn_stop_inference.setEnabled(False)
         self.progress_bar.setVisible(False)
-        self.status_label.setText("就绪")
-        self.status_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
-    
+        self._update_ready_state()
+
+    def shutdown(self):
+        """关窗前收工：推理线程还在跑就先请它停，再等它退出。
+
+        这里可以等——窗口都要关了，界面卡不卡已经无所谓；反过来，
+        QThread 在 run() 没结束时被销毁会直接崩。等待仍然给上限。
+        """
+        thread = self.inference_thread
+        if thread is not None and thread.isRunning():
+            thread.stop()
+            thread.wait(5000)
+
     def on_progress_updated(self, current: int, total: int):
         """进度更新"""
         self.progress_bar.setValue(current)
-        self.status_label.setText(f"推理中... {current}/{total}")
-    
+        self._set_status(f"正在测试… {current}/{total}", "running")
+
     def on_inference_finished(self, success: bool, message: str):
         """推理完成"""
+        stopping = self._stopping
+        self._stopping = False
         self.reset_ui_state()
-        
+
         if success:
-            QMessageBox.information(self, "推理完成", message)
-            # 显示第一个结果
+            self._set_status(f"✓ {message}", "success")
             if self.inference_results:
                 self.show_result(0)
+        elif stopping:
+            self._set_status("已停止", "normal")
         else:
-            QMessageBox.warning(self, "推理结束", message)
-        
+            self._set_status(f"✗ {message}", "error")
+            if not self.inference_results:
+                self.result_empty.set_text(
+                    "这次没有得到结果",
+                    message,
+                )
+                self.result_stack.setCurrentIndex(0)
+            QMessageBox.warning(self, "测试结束", message)
+
         # 更新导航按钮状态
         self.update_nav_buttons()
-    
+
     def on_log_message(self, message: str):
         """日志消息"""
         self.log_message(message)
-    
+
     def log_message(self, message: str):
         """添加日志"""
         from datetime import datetime
         timestamp = datetime.now().strftime("%H:%M:%S")
         self.log_text.append(f"[{timestamp}] {message}")
-        
+
         # 自动滚动到底部
         scrollbar = self.log_text.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
-    
+
+    # ==================== 结果 ====================
+
     def on_result_ready(self, result: dict):
         """单张推理结果就绪"""
         self.inference_results.append(result)
-        
+
         # 显示最新结果
         self.show_result(len(self.inference_results) - 1)
-        
+
         # 更新导出按钮
         self.btn_export.setEnabled(True)
-    
+
     def on_frame_ready(self, frame: np.ndarray, detection_info: dict):
         """视频帧就绪"""
         # 保留接口兼容；当前视频流程改为写盘后播放，不再使用内存帧缓存
         if detection_info.get('frame_number') == 0:
             self.result_tabs.setCurrentIndex(1)  # 切换到视频标签页
-    
+
     def show_result(self, index: int):
         """显示指定索引的结果"""
         if not self.inference_results or index < 0 or index >= len(self.inference_results):
             return
-        
+
         self.current_data_index = index
         result = self.inference_results[index]
-        
+
+        # 有结果了，从空状态切到结果视图
+        self.result_stack.setCurrentIndex(1)
+
         # 检查是否为视频
         if result.get('is_video'):
             # 切换到视频标签页
@@ -1804,31 +2061,33 @@ class TestPage(QWidget):
         else:
             # 切换到图像标签页
             self.result_tabs.setCurrentIndex(0)
-            
+
             # 显示写盘后的标注图像
             image_to_show = result.get('annotated_image_path') or result.get('source_path')
             self.image_viewer.show_image(image_to_show)
-        
+
         # 更新结果信息
         info_text = f"""
 <b>文件:</b> {result['filename']}<br>
         """
-        
+
         if result.get('is_video'):
             info_text += f"<b>类型:</b> 视频<br>"
             info_text += f"<b>总帧数:</b> {result.get('total_frames', 0)}<br>"
             info_text += f"<b>已处理:</b> {result.get('processed_frames', 0)} 帧<br>"
         else:
             # 显示检测框信息
-            info_text += f"<b>检测到:</b> {len(result['detections'])} 个目标<br>"
-            
-            if result['detections']:
+            detections = result['detections']
+            if detections:
+                info_text += f"<b>检测到:</b> {len(detections)} 个目标<br>"
                 info_text += "<b>检测详情:</b><br>"
-                for i, det in enumerate(result['detections'][:10]):  # 最多显示10个
+                for i, det in enumerate(detections[:10]):  # 最多显示10个
                     info_text += f"  {i+1}. {det['class_name']} ({det['confidence']:.2f})<br>"
-                if len(result['detections']) > 10:
-                    info_text += f"  ... 还有 {len(result['detections']) - 10} 个目标<br>"
-            
+                if len(detections) > 10:
+                    info_text += f"  ... 还有 {len(detections) - 10} 个目标<br>"
+            else:
+                info_text += "<b>这张图没有检测到目标。</b><br>"
+
             # 显示分割mask信息（如果有）
             if result.get('masks') and len(result['masks']) > 0:
                 info_text += f"<br><b>分割区域:</b> {len(result['masks'])} 个<br>"
@@ -1838,7 +2097,7 @@ class TestPage(QWidget):
                     info_text += f"  {i+1}. {mask['class_name']} ({mask['confidence']:.2f}) - {point_count} 个点<br>"
                 if len(result['masks']) > 10:
                     info_text += f"  ... 还有 {len(result['masks']) - 10} 个分割区域<br>"
-        
+
         if result.get('speed'):
             speed = result['speed']
             info_text += f"<br><b>推理速度:</b><br>"
@@ -1848,65 +2107,70 @@ class TestPage(QWidget):
                 info_text += f"  推理: {speed['inference']:.1f}ms<br>"
             if 'postprocess' in speed:
                 info_text += f"  后处理: {speed['postprocess']:.1f}ms<br>"
-        
+
         self.result_info.setText(info_text)
-        
+
         # 更新计数
         self.result_count_label.setText(f"{index + 1} / {len(self.inference_results)}")
-        
+
         # 更新导航按钮
         self.update_nav_buttons()
-    
+
     def update_nav_buttons(self):
         """更新导航按钮状态"""
         total = len(self.inference_results)
         current = self.current_data_index
-        
+
         self.btn_prev.setEnabled(current > 0)
         self.btn_next.setEnabled(current < total - 1)
-    
+
     def show_previous_result(self):
         """显示上一个结果"""
         if self.current_data_index > 0:
             self.show_result(self.current_data_index - 1)
-    
+
     def show_next_result(self):
         """显示下一个结果"""
         if self.current_data_index < len(self.inference_results) - 1:
             self.show_result(self.current_data_index + 1)
-    
+
+    def open_output_dir(self):
+        """打开保存结果的文件夹。"""
+        self.output_root.mkdir(parents=True, exist_ok=True)
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(self.output_root)))
+
     def export_results(self):
         """导出推理结果"""
         if not self.inference_results:
             QMessageBox.warning(self, "错误", "没有可导出的结果")
             return
-        
+
         # 选择导出目录
         export_dir = QFileDialog.getExistingDirectory(self, "选择导出目录")
         if not export_dir:
             return
-        
+
         try:
             import shutil
-            
+
             # 创建导出子目录
             from datetime import datetime
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             export_subdir = os.path.join(export_dir, f"inference_results_{timestamp}")
             os.makedirs(export_subdir, exist_ok=True)
-            
+
             # 创建images和labels目录
             images_dir = os.path.join(export_subdir, "images")
             labels_dir = os.path.join(export_subdir, "labels")
             os.makedirs(images_dir, exist_ok=True)
             os.makedirs(labels_dir, exist_ok=True)
-            
+
             exported_count = 0
-            
+
             for result in self.inference_results:
                 filename = result['filename']
                 name_without_ext = os.path.splitext(filename)[0]
-                
+
                 if result.get('is_video'):
                     # 导出视频
                     if result.get('annotated_image') is not None:
@@ -1921,7 +2185,7 @@ class TestPage(QWidget):
                     else:
                         # 复制原图
                         shutil.copy2(result['source_path'], os.path.join(images_dir, filename))
-                    
+
                     # 保存标注文件（YOLO格式）
                     label_file = os.path.join(labels_dir, f"{name_without_ext}.txt")
                     with open(label_file, 'w') as f:
@@ -1933,40 +2197,40 @@ class TestPage(QWidget):
                             y_center = (y1 + y2) / 2
                             width = x2 - x1
                             height = y2 - y1
-                            
+
                             # 这里假设图像是640x640，实际应该获取真实尺寸
                             # 简化处理，使用归一化坐标
                             f.write(f"{det['class_id']} {x_center} {y_center} {width} {height}\n")
-                
+
                 exported_count += 1
-            
+
             # 保存推理日志
             log_file = os.path.join(export_subdir, "inference_log.txt")
             with open(log_file, 'w', encoding='utf-8') as f:
                 f.write(self.log_text.toPlainText())
-            
+
             QMessageBox.information(
-                self, 
-                "导出成功", 
+                self,
+                "导出成功",
                 f"已导出 {exported_count} 个结果到:\n{export_subdir}"
             )
             self.log_message(f"✓ 导出完成: {export_subdir}")
-            
+
         except Exception as e:
             QMessageBox.critical(self, "导出失败", f"导出时出错:\n{str(e)}")
             self.log_message(f"✗ 导出失败: {e}")
-    
+
     def clear_log(self):
         """清空日志"""
         self.log_text.clear()
-    
+
     def save_log(self):
         """保存日志"""
         file_path, _ = QFileDialog.getSaveFileName(
             self, "保存日志", "inference_log.txt",
             "文本文件 (*.txt);;所有文件 (*.*)"
         )
-        
+
         if file_path:
             try:
                 with open(file_path, 'w', encoding='utf-8') as f:

--- a/gui/pages/train_page.py
+++ b/gui/pages/train_page.py
@@ -4,7 +4,7 @@
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QComboBox, QSpinBox, QDoubleSpinBox, QGroupBox, QFormLayout,
-    QCheckBox, QSlider, QProgressBar, QTextEdit, QSplitter,
+    QCheckBox, QSlider, QProgressBar, QTextEdit,
     QTabWidget, QFileDialog, QMessageBox, QScrollArea, QFrame,
     QInputDialog, QRadioButton, QListWidget, QListWidgetItem, QButtonGroup,
     QMenu,
@@ -13,9 +13,11 @@ from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSettings
 import os
 import json
 import shutil
+from html import escape
 from typing import Dict, List, Optional
 
-from gui.styles import COLORS, mono_font_family_css
+from gui.styles import COLORS, mono_font_family_css, set_menu_indicator
+from gui.widgets.elided_combo import ElidedComboBox
 from gui.workflow import (
     STEP_IMPORT, STEP_ANNOTATE, STEP_RESULT,
     get_project_snapshot,
@@ -142,6 +144,16 @@ class NoWheelComboBox(QComboBox):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def wheelEvent(self, event):
+        if self.hasFocus():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
+
+
+class ElidedNoWheelComboBox(ElidedComboBox):
+    """训练模板下拉：装不下就省略号收尾，未聚焦时也不吃滚轮。"""
 
     def wheelEvent(self, event):
         if self.hasFocus():
@@ -782,28 +794,22 @@ class TrainPage(QWidget):
         self.refresh_readiness()
 
     def init_ui(self):
-        """初始化界面：左边按顺序配置并开始，右边看进度、曲线和日志。"""
+        """初始化界面：左边按顺序配置并开始，右边看进度、曲线和日志。
+
+        左栏宽度固定，不用 QSplitter——窗口变宽时增量都该给右边的监控面板，
+        左边的配置卡片不应该跟着横向漂移。
+        """
         main_layout = QHBoxLayout(self)
         main_layout.setContentsMargins(20, 16, 20, 16)
         main_layout.setSpacing(16)
 
-        splitter = QSplitter(Qt.Orientation.Horizontal)
-        # 两侧都不许被拖没：主操作和日志任何时候都要看得见
-        splitter.setChildrenCollapsible(False)
+        self.config_panel = self.create_config_panel()
+        self.config_panel.setFixedWidth(360)
+        main_layout.addWidget(self.config_panel)
 
-        left_panel = self.create_config_panel()
-        left_panel.setMinimumWidth(380)
-        splitter.addWidget(left_panel)
-
-        right_panel = self.create_monitor_panel()
-        right_panel.setMinimumWidth(340)
-        splitter.addWidget(right_panel)
-
-        splitter.setStretchFactor(0, 0)
-        splitter.setStretchFactor(1, 1)
-        splitter.setSizes([430, 450])
-
-        main_layout.addWidget(splitter)
+        self.monitor_panel = self.create_monitor_panel()
+        self.monitor_panel.setMinimumWidth(340)
+        main_layout.addWidget(self.monitor_panel, 1)
 
         self.connect_config_signals()
         self.refresh_readiness()
@@ -823,8 +829,8 @@ class TrainPage(QWidget):
         card.setObjectName("card")
 
         layout = QVBoxLayout(card)
-        layout.setContentsMargins(16, 14, 16, 14)
-        layout.setSpacing(10)
+        layout.setContentsMargins(14, 12, 14, 12)
+        layout.setSpacing(8)
 
         heading = QLabel(title)
         heading.setObjectName("h2")
@@ -873,6 +879,9 @@ class TrainPage(QWidget):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
+        # 左栏宽度固定，装不下的内容纵向滚动就好，不许再横向滚出一条杠
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.config_scroll = scroll
 
         self.scroll_content = QWidget()
         scroll_layout = QVBoxLayout(self.scroll_content)
@@ -932,7 +941,7 @@ class TrainPage(QWidget):
         card, layout = self.make_card("基础配置")
 
         form = QFormLayout()
-        form.setSpacing(10)
+        form.setSpacing(8)
         form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
 
         # 模板行也走表单：以前它是卡片里单独一条 QHBoxLayout，标签列和字段列
@@ -978,19 +987,33 @@ class TrainPage(QWidget):
         row.setContentsMargins(0, 0, 0, 0)
         row.setSpacing(8)
 
-        self.template_combo = NoWheelComboBox()
+        self.template_combo = ElidedNoWheelComboBox()
         self.template_combo.setToolTip("把一套调好的参数存下来，下次直接套用。")
         self.template_combo.currentTextChanged.connect(self.on_template_selection_changed)
+        # 名字可以任意长，但这一行还要给两个按钮留位置：内容再长也不能把行撑宽，
+        # 装不下就交给 ElidedNoWheelComboBox 画省略号，而不是把 scroll_content 撑出横向滚动条
+        self.template_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        )
+        self.template_combo.setMinimumContentsLength(1)
+        self.template_combo.setMinimumWidth(40)
         row.addWidget(self.template_combo, 1)
+
+        compact_button_style = """
+            QPushButton { padding: 5px 8px; }
+            QPushButton[menuIndicator="true"] { padding-right: 30px; }
+        """
 
         self.btn_apply_template = QPushButton("套用")
         self.btn_apply_template.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_apply_template.setStyleSheet(compact_button_style)
         self.btn_apply_template.clicked.connect(self.apply_selected_template)
         row.addWidget(self.btn_apply_template)
 
         # 文案里不再自己写 ▾：挂了菜单的按钮，Qt 会再画一个箭头，写死一个就成了双箭头
         self.btn_template_menu = QPushButton("管理")
         self.btn_template_menu.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_template_menu.setStyleSheet(compact_button_style)
         menu = QMenu(self.btn_template_menu)
         self.action_save_template = menu.addAction("把当前参数保存为模板…")
         self.action_save_template.triggered.connect(self.save_current_as_template)
@@ -999,6 +1022,7 @@ class TrainPage(QWidget):
         self.action_delete_template = menu.addAction("删除所选模板")
         self.action_delete_template.triggered.connect(self.delete_selected_template)
         self.btn_template_menu.setMenu(menu)
+        set_menu_indicator(self.btn_template_menu)
         row.addWidget(self.btn_template_menu)
 
         return holder
@@ -1042,7 +1066,7 @@ class TrainPage(QWidget):
         group = QGroupBox("训练细节")
 
         layout = QFormLayout(group)
-        layout.setSpacing(10)
+        layout.setSpacing(8)
         layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
 
         # Batch Size
@@ -1090,7 +1114,7 @@ class TrainPage(QWidget):
         group = QGroupBox("数据增强")
 
         layout = QFormLayout(group)
-        layout.setSpacing(10)
+        layout.setSpacing(8)
 
         # Mosaic
         self.mosaic = QCheckBox("启用 Mosaic 增强")
@@ -1144,7 +1168,7 @@ class TrainPage(QWidget):
 
         self.ratio_split_widget = QWidget()
         ratio_layout = QFormLayout(self.ratio_split_widget)
-        ratio_layout.setSpacing(10)
+        ratio_layout.setSpacing(8)
         
         # 训练集比例
         self.train_split = NoWheelSlider(Qt.Orientation.Horizontal)
@@ -1361,11 +1385,32 @@ class TrainPage(QWidget):
         """④ 训练摘要：开始前把这次要跑的东西用人话摆出来。"""
         card, layout = self.make_card("训练摘要")
 
+        # 富文本：一行「训练轮数：100 轮」里，真正要人看清的是 100，
+        # 纯文本做不出这个层次——项目名、类别名之类的动态内容全部转义后才拼进去。
         self.summary_label = QLabel("")
         self.summary_label.setWordWrap(True)
+        self.summary_label.setTextFormat(Qt.TextFormat.RichText)
         layout.addWidget(self.summary_label)
 
         return card
+
+    def _summary_value(self, text: str, accent: bool = False) -> str:
+        """摘要里的一个值：加粗，可选蓝色。text 必须已经转义。"""
+        color = COLORS['accent_text'] if accent else COLORS['text_primary']
+        return f'<span style="color:{color}; font-weight:600;">{text}</span>'
+
+    def _summary_unit(self, text: str) -> str:
+        """跟在值后面的单位（轮、%、px）：灰、不加粗，把数字衬出来。"""
+        return f'<span style="color:{COLORS["text_secondary"]};">{escape(text)}</span>'
+
+    def _summary_row(self, label: str, value_html: str) -> str:
+        """一行：左边灰色说明，右边值。"""
+        return (
+            f'<tr>'
+            f'<td style="color:{COLORS["text_secondary"]};">{escape(label)}</td>'
+            f'<td>{value_html}</td>'
+            f'</tr>'
+        )
 
     def update_summary(self):
         """把当前表单翻译成几行人话。"""
@@ -1396,17 +1441,41 @@ class TrainPage(QWidget):
         if self.hsv.isChecked():
             augments.append(f"HSV {self.hsv_strength.value()}%")
 
-        lines = [
-            f"模型：{self.model_version.currentText()} · "
-            f"{self.model_size.currentText() or '-'} · {self.task_type.currentText() or '-'}",
-            f"训练轮数：{self.epochs.value()} 轮　　计算设备：{self.device.currentText()}",
-            f"数据划分：{split_text}",
-            f"数据增强：{'、'.join(augments) if augments else '全部关闭'}",
-            f"其他：批大小 {self.batch_size.value()} · 图片尺寸 {self.img_size.value()} · "
-            f"学习率 {self.lr.value():.4f} · 优化器 {self.optimizer.currentText()} · "
-            f"加载线程 {self.workers.value()}",
+        # 模型这一行：版本和型号是这次训练最要紧的两个选择，用蓝色点出来；
+        # 任务类型跟着它们走，用普通的深色。
+        sep = self._summary_unit(" · ")
+        model_html = sep.join([
+            self._summary_value(escape(self.model_version.currentText()), accent=True),
+            self._summary_value(escape(self.model_size.currentText() or '-'), accent=True),
+            self._summary_value(escape(self.task_type.currentText() or '-')),
+        ])
+
+        other_html = sep.join([
+            self._summary_unit("批大小 ") + self._summary_value(escape(str(self.batch_size.value()))),
+            self._summary_unit("图片尺寸 ") + self._summary_value(escape(str(self.img_size.value()))),
+            self._summary_unit("学习率 ") + self._summary_value(escape(f"{self.lr.value():.4f}")),
+            self._summary_unit("优化器 ") + self._summary_value(escape(self.optimizer.currentText())),
+            self._summary_unit("加载线程 ") + self._summary_value(escape(str(self.workers.value()))),
+        ])
+
+        rows = [
+            self._summary_row("模型", model_html),
+            self._summary_row(
+                "训练轮数",
+                self._summary_value(escape(str(self.epochs.value()))) + self._summary_unit(" 轮"),
+            ),
+            self._summary_row("计算设备", self._summary_value(escape(self.device.currentText()))),
+            self._summary_row("数据划分", self._summary_value(escape(split_text))),
+            self._summary_row(
+                "数据增强",
+                self._summary_value(escape('、'.join(augments) if augments else '全部关闭')),
+            ),
+            self._summary_row("其他", other_html),
         ]
-        self.summary_label.setText("\n".join(lines))
+
+        self.summary_label.setText(
+            f'<table cellspacing="0" cellpadding="3">{"".join(rows)}</table>'
+        )
 
     def connect_config_signals(self):
         """任何配置改动都要反映到摘要里，否则摘要就是骗人的。"""

--- a/gui/pages/train_page.py
+++ b/gui/pages/train_page.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import (
     QCheckBox, QSlider, QProgressBar, QTextEdit, QSplitter,
     QTabWidget, QFileDialog, QMessageBox, QScrollArea, QFrame,
     QInputDialog, QRadioButton, QListWidget, QListWidgetItem, QButtonGroup,
+    QMenu,
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSettings
 import os
@@ -14,7 +15,11 @@ import json
 import shutil
 from typing import Dict, List, Optional
 
-from gui.styles import COLORS
+from gui.styles import COLORS, mono_font_family_css
+from gui.workflow import (
+    STEP_IMPORT, STEP_ANNOTATE, STEP_RESULT,
+    get_project_snapshot,
+)
 from models.database import db
 
 UNGROUPED_GROUP_ID = 0
@@ -157,6 +162,44 @@ class NoWheelSlider(QSlider):
             super().wheelEvent(event)
         else:
             event.ignore()
+
+
+class CollapsibleSection(QWidget):
+    """默认收起的区域：点标题才展开，避免一进页面就是一堵参数墙。"""
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        self._title = title
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        self.toggle = QPushButton()
+        self.toggle.setObjectName("ghost")
+        self.toggle.setCheckable(True)
+        self.toggle.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.toggle.setMinimumHeight(34)
+        self.toggle.setStyleSheet("text-align: left; padding-left: 6px;")
+        self.toggle.toggled.connect(self._on_toggled)
+        layout.addWidget(self.toggle)
+
+        self.content = QWidget()
+        content_layout = QVBoxLayout(self.content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(12)
+        self.content.setVisible(False)
+        layout.addWidget(self.content)
+
+        self._content_layout = content_layout
+        self._on_toggled(False)
+
+    def _on_toggled(self, checked: bool):
+        self.content.setVisible(checked)
+        self.toggle.setText(f"{'▾' if checked else '▸'} {self._title}")
+
+    def add_widget(self, widget: QWidget):
+        self._content_layout.addWidget(widget)
 
 
 class TrainingThread(QThread):
@@ -342,7 +385,13 @@ class TrainingThread(QThread):
                 
                 if metrics.get('map50'):
                     self.log_message.emit(f"  验证指标 - mAP50: {metrics['map50']:.4f}, mAP50-95: {metrics.get('map50_95', 0):.4f}")
-            
+
+                # 用户点了停止：让 Ultralytics 在本轮收尾后自己退出循环。
+                # 界面线程因此不需要 wait() 干等到整个训练跑完。
+                if not self._is_running:
+                    trainer.stop = True
+                    self.log_message.emit("已收到停止请求，本轮结束后停止训练")
+
             def on_fit_epoch_end(trainer):
                 """每个fit epoch结束时调用（包含验证）"""
                 pass
@@ -705,10 +754,16 @@ class TrainPage(QWidget):
         self.training_history = []
         self.settings = QSettings("EzYOLO", "Settings")
         self.training_templates = {}
-        
+
+        # 当前项目的进度事实 + 「为什么还不能训练」
+        self.snapshot = get_project_snapshot(None)
+        self.blocker = None
+        self.stop_requested = False
+        self.total_epochs = 0
+
         self.init_ui()
         self.load_training_templates()
-    
+
     def set_project(self, project_id: int):
         """设置当前项目"""
         self.current_project_id = project_id
@@ -719,31 +774,71 @@ class TrainPage(QWidget):
                 print(f"[TrainPage] 已切换到项目: {project_name} (ID: {project_id})")
         else:
             print("[TrainPage] 项目已取消选择")
-        if hasattr(self, 'refresh_split_group_lists'):
-            self.refresh_split_group_lists()
-    
+
+        self.refresh_split_group_lists()
+        # 训练进行中就别动界面状态，免得把「停止」按钮换回「开始」
+        if not self.is_training_active():
+            self.reset_ui_state()
+        self.refresh_readiness()
+
     def init_ui(self):
-        """初始化界面"""
+        """初始化界面：左边按顺序配置并开始，右边看进度、曲线和日志。"""
         main_layout = QHBoxLayout(self)
-        main_layout.setContentsMargins(20, 20, 20, 20)
+        main_layout.setContentsMargins(20, 16, 20, 16)
         main_layout.setSpacing(16)
-        
-        # 创建分割器
+
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        
-        # 左侧：配置面板
+        # 两侧都不许被拖没：主操作和日志任何时候都要看得见
+        splitter.setChildrenCollapsible(False)
+
         left_panel = self.create_config_panel()
+        left_panel.setMinimumWidth(380)
         splitter.addWidget(left_panel)
-        
-        # 右侧：监控面板
+
         right_panel = self.create_monitor_panel()
+        right_panel.setMinimumWidth(340)
         splitter.addWidget(right_panel)
-        
-        # 设置分割比例
-        splitter.setSizes([400, 800])
-        
+
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([430, 450])
+
         main_layout.addWidget(splitter)
-    
+
+        self.connect_config_signals()
+        self.refresh_readiness()
+
+    def is_training_active(self) -> bool:
+        return self.training_thread is not None and self.training_thread.isRunning()
+
+    def goto_step(self, index: int):
+        """跳到主流程的某一步（主窗口负责真正的切换）。"""
+        window = self.window()
+        if hasattr(window, 'switch_page'):
+            window.switch_page(index)
+
+    def make_card(self, title: str, subtitle: str = "") -> tuple:
+        """一张卡片 = 一个步骤：标题 + 一句大白话 + 内容。"""
+        card = QFrame()
+        card.setObjectName("card")
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+
+        heading = QLabel(title)
+        heading.setObjectName("h2")
+        heading.setWordWrap(True)
+        layout.addWidget(heading)
+
+        if subtitle:
+            note = QLabel(subtitle)
+            note.setObjectName("caption")
+            note.setWordWrap(True)
+            layout.addWidget(note)
+
+        return card, layout
+
     def _init_model_lists(self):
         """初始化型号和任务列表"""
         version = self.model_version.currentText()
@@ -769,144 +864,154 @@ class TrainPage(QWidget):
                 self.task_type.addItem(display_name, task)
     
     def create_config_panel(self) -> QWidget:
-        """创建配置面板"""
+        """左栏：① 确认数据 → ② 基础配置 → ③ 高级参数（可选）→ ④ 摘要，⑤ 开始/停止固定在底部。"""
         panel = QWidget()
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("训练配置")
-        title.setObjectName("title")
-        title.setStyleSheet("font-size: 20px; font-weight: bold;")
-        layout.addWidget(title)
+        layout.setSpacing(12)
 
-        template_bar = self.create_template_bar()
-        layout.addWidget(template_bar)
-        
-        # 创建滚动区域
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
-        
-        scroll_content = QWidget()
-        scroll_layout = QVBoxLayout(scroll_content)
-        scroll_layout.setSpacing(16)
-        
-        # 模型选择组
-        model_group = self.create_model_group()
-        scroll_layout.addWidget(model_group)
-        
-        # 训练参数组
-        params_group = self.create_params_group()
-        scroll_layout.addWidget(params_group)
-        
-        # 数据增强组
-        augment_group = self.create_augment_group()
-        scroll_layout.addWidget(augment_group)
-        
-        # 数据集划分组
-        split_group = self.create_split_group()
-        scroll_layout.addWidget(split_group)
-        
-        # 控制按钮组
-        control_group = self.create_control_group()
-        scroll_layout.addWidget(control_group)
-        
+
+        self.scroll_content = QWidget()
+        scroll_layout = QVBoxLayout(self.scroll_content)
+        scroll_layout.setContentsMargins(0, 0, 6, 0)
+        scroll_layout.setSpacing(12)
+
+        scroll_layout.addWidget(self.create_prep_card())
+        scroll_layout.addWidget(self.create_basic_card())
+        scroll_layout.addWidget(self.create_advanced_section())
+        scroll_layout.addWidget(self.create_summary_card())
         scroll_layout.addStretch()
-        scroll.setWidget(scroll_content)
-        layout.addWidget(scroll)
-        
+
+        scroll.setWidget(self.scroll_content)
+        layout.addWidget(scroll, 1)
+
+        # 开始 / 停止不放进滚动区：窗口再小也不会被滚没
+        layout.addWidget(self.create_run_panel())
+
         return panel
 
-    def create_template_bar(self) -> QWidget:
-        """创建训练模板工具条。"""
-        bar = QFrame()
-        bar.setStyleSheet(f"""
-            QFrame {{
-                background-color: {COLORS['panel']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-            }}
-        """)
-        layout = QVBoxLayout(bar)
-        layout.setContentsMargins(10, 8, 10, 8)
-        layout.setSpacing(8)
+    def create_prep_card(self) -> QFrame:
+        """① 数据准备情况：图片、标注、类别齐了没有，缺什么、去哪补。"""
+        card, layout = self.make_card("数据准备")
 
-        top_row = QHBoxLayout()
-        top_row.setSpacing(8)
-        top_row.addWidget(QLabel("训练模板:"))
+        self.prep_labels = {}
+        for key in ('images', 'annotated', 'classes', 'model'):
+            label = QLabel("")
+            label.setWordWrap(True)
+            layout.addWidget(label)
+            self.prep_labels[key] = label
 
-        self.template_combo = NoWheelComboBox()
-        self.template_combo.currentTextChanged.connect(self.on_template_selection_changed)
-        top_row.addWidget(self.template_combo, 1)
-        layout.addLayout(top_row)
+        self.prep_hint = QLabel("")
+        self.prep_hint.setWordWrap(True)
+        self.prep_hint.setStyleSheet(f"color: {COLORS['warning']};")
+        self.prep_hint.hide()
+        layout.addWidget(self.prep_hint)
 
-        button_row = QHBoxLayout()
-        button_row.setSpacing(8)
-        self.btn_apply_template = QPushButton("套用模板")
-        self.btn_apply_template.clicked.connect(self.apply_selected_template)
-        button_row.addWidget(self.btn_apply_template)
+        goto_row = QHBoxLayout()
+        goto_row.setContentsMargins(0, 0, 0, 0)
+        self.btn_prep_goto = QPushButton("")
+        self.btn_prep_goto.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_prep_goto.clicked.connect(self.on_prep_goto_clicked)
+        self.btn_prep_goto.hide()
+        goto_row.addWidget(self.btn_prep_goto)
+        goto_row.addStretch()
+        layout.addLayout(goto_row)
 
-        self.btn_save_template = QPushButton("保存为模板")
-        self.btn_save_template.clicked.connect(self.save_current_as_template)
-        button_row.addWidget(self.btn_save_template)
+        return card
 
-        self.btn_update_template = QPushButton("更新模板")
-        self.btn_update_template.clicked.connect(self.update_selected_template)
-        button_row.addWidget(self.btn_update_template)
+    def on_prep_goto_clicked(self):
+        """「去补上」：跳到缺东西的那一步。"""
+        if self.blocker:
+            self.goto_step(self.blocker['action_index'])
 
-        self.btn_delete_template = QPushButton("删除模板")
-        self.btn_delete_template.clicked.connect(self.delete_selected_template)
-        button_row.addWidget(self.btn_delete_template)
+    def create_basic_card(self) -> QFrame:
+        """② 基础配置：只放小白必须做的选择，其余都有默认值。"""
+        card, layout = self.make_card("基础配置")
 
-        layout.addLayout(button_row)
-        return bar
-    
-    def get_group_style(self) -> str:
-        """获取分组框样式"""
-        return f"""
-            QGroupBox {{
-                font-weight: bold;
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                margin-top: 12px;
-                padding-top: 10px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px;
-            }}
-        """
-    
-    def create_model_group(self) -> QGroupBox:
-        """创建模型选择组"""
-        group = QGroupBox("模型选择")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QFormLayout(group)
-        layout.setSpacing(10)
-        
-        # YOLO版本选择
+        form = QFormLayout()
+        form.setSpacing(10)
+        form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+
+        # 模板行也走表单：以前它是卡片里单独一条 QHBoxLayout，标签列和字段列
+        # 都比下面的表单窄一截，六行控件的左边缘对不上一条线
+        form.addRow("训练模板:", self.create_template_row())
+
         self.model_version = NoWheelComboBox()
         self.model_version.addItems(sorted(ULTRALYTICS_MODELS.keys()))
+        self.model_version.setToolTip("YOLO 的版本。不清楚选哪个就用默认的。")
         self.model_version.currentTextChanged.connect(self.on_version_changed)
-        layout.addRow("版本:", self.model_version)
-        
-        # 模型型号选择
+        form.addRow("YOLO 版本:", self.model_version)
+
         self.model_size = NoWheelComboBox()
-        layout.addRow("型号:", self.model_size)
-        
-        # 任务类型
+        self.model_size.setToolTip("模型越大越准，但训练更慢、更吃显存。第一次建议用 nano。")
+        form.addRow("模型大小:", self.model_size)
+
         self.task_type = NoWheelComboBox()
-        layout.addRow("任务:", self.task_type)
-        
-        # 立即初始化型号和任务列表
+        self.task_type.setToolTip("要和你的标注方式对上：画框选「目标检测」，描轮廓选「实例分割」。")
+        form.addRow("任务类型:", self.task_type)
+
+        # 型号和任务列表依赖版本，先建好三个下拉再填
         self._init_model_lists()
-        
-        return group
-    
+
+        self.epochs = NoWheelSpinBox()
+        self.epochs.setRange(1, 1000)
+        self.epochs.setValue(100)
+        self.epochs.setToolTip("模型把所有训练图片反复看多少遍。轮数越多越慢，也不是越多越好。")
+        form.addRow("训练轮数:", self.epochs)
+
+        self.device = NoWheelComboBox()
+        self.device.addItems(["自动选择", "CPU", "CUDA:0", "CUDA:1", "CUDA:2", "CUDA:3"])
+        self.device.setToolTip("自动选择：有 NVIDIA 显卡就用显卡，没有就用 CPU（会慢很多）。")
+        form.addRow("计算设备:", self.device)
+
+        layout.addLayout(form)
+
+        return card
+
+    def create_template_row(self) -> QWidget:
+        """训练模板：一行「选择 + 套用」，增删改收进菜单，不在页面上堆四个同级按钮。"""
+        holder = QWidget()
+        row = QHBoxLayout(holder)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(8)
+
+        self.template_combo = NoWheelComboBox()
+        self.template_combo.setToolTip("把一套调好的参数存下来，下次直接套用。")
+        self.template_combo.currentTextChanged.connect(self.on_template_selection_changed)
+        row.addWidget(self.template_combo, 1)
+
+        self.btn_apply_template = QPushButton("套用")
+        self.btn_apply_template.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_apply_template.clicked.connect(self.apply_selected_template)
+        row.addWidget(self.btn_apply_template)
+
+        # 文案里不再自己写 ▾：挂了菜单的按钮，Qt 会再画一个箭头，写死一个就成了双箭头
+        self.btn_template_menu = QPushButton("管理")
+        self.btn_template_menu.setCursor(Qt.CursorShape.PointingHandCursor)
+        menu = QMenu(self.btn_template_menu)
+        self.action_save_template = menu.addAction("把当前参数保存为模板…")
+        self.action_save_template.triggered.connect(self.save_current_as_template)
+        self.action_update_template = menu.addAction("用当前参数更新所选模板")
+        self.action_update_template.triggered.connect(self.update_selected_template)
+        self.action_delete_template = menu.addAction("删除所选模板")
+        self.action_delete_template.triggered.connect(self.delete_selected_template)
+        self.btn_template_menu.setMenu(menu)
+        row.addWidget(self.btn_template_menu)
+
+        return holder
+
+    def create_advanced_section(self) -> QWidget:
+        """③ 高级参数：默认收起。"""
+        section = CollapsibleSection("高级参数")
+        section.add_widget(self.create_params_group())
+        section.add_widget(self.create_augment_group())
+        section.add_widget(self.create_split_group())
+        self.advanced_section = section
+        return section
+
     def on_version_changed(self, version: str):
         """版本改变时更新型号和任务"""
         if not version or version not in ULTRALYTICS_MODELS:
@@ -933,67 +1038,60 @@ class TrainPage(QWidget):
             return
     
     def create_params_group(self) -> QGroupBox:
-        """创建训练参数组"""
-        group = QGroupBox("训练参数")
-        group.setStyleSheet(self.get_group_style())
-        
+        """训练细节：影响明显，所以收在高级里，默认值适合大多数情况。"""
+        group = QGroupBox("训练细节")
+
         layout = QFormLayout(group)
         layout.setSpacing(10)
-        
-        # Epochs
-        self.epochs = NoWheelSpinBox()
-        self.epochs.setRange(1, 1000)
-        self.epochs.setValue(100)
-        layout.addRow("Epochs:", self.epochs)
-        
+        layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+
         # Batch Size
         self.batch_size = NoWheelSpinBox()
         self.batch_size.setRange(1, 128)
         self.batch_size.setValue(16)
-        layout.addRow("Batch Size:", self.batch_size)
-        
+        self.batch_size.setToolTip("一次同时看多少张图。显存不够（日志里报 out of memory）就往小调：16 → 8 → 4。")
+        layout.addRow("批大小:", self.batch_size)
+
         # Image Size
         self.img_size = NoWheelSpinBox()
         self.img_size.setRange(320, 1280)
         self.img_size.setValue(640)
         self.img_size.setSingleStep(32)
-        layout.addRow("Image Size:", self.img_size)
-        
+        self.img_size.setToolTip("训练时把图片统一缩放到这个大小。越大越慢；要认的东西很小可以调大。")
+        layout.addRow("图片尺寸:", self.img_size)
+
         # Learning Rate
         self.lr = NoWheelDoubleSpinBox()
         self.lr.setRange(0.0001, 0.1)
         self.lr.setValue(0.01)
         self.lr.setDecimals(4)
         self.lr.setSingleStep(0.001)
-        layout.addRow("Learning Rate:", self.lr)
-        
+        self.lr.setToolTip("模型每一步调整的幅度。没有把握就别改。")
+        layout.addRow("学习率:", self.lr)
+
         # Optimizer
         self.optimizer = NoWheelComboBox()
         self.optimizer.addItems(["SGD", "Adam", "AdamW", "LION"])
-        layout.addRow("Optimizer:", self.optimizer)
-        
-        # Device
-        self.device = NoWheelComboBox()
-        self.device.addItems(["自动选择", "CPU", "CUDA:0", "CUDA:1", "CUDA:2", "CUDA:3"])
-        layout.addRow("Device:", self.device)
-        
+        self.optimizer.setToolTip("模型的「调参策略」。默认 SGD 最稳。")
+        layout.addRow("优化器:", self.optimizer)
+
         # Workers
         self.workers = NoWheelSpinBox()
         self.workers.setRange(0, 32)
         self.workers.setValue(4)
         self.workers.setSingleStep(1)
-        layout.addRow("Workers:", self.workers)
-        
+        self.workers.setToolTip("读图片的并行线程数。Windows 上如果训练一开始就卡住，可以设为 0。")
+        layout.addRow("数据加载线程:", self.workers)
+
         return group
-    
+
     def create_augment_group(self) -> QGroupBox:
         """创建数据增强组"""
         group = QGroupBox("数据增强")
-        group.setStyleSheet(self.get_group_style())
-        
+
         layout = QFormLayout(group)
         layout.setSpacing(10)
-        
+
         # Mosaic
         self.mosaic = QCheckBox("启用 Mosaic 增强")
         self.mosaic.setChecked(True)
@@ -1028,8 +1126,7 @@ class TrainPage(QWidget):
     def create_split_group(self) -> QGroupBox:
         """创建数据集划分组"""
         group = QGroupBox("数据集划分")
-        group.setStyleSheet(self.get_group_style())
-        
+
         layout = QVBoxLayout(group)
         layout.setSpacing(10)
 
@@ -1053,6 +1150,7 @@ class TrainPage(QWidget):
         self.train_split = NoWheelSlider(Qt.Orientation.Horizontal)
         self.train_split.setRange(50, 95)
         self.train_split.setValue(80)
+        self.train_split.setMinimumWidth(120)
         self.train_split.valueChanged.connect(self.on_split_changed)
         self.train_label = QLabel("80%")
         split_layout = QHBoxLayout()
@@ -1064,6 +1162,7 @@ class TrainPage(QWidget):
         self.val_split = NoWheelSlider(Qt.Orientation.Horizontal)
         self.val_split.setRange(5, 30)
         self.val_split.setValue(10)
+        self.val_split.setMinimumWidth(120)
         self.val_split.valueChanged.connect(self.on_split_changed)
         self.val_label = QLabel("10%")
         split_layout = QHBoxLayout()
@@ -1075,6 +1174,7 @@ class TrainPage(QWidget):
         self.test_split = NoWheelSlider(Qt.Orientation.Horizontal)
         self.test_split.setRange(0, 20)
         self.test_split.setValue(10)
+        self.test_split.setMinimumWidth(120)
         self.test_split.valueChanged.connect(self.on_split_changed)
         self.test_label = QLabel("10%")
         split_layout = QHBoxLayout()
@@ -1084,6 +1184,7 @@ class TrainPage(QWidget):
         
         # 总和提示
         self.split_warning = QLabel("")
+        self.split_warning.setWordWrap(True)
         self.split_warning.setStyleSheet(f"color: {COLORS['error']}; font-size: 12px;")
         ratio_layout.addRow(self.split_warning)
         layout.addWidget(self.ratio_split_widget)
@@ -1105,6 +1206,7 @@ class TrainPage(QWidget):
         group_layout.addRow("测试集分组:", self.test_group_list)
 
         self.group_split_warning = QLabel("")
+        self.group_split_warning.setWordWrap(True)
         self.group_split_warning.setStyleSheet(f"color: {COLORS['error']}; font-size: 12px;")
         group_layout.addRow(self.group_split_warning)
 
@@ -1119,6 +1221,7 @@ class TrainPage(QWidget):
 
     def _create_group_check_list(self) -> QListWidget:
         widget = QListWidget()
+        widget.itemChanged.connect(self.on_group_selection_changed)
         widget.setMaximumHeight(110)
         widget.setStyleSheet(f"""
             QListWidget {{
@@ -1139,6 +1242,20 @@ class TrainPage(QWidget):
         self.group_split_widget.setVisible(use_groups)
         if use_groups:
             self.refresh_split_group_lists()
+        self.update_group_split_warning()
+        self.update_summary()
+
+    def on_group_selection_changed(self, _item: QListWidgetItem):
+        """勾选分组时立刻回报问题，别等到点了开始才报错。"""
+        self.update_group_split_warning()
+        self.update_summary()
+
+    def update_group_split_warning(self):
+        if not hasattr(self, 'group_split_warning') or not self.split_mode_groups.isChecked():
+            return
+        # 只做不查库的快速检查，勾一下就查一次图片数会卡
+        error = self._validate_group_split_selection(check_images=False)
+        self.group_split_warning.setText(f"⚠️ {error}" if error else "")
 
     def refresh_split_group_lists(self):
         """刷新按分组划分时的分组列表。"""
@@ -1194,7 +1311,7 @@ class TrainPage(QWidget):
                 group_ids.append(item.data(Qt.ItemDataRole.UserRole))
         return group_ids
 
-    def _validate_group_split_selection(self) -> Optional[str]:
+    def _validate_group_split_selection(self, check_images: bool = True) -> Optional[str]:
         train_ids = self._get_checked_group_ids(self.train_group_list)
         val_ids = self._get_checked_group_ids(self.val_group_list)
         test_ids = self._get_checked_group_ids(self.test_group_list)
@@ -1212,7 +1329,7 @@ class TrainPage(QWidget):
             if overlap:
                 return f"{name_a}与{name_b}选择了重复的分组，请调整"
 
-        if self.current_project_id:
+        if check_images and self.current_project_id:
             train_count = len(db.get_project_images_by_groups(self.current_project_id, train_ids))
             val_count = len(db.get_project_images_by_groups(self.current_project_id, val_ids))
             if train_count == 0:
@@ -1221,79 +1338,280 @@ class TrainPage(QWidget):
                 return "验证集所选分组中没有图片"
 
         return None
-    
+
     def on_split_changed(self):
         """数据集划分改变"""
         train = self.train_split.value()
         val = self.val_split.value()
         test = self.test_split.value()
-        
+
         self.train_label.setText(f"{train}%")
         self.val_label.setText(f"{val}%")
         self.test_label.setText(f"{test}%")
-        
+
         total = train + val + test
         if total != 100:
             self.split_warning.setText(f"⚠️ 总和为 {total}%，应为 100%")
         else:
             self.split_warning.setText("")
+
+        self.update_summary()
     
-    def create_control_group(self) -> QGroupBox:
-        """创建控制按钮组"""
-        group = QGroupBox("训练控制")
-        group.setStyleSheet(self.get_group_style())
-        
-        layout = QVBoxLayout(group)
-        layout.setSpacing(10)
-        
-        # 进度条
-        self.progress_bar = QProgressBar()
-        self.progress_bar.setVisible(False)
-        self.progress_bar.setStyleSheet(f"""
-            QProgressBar {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                text-align: center;
-                color: white;
-                height: 20px;
-            }}
-            QProgressBar::chunk {{
-                background-color: {COLORS['primary']};
-                border-radius: 3px;
-            }}
-        """)
-        layout.addWidget(self.progress_bar)
-        
-        # 状态标签
-        self.status_label = QLabel("就绪")
-        self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.status_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
+    def create_summary_card(self) -> QFrame:
+        """④ 训练摘要：开始前把这次要跑的东西用人话摆出来。"""
+        card, layout = self.make_card("训练摘要")
+
+        self.summary_label = QLabel("")
+        self.summary_label.setWordWrap(True)
+        layout.addWidget(self.summary_label)
+
+        return card
+
+    def update_summary(self):
+        """把当前表单翻译成几行人话。"""
+        if not hasattr(self, 'summary_label'):
+            return
+
+        if self.split_mode_groups.isChecked():
+            split_text = (
+                f"按分组指定 · 训练 {len(self._get_checked_group_ids(self.train_group_list))} 组 / "
+                f"验证 {len(self._get_checked_group_ids(self.val_group_list))} 组 / "
+                f"测试 {len(self._get_checked_group_ids(self.test_group_list))} 组"
+            )
+        else:
+            split_text = (
+                f"按比例随机划分 · 训练 {self.train_split.value()}% / "
+                f"验证 {self.val_split.value()}% / 测试 {self.test_split.value()}%"
+            )
+
+        augments = []
+        if self.mosaic.isChecked():
+            augments.append("Mosaic")
+        if self.mixup.isChecked():
+            augments.append("MixUp")
+        if self.flip.isChecked():
+            augments.append("水平翻转")
+        if self.rotate.isChecked():
+            augments.append("随机旋转")
+        if self.hsv.isChecked():
+            augments.append(f"HSV {self.hsv_strength.value()}%")
+
+        lines = [
+            f"模型：{self.model_version.currentText()} · "
+            f"{self.model_size.currentText() or '-'} · {self.task_type.currentText() or '-'}",
+            f"训练轮数：{self.epochs.value()} 轮　　计算设备：{self.device.currentText()}",
+            f"数据划分：{split_text}",
+            f"数据增强：{'、'.join(augments) if augments else '全部关闭'}",
+            f"其他：批大小 {self.batch_size.value()} · 图片尺寸 {self.img_size.value()} · "
+            f"学习率 {self.lr.value():.4f} · 优化器 {self.optimizer.currentText()} · "
+            f"加载线程 {self.workers.value()}",
+        ]
+        self.summary_label.setText("\n".join(lines))
+
+    def connect_config_signals(self):
+        """任何配置改动都要反映到摘要里，否则摘要就是骗人的。"""
+        for combo in (self.model_version, self.model_size, self.task_type,
+                      self.optimizer, self.device):
+            combo.currentIndexChanged.connect(self.update_summary)
+
+        for spin in (self.epochs, self.batch_size, self.img_size, self.workers):
+            spin.valueChanged.connect(self.update_summary)
+        self.lr.valueChanged.connect(self.update_summary)
+
+        for check in (self.mosaic, self.mixup, self.flip, self.rotate, self.hsv):
+            check.toggled.connect(self.update_summary)
+        self.hsv_strength.valueChanged.connect(self.update_summary)
+
+    def create_run_panel(self) -> QFrame:
+        """⑤ 开始 / 停止 / 完成后去哪。固定在左栏底部，永远看得见。"""
+        card, layout = self.make_card("开始训练")
+
+        self.status_label = QLabel("准备就绪")
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet(f"color: {COLORS['text_secondary']};")
         layout.addWidget(self.status_label)
-        
-        # 按钮布局
-        btn_layout = QHBoxLayout()
-        
-        # 开始按钮
-        self.btn_start = QPushButton("▶ 开始训练")
-        self.btn_start.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {COLORS['success']};
-                color: white;
-                font-weight: bold;
-                padding: 12px 30px;
-                font-size: 14px;
-            }}
-        """)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        self.btn_start = QPushButton("开始训练")
+        self.btn_start.setObjectName("primary")
+        self.btn_start.setMinimumHeight(40)
+        self.btn_start.setCursor(Qt.CursorShape.PointingHandCursor)
         self.btn_start.clicked.connect(self.start_training)
-        btn_layout.addWidget(self.btn_start)
-        
-        # 居中布局
-        btn_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
-        layout.addLayout(btn_layout)
-        
-        return group
+        layout.addWidget(self.btn_start)
+
+        # 训练中才出现，和「开始」互斥，不和别的按钮挤在一排
+        self.btn_stop = QPushButton("停止")
+        self.btn_stop.setObjectName("danger")
+        self.btn_stop.setMinimumHeight(40)
+        self.btn_stop.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_stop.setToolTip("会在当前这一轮跑完后停下。已经跑完的轮次仍然保留。")
+        self.btn_stop.clicked.connect(self.stop_training)
+        self.btn_stop.hide()
+        layout.addWidget(self.btn_stop)
+
+        # 训练完成后出现：模型在哪、下一步去哪
+        self.done_label = QLabel("")
+        self.done_label.setWordWrap(True)
+        self.done_label.hide()
+        layout.addWidget(self.done_label)
+
+        done_row = QHBoxLayout()
+        done_row.setContentsMargins(0, 0, 0, 0)
+        done_row.setSpacing(8)
+
+        self.btn_goto_result = QPushButton("查看训练结果")
+        self.btn_goto_result.setObjectName("primary")
+        self.btn_goto_result.setMinimumHeight(36)
+        self.btn_goto_result.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_goto_result.clicked.connect(lambda: self.goto_step(STEP_RESULT))
+        self.btn_goto_result.hide()
+        done_row.addWidget(self.btn_goto_result, 1)
+
+        self.btn_train_again = QPushButton("再训练一次")
+        self.btn_train_again.setMinimumHeight(36)
+        self.btn_train_again.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_train_again.clicked.connect(self.reset_ui_state)
+        self.btn_train_again.hide()
+        done_row.addWidget(self.btn_train_again)
+
+        layout.addLayout(done_row)
+
+        return card
+
+    def set_status(self, text: str, color: str = None):
+        self.status_label.setText(text)
+        self.status_label.setStyleSheet(f"color: {color or COLORS['text_secondary']};")
+
+    def show_done_panel(self):
+        """训练完成：说清楚产出在哪、下一步该去哪。"""
+        weights = self.snapshot.get('weights')
+        lines = ["✓ 训练完成。"]
+        if weights:
+            # 绝对路径可能很长，省略中段显示，完整路径放进 tooltip，避免硬换行截断
+            metrics = self.done_label.fontMetrics()
+            elided = metrics.elidedText(str(weights), Qt.TextElideMode.ElideMiddle, 320)
+            lines.append(f"模型权重（best.pt）：{elided}")
+            self.done_label.setToolTip(str(weights))
+        else:
+            self.done_label.setToolTip("")
+        lines.append("下一步：到「4. 结果分析」看曲线和指标；确认可用后再去「5. 模型测试」拿新图片试。")
+        self.done_label.setText("\n".join(lines))
+
+        # 完成后主操作变成「查看训练结果」，所以开始按钮先让位
+        self.btn_start.hide()
+        self.done_label.show()
+        self.btn_goto_result.show()
+        self.btn_train_again.show()
+
+    def hide_done_panel(self):
+        self.done_label.hide()
+        self.btn_goto_result.hide()
+        self.btn_train_again.hide()
+
+    def refresh_readiness(self):
+        """重新读项目事实，回答「现在能不能训练」，不能就说清缺什么、去哪补。"""
+        self.snapshot = get_project_snapshot(self.current_project_id)
+
+        images = self.snapshot.get('image_count', 0)
+        annotated = self.snapshot.get('annotated_count', 0)
+        classes = self.snapshot.get('class_count', 0)
+        weights = self.snapshot.get('weights')
+
+        ok = COLORS['success']
+        bad = COLORS['error']
+        muted = COLORS['text_secondary']
+
+        if not self.current_project_id:
+            self.set_prep_row('images', "✗ 还没有选择项目", bad)
+            self.set_prep_row('annotated', "标注情况：等选好项目再看", muted)
+            self.set_prep_row('classes', "类别情况：等选好项目再看", muted)
+            self.set_prep_row('model', "", muted)
+            self.blocker = {
+                'reason': "还没有选择项目。先在左上角选一个，或去「1. 数据导入」新建。",
+                'action_text': "去数据导入",
+                'action_index': STEP_IMPORT,
+            }
+        else:
+            if images:
+                self.set_prep_row('images', f"✓ 已导入 {images} 张图片", ok)
+            else:
+                self.set_prep_row('images', "✗ 项目里还没有图片", bad)
+
+            if annotated == 0:
+                self.set_prep_row('annotated', "✗ 一张标注也没有，模型没有可学的材料", bad)
+            elif annotated < images:
+                self.set_prep_row(
+                    'annotated',
+                    f"✓ 已标注 {annotated}/{images} 张",
+                    ok,
+                    tooltip=f"没标注的那 {images - annotated} 张也会送去训练，当成「里面没有目标」的背景图。",
+                )
+            else:
+                self.set_prep_row('annotated', f"✓ {images} 张图片全部标注完成", ok)
+
+            if classes:
+                self.set_prep_row('classes', f"✓ 已设置 {classes} 个类别", ok)
+            else:
+                self.set_prep_row('classes', "✗ 还没有类别，模型不知道要认什么", bad)
+
+            if weights:
+                self.set_prep_row(
+                    'model',
+                    "· 再次训练会覆盖上一次的结果目录（runs/train/exp_"
+                    f"{self.current_project_id}）。",
+                    muted,
+                )
+            else:
+                self.set_prep_row('model', "", muted)
+
+            if images == 0:
+                self.blocker = {
+                    'reason': "项目里还没有图片，去「1. 数据导入」导入。",
+                    'action_text': "去导入图片",
+                    'action_index': STEP_IMPORT,
+                }
+            elif annotated == 0:
+                self.blocker = {
+                    'reason': "还没有标注，去「2. 数据标注」标注几张图片。",
+                    'action_text': "去标注图片",
+                    'action_index': STEP_ANNOTATE,
+                }
+            elif classes == 0:
+                self.blocker = {
+                    'reason': "还没有设置类别，去「2. 数据标注」添加类别。",
+                    'action_text': "去添加类别",
+                    'action_index': STEP_ANNOTATE,
+                }
+            else:
+                self.blocker = None
+
+        if self.blocker:
+            self.prep_hint.setText(self.blocker['reason'])
+            self.prep_hint.show()
+            self.btn_prep_goto.setText(self.blocker['action_text'])
+            self.btn_prep_goto.show()
+        else:
+            self.prep_hint.hide()
+            self.btn_prep_goto.hide()
+
+        if not self.is_training_active():
+            self.btn_start.setEnabled(self.blocker is None)
+            self.btn_start.setToolTip(
+                self.blocker['reason'] if self.blocker else "用上面的配置开始训练"
+            )
+
+        self.update_summary()
+
+    def set_prep_row(self, key: str, text: str, color: str, tooltip: str = ""):
+        label = self.prep_labels[key]
+        label.setText(text)
+        label.setVisible(bool(text))
+        label.setStyleSheet(f"color: {color};")
+        label.setToolTip(tooltip)
 
     def load_training_templates(self):
         """加载全局训练模板。"""
@@ -1342,8 +1660,8 @@ class TrainPage(QWidget):
         current_name = self.template_combo.currentText() if hasattr(self, "template_combo") else NO_TEMPLATE_OPTION
         has_template = current_name in self.training_templates
         self.btn_apply_template.setEnabled(has_template)
-        self.btn_update_template.setEnabled(has_template)
-        self.btn_delete_template.setEnabled(has_template)
+        self.action_update_template.setEnabled(has_template)
+        self.action_delete_template.setEnabled(has_template)
 
     def collect_training_form_config(self) -> dict:
         """收集当前表单配置。"""
@@ -1450,6 +1768,9 @@ class TrainPage(QWidget):
         _apply_checks(self.train_group_list, config.get('train_group_ids'))
         _apply_checks(self.val_group_list, config.get('val_group_ids'))
         _apply_checks(self.test_group_list, config.get('test_group_ids'))
+
+        self.update_group_split_warning()
+        self.update_summary()
         return True
 
     def save_current_as_template(self):
@@ -1592,54 +1913,23 @@ class TrainPage(QWidget):
         }
     
     def create_monitor_panel(self) -> QWidget:
-        """创建监控面板"""
+        """右栏：训练过程中发生了什么。"""
         panel = QWidget()
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(16)
-        
-        # 标题
-        title = QLabel("训练监控")
+        layout.setSpacing(10)
+
+        title = QLabel("训练过程")
         title.setObjectName("title")
-        title.setStyleSheet("font-size: 20px; font-weight: bold;")
         layout.addWidget(title)
-        
-        # 标签页
-        tabs = QTabWidget()
-        tabs.setStyleSheet(f"""
-            QTabWidget::pane {{
-                border: 1px solid {COLORS['border']};
-                border-radius: 6px;
-                background-color: {COLORS['panel']};
-            }}
-            QTabBar::tab {{
-                background-color: {COLORS['sidebar']};
-                color: {COLORS['text_secondary']};
-                padding: 8px 16px;
-                margin-right: 4px;
-                border-top-left-radius: 4px;
-                border-top-right-radius: 4px;
-            }}
-            QTabBar::tab:selected {{
-                background-color: {COLORS['primary']};
-                color: white;
-            }}
-        """)
-        
-        # 损失曲线标签页
-        loss_tab = self.create_loss_tab()
-        tabs.addTab(loss_tab, "📉 损失曲线")
-        
-        # mAP曲线标签页
-        map_tab = self.create_map_tab()
-        tabs.addTab(map_tab, "📈 mAP曲线")
-        
-        # 日志标签页
-        log_tab = self.create_log_tab()
-        tabs.addTab(log_tab, "📝 训练日志")
-        
-        layout.addWidget(tabs)
-        
+
+        self.monitor_tabs = QTabWidget()
+        self.monitor_tabs.addTab(self.create_loss_tab(), "损失曲线")
+        self.monitor_tabs.addTab(self.create_map_tab(), "mAP 曲线")
+        self.log_tab_index = self.monitor_tabs.addTab(self.create_log_tab(), "训练日志")
+
+        layout.addWidget(self.monitor_tabs, 1)
+
         return panel
     
     def create_loss_tab(self) -> QWidget:
@@ -1660,23 +1950,23 @@ class TrainPage(QWidget):
         self.loss_ax.set_xlabel('Epoch', color=COLORS['text_primary'])
         self.loss_ax.set_ylabel('Loss', color=COLORS['text_primary'])
         self.loss_ax.tick_params(colors=COLORS['text_primary'])
-        self.loss_ax.grid(True, alpha=0.3)
-        
+        for spine in self.loss_ax.spines.values():
+            spine.set_color(COLORS['border'])
+        self.loss_ax.grid(True, alpha=0.3, color=COLORS['border'])
+
         # 初始化空曲线
         self.loss_lines = {
-            'box': self.loss_ax.plot([], [], 'b-', label='Box Loss', linewidth=2)[0],
-            'cls': self.loss_ax.plot([], [], 'r-', label='Cls Loss', linewidth=2)[0],
-            'dfl': self.loss_ax.plot([], [], 'g-', label='DFL Loss', linewidth=2)[0],
+            'box': self.loss_ax.plot([], [], color=COLORS['primary'], label='Box Loss', linewidth=2)[0],
+            'cls': self.loss_ax.plot([], [], color=COLORS['error_fill'], label='Cls Loss', linewidth=2)[0],
+            'dfl': self.loss_ax.plot([], [], color=COLORS['success_fill'], label='DFL Loss', linewidth=2)[0],
         }
-        # 设置标签颜色为白色
-        self.loss_ax.legend(loc='upper right', facecolor=COLORS['sidebar'], edgecolor=COLORS['border'], labelcolor='white')
-        # 设置坐标轴文字颜色为白色
-        self.loss_ax.xaxis.label.set_color('white')
-        self.loss_ax.yaxis.label.set_color('white')
-        # 设置刻度文字颜色为白色
-        self.loss_ax.tick_params(axis='x', colors='white')
-        self.loss_ax.tick_params(axis='y', colors='white')
-        
+        # 图例、坐标轴文字、刻度统一用主文字色，浅色背景下才看得清（不能再写死白色）
+        self.loss_ax.legend(loc='upper right', facecolor=COLORS['sidebar'], edgecolor=COLORS['border'], labelcolor=COLORS['text_primary'])
+        self.loss_ax.xaxis.label.set_color(COLORS['text_primary'])
+        self.loss_ax.yaxis.label.set_color(COLORS['text_primary'])
+        self.loss_ax.tick_params(axis='x', colors=COLORS['text_primary'])
+        self.loss_ax.tick_params(axis='y', colors=COLORS['text_primary'])
+
         return tab
     
     def create_map_tab(self) -> QWidget:
@@ -1697,23 +1987,23 @@ class TrainPage(QWidget):
         self.map_ax.set_xlabel('Epoch', color=COLORS['text_primary'])
         self.map_ax.set_ylabel('mAP', color=COLORS['text_primary'])
         self.map_ax.tick_params(colors=COLORS['text_primary'])
-        self.map_ax.grid(True, alpha=0.3)
+        for spine in self.map_ax.spines.values():
+            spine.set_color(COLORS['border'])
+        self.map_ax.grid(True, alpha=0.3, color=COLORS['border'])
         self.map_ax.set_ylim(0, 1)
-        
+
         # 初始化空曲线
         self.map_lines = {
-            'map50': self.map_ax.plot([], [], 'b-', label='mAP50', linewidth=2)[0],
-            'map50_95': self.map_ax.plot([], [], 'r-', label='mAP50-95', linewidth=2)[0],
+            'map50': self.map_ax.plot([], [], color=COLORS['primary'], label='mAP50', linewidth=2)[0],
+            'map50_95': self.map_ax.plot([], [], color=COLORS['error_fill'], label='mAP50-95', linewidth=2)[0],
         }
-        # 设置标签颜色为白色
-        self.map_ax.legend(loc='lower right', facecolor=COLORS['sidebar'], edgecolor=COLORS['border'], labelcolor='white')
-        # 设置坐标轴文字颜色为白色
-        self.map_ax.xaxis.label.set_color('white')
-        self.map_ax.yaxis.label.set_color('white')
-        # 设置刻度文字颜色为白色
-        self.map_ax.tick_params(axis='x', colors='white')
-        self.map_ax.tick_params(axis='y', colors='white')
-        
+        # 图例、坐标轴文字、刻度统一用主文字色，浅色背景下才看得清（不能再写死白色）
+        self.map_ax.legend(loc='lower right', facecolor=COLORS['sidebar'], edgecolor=COLORS['border'], labelcolor=COLORS['text_primary'])
+        self.map_ax.xaxis.label.set_color(COLORS['text_primary'])
+        self.map_ax.yaxis.label.set_color(COLORS['text_primary'])
+        self.map_ax.tick_params(axis='x', colors=COLORS['text_primary'])
+        self.map_ax.tick_params(axis='y', colors=COLORS['text_primary'])
+
         return tab
     
     def create_log_tab(self) -> QWidget:
@@ -1724,6 +2014,7 @@ class TrainPage(QWidget):
         # 日志文本框
         self.log_text = QTextEdit()
         self.log_text.setReadOnly(True)
+        mono = mono_font_family_css()
         self.log_text.setStyleSheet(f"""
             QTextEdit {{
                 background-color: {COLORS['sidebar']};
@@ -1731,7 +2022,7 @@ class TrainPage(QWidget):
                 border: 1px solid {COLORS['border']};
                 border-radius: 6px;
                 padding: 10px;
-                font-family: 'Consolas', 'Monaco', monospace;
+                {f'font-family: {mono};' if mono else ''}
                 font-size: 12px;
             }}
         """)
@@ -1740,11 +2031,11 @@ class TrainPage(QWidget):
         # 日志按钮
         btn_layout = QHBoxLayout()
         
-        self.btn_clear_log = QPushButton("🗑 清空日志")
+        self.btn_clear_log = QPushButton("清空")
         self.btn_clear_log.clicked.connect(self.clear_log)
         btn_layout.addWidget(self.btn_clear_log)
-        
-        self.btn_save_log = QPushButton("💾 保存日志")
+
+        self.btn_save_log = QPushButton("保存")
         self.btn_save_log.clicked.connect(self.save_log)
         btn_layout.addWidget(self.btn_save_log)
         
@@ -1755,9 +2046,10 @@ class TrainPage(QWidget):
     
     def start_training(self):
         """开始训练"""
-        # 检查是否选择了项目
-        if not self.current_project_id:
-            QMessageBox.warning(self, "错误", "请先选择一个项目")
+        # 前置条件：项目、图片、标注、类别，缺一样就说清楚缺什么
+        self.refresh_readiness()
+        if self.blocker:
+            QMessageBox.warning(self, "还不能开始训练", self.blocker['reason'])
             return
 
         form_config = self.maybe_confirm_template_before_training()
@@ -1778,16 +2070,6 @@ class TrainPage(QWidget):
                 QMessageBox.warning(self, "配置错误", "数据集划分比例总和必须等于100%")
                 return
 
-        project = db.get_project(self.current_project_id)
-        if project:
-            classes = json.loads(project.get('classes') or '[]')
-            if not classes:
-                QMessageBox.warning(
-                    self, "配置错误",
-                    "项目未设置类别，请先在标注页添加任务类别后再训练"
-                )
-                return
-
         config = self.build_training_runtime_config(form_config)
         if not config:
             QMessageBox.warning(self, "错误", "请选择有效的模型版本和型号")
@@ -1796,14 +2078,14 @@ class TrainPage(QWidget):
         version = config['version']
         model_size = config['model_size']
         task = config['task']
-        
+
         # 清空历史
         self.training_history = []
         self.log_text.clear()
-        
+
         # 清空曲线数据
         self.clear_plots()
-        
+
         # 创建训练线程
         self.training_thread = TrainingThread(config, self.current_project_id)
         self.training_thread.epoch_started.connect(self.on_epoch_started)
@@ -1812,61 +2094,87 @@ class TrainPage(QWidget):
         self.training_thread.training_finished.connect(self.on_training_finished)
         self.training_thread.log_message.connect(self.on_log_message)
         self.training_thread.metrics_updated.connect(self.on_metrics_updated)
-        
-        # 更新UI状态
-        self.btn_start.setEnabled(False)
+
+        # 更新UI状态：开始让位给停止，配置区锁住（改了也不会生效，别让人误会）
+        self.stop_requested = False
+        self.total_epochs = config['epochs']
+        self.hide_done_panel()
+        self.scroll_content.setEnabled(False)
+        self.btn_start.hide()
+        self.btn_stop.setEnabled(True)
+        self.btn_stop.show()
         self.progress_bar.setVisible(True)
         self.progress_bar.setMaximum(config['epochs'])
         self.progress_bar.setValue(0)
-        self.status_label.setText("训练中...")
-        self.status_label.setStyleSheet(f"color: {COLORS['primary']}; font-size: 12px;")
-        
+        self.set_status(
+            "正在准备数据、加载模型…第一轮开始前要复制图片，可能要等一会。",
+            COLORS['accent_text'],
+        )
+
+        # 曲线要等第一轮跑完才有数据，先让用户看到日志在动
+        self.monitor_tabs.setCurrentIndex(self.log_tab_index)
+
         # 启动训练
         self.training_thread.start()
-        
+
         self.log_message("=" * 50)
         self.log_message("训练开始！")
         self.log_message(f"模型: {version} {model_size} ({task})")
         self.log_message(f"Epochs: {config['epochs']}, Batch: {config['batch_size']}")
         self.log_message("=" * 50)
-    
-    def pause_training(self):
-        """暂停/恢复训练"""
-        if self.training_thread:
-            if self.btn_pause.text() == "⏸ 暂停":
-                self.training_thread.pause()
-                self.btn_pause.setText("▶ 继续")
-                self.status_label.setText("已暂停")
-                self.status_label.setStyleSheet(f"color: {COLORS['warning']}; font-size: 12px;")
-            else:
-                self.training_thread.resume()
-                self.btn_pause.setText("⏸ 暂停")
-                self.status_label.setText("训练中...")
-                self.status_label.setStyleSheet(f"color: {COLORS['primary']}; font-size: 12px;")
-    
+
     def stop_training(self):
-        """停止训练"""
-        if self.training_thread:
-            self.training_thread.stop()
-            self.training_thread.wait()
-        
-        self.reset_ui_state()
-        self.log_message("训练已停止")
-    
+        """停止训练：只发请求，不阻塞界面。"""
+        if not self.is_training_active():
+            self.reset_ui_state()
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "停止训练",
+            "确定要停止这次训练吗？\n\n"
+            "会在当前这一轮跑完后停下（可能还要等几分钟）。\n"
+            "已经跑完的轮次会保留在 runs 目录里，但这次训练不会再继续。",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self.stop_requested = True
+        self.training_thread.stop()
+        self.btn_stop.setEnabled(False)
+        self.set_status("正在停止…当前这一轮跑完就会停下。", COLORS['warning'])
+        self.log_message("已请求停止训练，等待当前轮次结束…")
+
     def reset_ui_state(self):
-        """重置UI状态"""
-        self.btn_start.setEnabled(True)
+        """回到「可以开始训练」的样子。"""
+        self.hide_done_panel()
+        self.btn_stop.hide()
+        self.btn_start.show()
+        self.btn_start.setEnabled(self.blocker is None)
         self.progress_bar.setVisible(False)
-        self.status_label.setText("就绪")
-        self.status_label.setStyleSheet(f"color: {COLORS['text_secondary']}; font-size: 12px;")
-    
+        self.scroll_content.setEnabled(True)
+        self.set_status("准备就绪")
+
     def on_epoch_started(self, epoch: int, total: int):
         """Epoch开始"""
+        self.total_epochs = total
+        self.progress_bar.setMaximum(total)
         self.progress_bar.setValue(epoch - 1)
-        self.status_label.setText(f"训练中... Epoch {epoch}/{total}")
-    
+        if self.stop_requested:
+            return
+        self.set_status(f"训练中… 第 {epoch}/{total} 轮", COLORS['accent_text'])
+
     def on_epoch_finished(self, epoch: int, metrics: dict):
         """Epoch完成"""
+        self.progress_bar.setValue(epoch)
+        if not self.stop_requested:
+            text = f"训练中… 已完成 {epoch}/{self.total_epochs} 轮"
+            if metrics.get('map50'):
+                text += f"，当前 mAP50 {metrics['map50']:.3f}"
+            self.set_status(text, COLORS['accent_text'])
+
         # 确保所有指标值都是标量
         def to_scalar(value):
             import torch
@@ -1945,13 +2253,33 @@ class TrainPage(QWidget):
         pass
     
     def on_training_finished(self, success: bool, message: str):
-        """训练完成"""
-        self.reset_ui_state()
-        
+        """训练结束：完成、被停止、或者失败。"""
+        self.btn_stop.hide()
+        self.progress_bar.setVisible(False)
+        self.scroll_content.setEnabled(True)
+
         if success:
+            # 重新读一次项目事实，才知道模型落在哪里
+            self.refresh_readiness()
+            self.set_status("训练完成", COLORS['success'])
+            self.show_done_panel()
             QMessageBox.information(self, "训练完成", message)
+            return
+
+        self.reset_ui_state()
+
+        if self.stop_requested:
+            self.set_status("已停止训练", COLORS['warning'])
+            QMessageBox.information(
+                self, "已停止训练",
+                "训练已停止。已经跑完的轮次结果保留在 runs 目录里，随时可以重新开始一次训练。"
+            )
         else:
-            QMessageBox.warning(self, "训练结束", message)
+            self.set_status("训练失败，看右边的训练日志找原因", COLORS['error'])
+            QMessageBox.warning(
+                self, "训练没能完成",
+                f"{message}\n\n右边「训练日志」里有完整报错，可以保存下来再排查。"
+            )
     
     def on_log_message(self, message: str):
         """日志消息"""

--- a/gui/pages/visualize_page.py
+++ b/gui/pages/visualize_page.py
@@ -1,31 +1,65 @@
 # -*- coding: utf-8 -*-
 """
 可视化页面
+
+占位页。训练可视化已经并进主流程——曲线和指标在「④ 结果分析」，
+在新数据上验证在「⑤ 模型测试」——这里不再单独实现，也没有挂在主窗口里，
+保留只是为了兼容旧入口。真进来了就把话说清楚：这页是干什么的、现在什么状态、回哪去。
 """
 
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame
 
 
 class VisualizePage(QWidget):
     """可视化页面"""
-    
+
     def __init__(self):
         super().__init__()
         self.init_ui()
-    
+
     def init_ui(self):
         """初始化界面"""
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(20, 20, 20, 20)
-        
-        # 标题
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(24, 24, 24, 24)
+        outer.addStretch()
+
+        card = QFrame()
+        card.setObjectName("card")
+        card.setMaximumWidth(560)
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(28, 26, 28, 26)
+        layout.setSpacing(10)
+
+        badge_row = QHBoxLayout()
+        badge_row.setContentsMargins(0, 0, 0, 0)
+        badge_row.setSpacing(10)
+
+        badge = QLabel("占位页")
+        badge.setObjectName("step_badge")
+        badge_row.addWidget(badge)
+
         title = QLabel("训练可视化")
-        title.setObjectName("title")
-        layout.addWidget(title)
-        
-        # 说明文字
-        desc = QLabel("查看训练结果和模型性能")
-        desc.setObjectName("subtitle")
-        layout.addWidget(desc)
-        
-        layout.addStretch()
+        title.setObjectName("h2")
+        badge_row.addWidget(title)
+        badge_row.addStretch()
+
+        layout.addLayout(badge_row)
+
+        for text in (
+            "用途：查看训练曲线、准确率指标和预测示例。",
+            "当前状态：这些内容已经并入主流程，本页不再单独提供。",
+            "回到主流程：左侧「④ 结果分析」看曲线和指标，「⑤ 模型测试」拿新图片验证模型。",
+        ):
+            label = QLabel(text)
+            label.setObjectName("subtitle")
+            label.setWordWrap(True)
+            layout.addWidget(label)
+
+        row = QHBoxLayout()
+        row.addStretch()
+        row.addWidget(card)
+        row.addStretch()
+        outer.addLayout(row)
+
+        outer.addStretch()

--- a/gui/styles.py
+++ b/gui/styles.py
@@ -23,6 +23,7 @@ EzYOLO 样式定义
     subtitle 说明 / caption 辅助小字 / muted 弱化 / value 大数字
 """
 
+from pathlib import Path
 from typing import List
 
 # ==================== 颜色令牌 ====================
@@ -175,12 +176,47 @@ def _font_family_declaration() -> str:
     return f"    font-family: {', '.join(families)};\n"
 
 
+# ==================== 箭头图标 ====================
+
+# 下拉框和数字框的箭头。Qt 的规矩是：一旦用样式表接管 ::drop-down / ::up-button，
+# 系统画的那个箭头就一起没了——下拉框会剩一个 macOS 原生的黑色小三角贴在角上，
+# 数字框则连上下箭头都不剩（试过：只写 ::up-button 不写 ::up-arrow，步进器整个消失）。
+# 所以箭头得自己给。QSS 里能画出箭头的只有 image: url(...)：border 拼三角那套
+# CSS 技巧 Qt 不认（它不做斜接，直接糊成一个方块）。
+#
+# 这些 svg 由本项目自己画，没有第三方素材。颜色跟下面的令牌对齐——
+# 正常态 COLORS['primary']、禁用态 COLORS['text_disabled']；改令牌时记得一起改。
+_ASSETS_DIR = Path(__file__).parent / "assets"
+
+
+def _arrow_url(name: str) -> str:
+    """QSS 的 url() 要一个能直接打开的路径，所以给绝对路径（POSIX 分隔符，Windows 也认）。"""
+    return (_ASSETS_DIR / name).as_posix()
+
+
+def set_menu_indicator(button, enabled: bool = True):
+    """标记带菜单的按钮，并立即刷新动态属性对应的样式。"""
+    button.setProperty("menuIndicator", bool(enabled))
+    style = button.style()
+    if style is not None:
+        style.unpolish(button)
+        style.polish(button)
+    button.updateGeometry()
+    button.update()
+
+
 # ==================== 样式表 ====================
 
 def generate_stylesheet(colors: dict) -> str:
     """根据颜色令牌生成全局样式表。"""
     c = colors
     font_family = _font_family_declaration()
+
+    chevron_down = _arrow_url("chevron_down.svg")
+    chevron_down_white = _arrow_url("chevron_down_white.svg")
+    chevron_up = _arrow_url("chevron_up.svg")
+    chevron_down_off = _arrow_url("chevron_down_disabled.svg")
+    chevron_up_off = _arrow_url("chevron_up_disabled.svg")
 
     return f"""
 /* ---------- 基础 ---------- */
@@ -418,6 +454,29 @@ QPushButton:disabled {{
     border-color: {c['border']};
 }}
 
+/* QPushButton 的菜单箭头不交给平台绘制：macOS 会退化成黑点或空白。 */
+QPushButton[menuIndicator="true"] {{
+    padding-right: 32px;
+}}
+
+QPushButton[menuIndicator="true"]::menu-indicator {{
+    image: url({chevron_down});
+    subcontrol-origin: padding;
+    subcontrol-position: right center;
+    width: 12px;
+    height: 12px;
+    right: 10px;
+}}
+
+QPushButton#primary[menuIndicator="true"]::menu-indicator {{
+    image: url({chevron_down_white});
+}}
+
+QPushButton[menuIndicator="true"]::menu-indicator:disabled,
+QPushButton#primary[menuIndicator="true"]::menu-indicator:disabled {{
+    image: url({chevron_down_off});
+}}
+
 QPushButton#secondary {{
     background-color: {c['panel']};
     color: {c['text_primary']};
@@ -531,7 +590,39 @@ QLineEdit:disabled, QComboBox:disabled, QSpinBox:disabled, QDoubleSpinBox:disabl
     border-color: {c['border']};
 }}
 
-/* 下拉箭头交给 Qt 自己画：自定义 ::drop-down 会把箭头一起干掉 */
+/* 箭头区要先占住位置，否则长选项的文字会压到箭头底下 */
+QComboBox {{
+    padding-right: 28px;
+}}
+
+QSpinBox, QDoubleSpinBox {{
+    padding-right: 22px;
+}}
+
+/* 下拉框：整块都能点开，所以不给箭头区画边框/底色，只在悬停时亮一个浅色圆角块 */
+QComboBox::drop-down {{
+    subcontrol-origin: padding;
+    subcontrol-position: center right;
+    width: 24px;
+    margin: 3px 3px 3px 0;
+    border: none;
+    border-radius: 6px;
+    background-color: transparent;
+}}
+
+QComboBox::drop-down:hover {{
+    background-color: {c['hover']};
+}}
+
+QComboBox::down-arrow {{
+    image: url({chevron_down});
+    width: 12px;
+    height: 12px;
+}}
+
+QComboBox::down-arrow:disabled {{
+    image: url({chevron_down_off});
+}}
 
 QComboBox QAbstractItemView {{
     background-color: {c['panel']};
@@ -544,16 +635,63 @@ QComboBox QAbstractItemView {{
     selection-color: {c['text_primary']};
 }}
 
+/* 行距。注意：macOS 上下拉弹层是系统画的，样式表管不到它——选中行仍是系统那条
+   蓝底白字（清楚可读，所以不去动它；强行换成 QListView 反而会让当前项没有任何
+   高亮）。这条和上面的 selection-* 是给其他平台的。 */
+QComboBox QAbstractItemView::item {{
+    padding: 5px 8px;
+    border-radius: 6px;
+    min-height: 20px;
+}}
+
+/* 数字框的步进器：跟下拉框同一套雪佛龙，上下各占一半高 */
 QSpinBox::up-button, QDoubleSpinBox::up-button,
 QSpinBox::down-button, QDoubleSpinBox::down-button {{
-    background-color: transparent;
+    subcontrol-origin: padding;
+    width: 20px;
+    height: 11px;
     border: none;
-    width: 16px;
+    border-radius: 4px;
+    margin-right: 3px;
+    background-color: transparent;
+}}
+
+QSpinBox::up-button, QDoubleSpinBox::up-button {{
+    subcontrol-position: top right;
+    margin-top: 3px;
+}}
+
+QSpinBox::down-button, QDoubleSpinBox::down-button {{
+    subcontrol-position: bottom right;
+    margin-bottom: 3px;
 }}
 
 QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,
 QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {{
     background-color: {c['hover']};
+}}
+
+QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {{
+    image: url({chevron_up});
+    width: 9px;
+    height: 9px;
+}}
+
+QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {{
+    image: url({chevron_down});
+    width: 9px;
+    height: 9px;
+}}
+
+/* 到头了 / 整个控件禁用：箭头转灰，不再假装还能点 */
+QSpinBox::up-arrow:disabled, QSpinBox::up-arrow:off,
+QDoubleSpinBox::up-arrow:disabled, QDoubleSpinBox::up-arrow:off {{
+    image: url({chevron_up_off});
+}}
+
+QSpinBox::down-arrow:disabled, QSpinBox::down-arrow:off,
+QDoubleSpinBox::down-arrow:disabled, QDoubleSpinBox::down-arrow:off {{
+    image: url({chevron_down_off});
 }}
 
 QTextEdit {{

--- a/gui/styles.py
+++ b/gui/styles.py
@@ -1,457 +1,799 @@
 # -*- coding: utf-8 -*-
 """
 EzYOLO 样式定义
-支持深色主题和浅色主题
+
+一套集中管理的设计令牌（颜色 / 字体 / 圆角 / 尺寸）+ 全局样式表。
+页面通过 objectName 声明「这是什么」，样式在这里统一给出，
+避免每个页面各写一份内联 QSS。
+
+外观基调：浅色、克制、层级靠留白和字重拉开，而不是靠色块和粗边框。
+表面只有三层——画布（background）、卡片（panel）、控件（inset）；
+彩色只留给「主操作」和「状态」。
+
+按钮层级（用 setObjectName 指定）:
+    primary   —— 当前页面唯一的主操作（实心蓝）
+    (默认)     —— 次级操作（白底描边）
+    secondary —— 同默认，历史兼容
+    ghost     —— 弱化的第三级操作（无边框）
+    danger    —— 破坏性操作（红字描边）
+    link      —— 纯文字入口
+
+文字层级（objectName）:
+    h1 页面标题 / h2 区块标题 / title 卡片标题
+    subtitle 说明 / caption 辅助小字 / muted 弱化 / value 大数字
 """
 
-# 深色主题颜色定义
-DARK_COLORS = {
-    # 主色调
-    'background': '#1E1E1E',
-    'sidebar': '#252526',
-    'panel': '#2D2D30',
-    'selected': '#094771',
-    
+from typing import List
+
+# ==================== 颜色令牌 ====================
+
+# 语义色有「文字版」和「填充版」两套：
+# 同一个亮色在浅底上当填充好看，当小字就糊了（#34C759 在白底上对比度只有 2:1）。
+# 页面里 COLORS['success'] / ['error'] / ['warning'] 绝大多数是拿去当 color: 用的，
+# 所以这三个键给可读的深色版，亮色版另存 *_fill，只用在圆点、进度条这类填充上。
+COLORS = {
+    # 表面：画布 → 侧栏 → 卡片 → 控件
+    'background': '#F5F5F7',   # 页面画布
+    'sidebar': '#EFEFF2',      # 左侧导航，比画布再灰一点
+    'panel': '#FFFFFF',        # 卡片 / 分组面板
+    'inset': '#FFFFFF',        # 输入框、列表等控件表面
+    'track': '#E6E6EB',        # 进度条、滑杆的底槽
+    'hover': '#EBEBF0',
+    'selected': '#E4EEFF',     # 选中态的蓝色底纹
+
+    # 边框：1px、淡
+    'border': '#E3E3E8',
+    'border_strong': '#D2D2D7',
+
     # 强调色
-    'primary': '#007ACC',
-    'secondary': '#6B8E23',
-    'success': '#4EC9B0',
-    'warning': '#DCDCAA',
-    'error': '#F44747',
-    
-    # 文字色
-    'text_primary': '#D4D4D4',
-    'text_secondary': '#858585',
-    'text_disabled': '#5C5C5C',
-    
-    # 边框
-    'border': '#3E3E42',
-    'hover': '#2A2D2E',
+    'primary': '#007AFF',
+    'primary_hover': '#1A88FF',
+    'primary_pressed': '#0062CC',
+    'accent_text': '#0066CC',  # 浅底上的蓝色文字，够对比度
+    'secondary': '#6E6E73',
+
+    # 语义色（text 版本，浅底上可读）
+    'success': '#248A3D',
+    'success_soft': '#E7F6EC',  # 「已标注」这类状态底色
+    'warning': '#9A5B00',
+    'error': '#D70015',
+
+    # 语义色（fill 版本，用于圆点 / 进度 / 实心块）
+    'success_fill': '#34C759',
+    'warning_fill': '#FF9500',
+    'error_fill': '#FF3B30',
+
+    # 文字
+    'text_primary': '#1D1D1F',
+    'text_secondary': '#6E6E73',
+    'text_disabled': '#AEAEB2',
 }
 
-# 浅色主题颜色定义
-LIGHT_COLORS = {
-    # 主色调
-    'background': '#FFFFFF',
-    'sidebar': '#F5F5F5',
-    'panel': '#F0F0F0',
-    'selected': '#E6F2FB',
-    
-    # 强调色
-    'primary': '#0078D7',
-    'secondary': '#6B8E23',
-    'success': '#107C10',
-    'warning': '#FFB900',
-    'error': '#D13438',
-    
-    # 文字色
-    'text_primary': '#333333',
-    'text_secondary': '#666666',
-    'text_disabled': '#999999',
-    
-    # 边框
-    'border': '#E0E0E0',
-    'hover': '#E8E8E8',
-}
+# ==================== 尺寸令牌 ====================
 
-# 默认使用深色主题
-COLORS = DARK_COLORS
+RADIUS = 12         # 卡片
+RADIUS_SM = 8       # 控件
 
-def generate_stylesheet(colors):
-    """根据颜色生成样式表"""
-    stylesheet = ""
-    
-    # 主窗口样式
-    stylesheet += """
-QMainWindow {
-    background-color: %s;
-    color: %s;
-}
+CONTROL_HEIGHT = 30      # 按钮 / 输入框统一高度
+CONTROL_HEIGHT_LG = 34   # 主操作按钮
 
-QWidget {
-    background-color: %s;
-    color: %s;
-    font-family: "Microsoft YaHei", "Segoe UI", sans-serif;
-    font-size: 13px;
-}
+# ==================== 字体 ====================
 
-QFrame {
-    background-color: %s;
-    border: 1px solid %s;
-    border-radius: 4px;
-}
-"""
-    
-    # 侧边栏样式
-    stylesheet += """
-QWidget#sidebar {
-    background-color: %s;
-    border-right: 1px solid %s;
-}
+# 每个平台上优先选用的字体，按顺序取第一个真实存在的。
+# 只请求系统上真的装了的字体，Qt 才不会报字体缺失警告，
+# 也不会悄悄回退到一个难看的默认族。
+_FONT_CANDIDATES = [
+    "PingFang SC",        # macOS 中文
+    "SF Pro Text",        # macOS 西文（较新系统）
+    "Helvetica Neue",     # macOS 回退
+    "Hiragino Sans GB",
+    "Microsoft YaHei",    # Windows
+    "Segoe UI",
+    "Noto Sans CJK SC",   # Linux
+    "Source Han Sans SC",
+    "WenQuanYi Micro Hei",
+    "Arial",
+]
 
-QPushButton#nav_button {
-    background-color: transparent;
-    color: %s;
-    border: none;
-    padding: 12px 16px;
-    text-align: left;
-    font-size: 14px;
-}
+# 日志、代码这类等宽场景。Consolas 只有 Windows 有，macOS 上要用 Menlo / SF Mono。
+_MONO_CANDIDATES = [
+    "SF Mono",
+    "Menlo",
+    "Consolas",
+    "DejaVu Sans Mono",
+    "Liberation Mono",
+    "Courier New",
+]
 
-QPushButton#nav_button:hover {
-    background-color: %s;
-}
+_font_stack_cache: List[str] = []
+_mono_stack_cache: List[str] = []
 
-QPushButton#nav_button:checked {
-    background-color: %s;
-    color: %s;
-}
 
-QPushButton#nav_button:disabled {
-    color: %s;
-}
-"""
-    
-    # 按钮样式
-    stylesheet += """
-QPushButton {
-    background-color: %s;
-    color: white;
-    border: none;
-    padding: 8px 16px;
-    border-radius: 4px;
-    font-size: 13px;
-}
+def _available_families() -> set:
+    try:
+        from PyQt6.QtGui import QFontDatabase
 
-QPushButton:hover {
-    background-color: %s;
-    opacity: 0.9;
-}
+        return set(QFontDatabase.families())
+    except Exception:
+        return set()
 
-QPushButton:pressed {
-    background-color: %s;
-    opacity: 0.8;
-}
 
-QPushButton:disabled {
-    background-color: %s;
-    color: %s;
-}
+def get_font_stack() -> List[str]:
+    """返回当前系统上真实存在的界面字体族列表（结果缓存）。
 
-QPushButton#secondary {
-    background-color: %s;
-    color: %s;
-    border: 1px solid %s;
-}
-
-QPushButton#secondary:hover {
-    background-color: %s;
-}
-"""
-    
-    # 输入框样式
-    stylesheet += """
-QLineEdit {
-    background-color: %s;
-    color: %s;
-    border: 1px solid %s;
-    padding: 6px 10px;
-    border-radius: 4px;
-}
-
-QLineEdit:focus {
-    border: 1px solid %s;
-}
-
-QLineEdit:disabled {
-    background-color: %s;
-    color: %s;
-}
-
-QComboBox {
-    background-color: %s;
-    color: %s;
-    border: 1px solid %s;
-    padding: 6px 10px;
-    border-radius: 4px;
-}
-
-QComboBox:focus {
-    border: 1px solid %s;
-}
-
-QComboBox::drop-down {
-    border: none;
-    width: 20px;
-}
-
-QComboBox QAbstractItemView {
-    background-color: %s;
-    color: %s;
-    border: 1px solid %s;
-    selection-background-color: %s;
-}
-"""
-    
-    # 标签样式
-    stylesheet += """
-QLabel {
-    color: %s;
-    font-size: 13px;
-}
-
-QLabel#title {
-    font-size: 16px;
-    font-weight: bold;
-    color: %s;
-}
-
-QLabel#subtitle {
-    font-size: 12px;
-    color: %s;
-}
-"""
-    
-    # 滚动条样式
-    stylesheet += """
-QScrollBar:vertical {
-    background-color: %s;
-    width: 12px;
-    border-radius: 6px;
-}
-
-QScrollBar::handle:vertical {
-    background-color: %s;
-    border-radius: 6px;
-    min-height: 30px;
-}
-
-QScrollBar::handle:vertical:hover {
-    background-color: %s;
-}
-
-QScrollBar::add-line:vertical,
-QScrollBar::sub-line:vertical {
-    height: 0px;
-}
-
-QScrollBar:horizontal {
-    background-color: %s;
-    height: 12px;
-    border-radius: 6px;
-}
-
-QScrollBar::handle:horizontal {
-    background-color: %s;
-    border-radius: 6px;
-    min-width: 30px;
-}
-
-QScrollBar::handle:horizontal:hover {
-    background-color: %s;
-}
-
-QScrollBar::add-line:horizontal,
-QScrollBar::sub-line:horizontal {
-    width: 0px;
-}
-"""
-    
-    # 列表样式
-    stylesheet += """
-QListWidget {
-    background-color: %s;
-    color: %s;
-    border: 1px solid %s;
-    border-radius: 4px;
-    outline: none;
-}
-
-QListWidget::item {
-    padding: 8px 12px;
-    border-bottom: 1px solid %s;
-}
-
-QListWidget::item:selected {
-    background-color: %s;
-    color: %s;
-}
-
-QListWidget::item:hover {
-    background-color: %s;
-}
-"""
-    
-    # 分组框样式
-    stylesheet += """
-QGroupBox {
-    background-color: %s;
-    color: %s;
-    border: 1px solid %s;
-    border-radius: 4px;
-    margin-top: 12px;
-    padding-top: 12px;
-    font-weight: bold;
-}
-
-QGroupBox::title {
-    subcontrol-origin: margin;
-    left: 12px;
-    padding: 0 8px;
-    color: %s;
-}
-"""
-    
-    # 进度条样式
-    stylesheet += """
-QProgressBar {
-    background-color: %s;
-    border: 1px solid %s;
-    border-radius: 4px;
-    text-align: center;
-    color: %s;
-}
-
-QProgressBar::chunk {
-    background-color: %s;
-    border-radius: 3px;
-}
-"""
-    
-    # 标签页样式
-    stylesheet += """
-QTabWidget::pane {
-    background-color: %s;
-    border: 1px solid %s;
-    border-radius: 4px;
-    top: -1px;
-}
-
-QTabBar::tab {
-    background-color: %s;
-    color: %s;
-    padding: 8px 16px;
-    border: 1px solid %s;
-    border-bottom: none;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-}
-
-QTabBar::tab:selected {
-    background-color: %s;
-    color: %s;
-    border-bottom: 1px solid %s;
-}
-
-QTabBar::tab:hover:!selected {
-    background-color: %s;
-    color: %s;
-}
-"""
-    
-    # 替换颜色值
-    color_values = [
-        # 主窗口样式
-        colors['background'],
-        colors['text_primary'],
-        colors['background'],
-        colors['text_primary'],
-        colors['panel'],
-        colors['border'],
-        
-        # 侧边栏样式
-        colors['sidebar'],
-        colors['border'],
-        colors['text_primary'],
-        colors['hover'],
-        colors['selected'],
-        colors['text_primary'],
-        colors['text_disabled'],
-        
-        # 按钮样式
-        colors['primary'],
-        colors['primary'],
-        colors['primary'],
-        colors['text_disabled'],
-        colors['text_secondary'],
-        colors['panel'],
-        colors['text_primary'],
-        colors['border'],
-        colors['hover'],
-        
-        # 输入框样式
-        colors['panel'],
-        colors['text_primary'],
-        colors['border'],
-        colors['primary'],
-        colors['sidebar'],
-        colors['text_disabled'],
-        colors['panel'],
-        colors['text_primary'],
-        colors['border'],
-        colors['primary'],
-        colors['panel'],
-        colors['text_primary'],
-        colors['border'],
-        colors['selected'],
-        
-        # 标签样式
-        colors['text_primary'],
-        colors['text_primary'],
-        colors['text_secondary'],
-        
-        # 滚动条样式
-        colors['sidebar'],
-        colors['border'],
-        colors['text_secondary'],
-        colors['sidebar'],
-        colors['border'],
-        colors['text_secondary'],
-        
-        # 列表样式
-        colors['panel'],
-        colors['text_primary'],
-        colors['border'],
-        colors['border'],
-        colors['selected'],
-        colors['text_primary'],
-        colors['hover'],
-        
-        # 分组框样式
-        colors['panel'],
-        colors['text_primary'],
-        colors['border'],
-        colors['text_secondary'],
-        
-        # 进度条样式
-        colors['sidebar'],
-        colors['border'],
-        colors['text_primary'],
-        colors['primary'],
-        
-        # 标签页样式
-        colors['panel'],
-        colors['border'],
-        colors['sidebar'],
-        colors['text_secondary'],
-        colors['border'],
-        colors['panel'],
-        colors['text_primary'],
-        colors['panel'],
-        colors['hover'],
-        colors['text_primary']
-    ]
-    
-    return stylesheet % tuple(color_values)
-
-# 完整样式表
-def get_full_stylesheet(theme='dark'):
-    """获取完整样式表
-    
-    Args:
-        theme: 主题名称，'dark' 或 'light'
+    需要在 QApplication 创建之后调用；未创建时退化为空列表，
+    样式表就不写 font-family，交给 Qt 默认字体。
     """
-    if theme == 'light':
-        return generate_stylesheet(LIGHT_COLORS)
-    else:
-        return generate_stylesheet(DARK_COLORS)
+    global _font_stack_cache
+    if _font_stack_cache:
+        return _font_stack_cache
+
+    available = _available_families()
+    _font_stack_cache = [name for name in _FONT_CANDIDATES if name in available]
+    return _font_stack_cache
+
+
+def get_mono_font_stack() -> List[str]:
+    """返回当前系统上真实存在的等宽字体族列表（日志框用）。"""
+    global _mono_stack_cache
+    if _mono_stack_cache:
+        return _mono_stack_cache
+
+    available = _available_families()
+    _mono_stack_cache = [name for name in _MONO_CANDIDATES if name in available]
+    return _mono_stack_cache
+
+
+def get_primary_font_family() -> str:
+    """返回首选界面字体族名；系统上一个都没有时返回空字符串，交给 Qt 默认字体。"""
+    stack = get_font_stack()
+    return stack[0] if stack else ""
+
+
+def mono_font_family_css() -> str:
+    """给日志框等等宽场景用：返回可直接写进 QSS 的 font-family 值。
+
+    只列系统上真实存在的字体，避免出现 “missing font family Consolas” 这类警告。
+    没有可用等宽字体时返回空字符串，调用方应整行不写 font-family。
+    """
+    stack = get_mono_font_stack()
+    if not stack:
+        return ""
+    return ", ".join(f"'{name}'" for name in stack)
+
+
+def _font_family_declaration() -> str:
+    """生成 QSS 的 font-family 声明。
+
+    Qt 的样式表不认 CSS 的通用族（sans-serif 会被当成一个真实字体名去找，
+    找不到同样会报字体缺失），所以这里只列真实存在的字体；
+    一个都没有时就整行不写，交给 Qt 默认字体。
+    """
+    families = [f'"{name}"' for name in get_font_stack()]
+    if not families:
+        return ""
+    return f"    font-family: {', '.join(families)};\n"
+
+
+# ==================== 样式表 ====================
+
+def generate_stylesheet(colors: dict) -> str:
+    """根据颜色令牌生成全局样式表。"""
+    c = colors
+    font_family = _font_family_declaration()
+
+    return f"""
+/* ---------- 基础 ---------- */
+QMainWindow, QDialog {{
+    background-color: {c['background']};
+    color: {c['text_primary']};
+}}
+
+QWidget {{
+    background-color: {c['background']};
+    color: {c['text_primary']};
+{font_family}    font-size: 13px;
+}}
+
+QFrame {{
+    background-color: {c['panel']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS}px;
+}}
+
+/* QStackedWidget / QSplitter 都继承自 QFrame，别让它们套上卡片的边框和底色 */
+QStackedWidget {{
+    background-color: transparent;
+    border: none;
+    border-radius: 0px;
+}}
+
+QSplitter {{
+    background-color: transparent;
+    border: none;
+}}
+
+QSplitter::handle {{
+    background-color: transparent;
+}}
+
+QSplitter::handle:horizontal {{
+    width: 10px;
+}}
+
+QSplitter::handle:vertical {{
+    height: 10px;
+}}
+
+QScrollArea {{
+    background-color: transparent;
+    border: none;
+}}
+
+QToolTip {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+    border-radius: {RADIUS_SM}px;
+    padding: 6px 9px;
+}}
+
+/* ---------- 文字 ---------- */
+QLabel {{
+    background-color: transparent;
+    border: none;
+    color: {c['text_primary']};
+    font-size: 13px;
+}}
+
+QLabel#h1 {{
+    font-size: 21px;
+    font-weight: 600;
+    color: {c['text_primary']};
+}}
+
+QLabel#h2 {{
+    font-size: 15px;
+    font-weight: 600;
+    color: {c['text_primary']};
+}}
+
+QLabel#title {{
+    font-size: 14px;
+    font-weight: 600;
+    color: {c['text_primary']};
+}}
+
+QLabel#subtitle, QLabel#muted {{
+    font-size: 13px;
+    color: {c['text_secondary']};
+}}
+
+QLabel#caption {{
+    font-size: 12px;
+    color: {c['text_secondary']};
+}}
+
+QLabel#value {{
+    font-size: 22px;
+    font-weight: 600;
+    color: {c['text_primary']};
+}}
+
+/* ---------- 卡片 ---------- */
+QFrame#card {{
+    background-color: {c['panel']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS}px;
+}}
+
+QFrame#toolbar {{
+    background-color: {c['panel']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS}px;
+}}
+
+QFrame#divider {{
+    background-color: {c['border']};
+    border: none;
+    border-radius: 0px;
+    max-height: 1px;
+    min-height: 1px;
+}}
+
+/* ---------- 主窗口结构 ---------- */
+QWidget#sidebar {{
+    background-color: {c['sidebar']};
+    border: none;
+    border-right: 1px solid {c['border']};
+}}
+
+QWidget#sidebar QLabel {{
+    background-color: transparent;
+}}
+
+QLabel#brand {{
+    font-size: 17px;
+    font-weight: 700;
+    color: {c['text_primary']};
+}}
+
+QLabel#nav_section {{
+    font-size: 11px;
+    font-weight: 600;
+    color: {c['text_disabled']};
+}}
+
+QWidget#page_header {{
+    background-color: {c['background']};
+    border: none;
+    border-bottom: 1px solid {c['border']};
+}}
+
+QWidget#page_header QLabel {{
+    background-color: transparent;
+}}
+
+/* 页头的「第 N 步」：灰色小胶囊，不跟主操作抢颜色 */
+QLabel#step_badge {{
+    background-color: {c['hover']};
+    color: {c['text_secondary']};
+    border-radius: 5px;
+    padding: 2px 7px;
+    font-size: 11px;
+    font-weight: 600;
+}}
+
+/* ---------- 流程导航项 ---------- */
+/* 内边距不写在这里：step_item 里面是自己的布局，QSS 的 padding 影响不到子控件，
+   只会把按钮的 sizeHint 虚增一截。内边距由 StepNavItem 的布局边距给。 */
+QPushButton#step_item {{
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: {RADIUS_SM}px;
+    text-align: left;
+    padding: 0px;
+}}
+
+QPushButton#step_item:hover {{
+    background-color: {c['hover']};
+}}
+
+QPushButton#step_item:checked {{
+    background-color: {c['selected']};
+    border: 1px solid transparent;
+}}
+
+QPushButton#step_item:disabled {{
+    background-color: transparent;
+}}
+
+/* 兼容旧的侧边栏按钮样式 */
+QPushButton#nav_button {{
+    background-color: transparent;
+    color: {c['text_primary']};
+    border: none;
+    border-radius: {RADIUS_SM}px;
+    padding: 9px 12px;
+    text-align: left;
+    font-size: 13px;
+}}
+
+QPushButton#nav_button:hover {{
+    background-color: {c['hover']};
+}}
+
+QPushButton#nav_button:checked {{
+    background-color: {c['selected']};
+    color: {c['text_primary']};
+}}
+
+QPushButton#nav_button:disabled {{
+    color: {c['text_disabled']};
+}}
+
+/* ---------- 按钮层级 ---------- */
+/* 默认 = 次级操作：白底描边 */
+QPushButton {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+    border-radius: {RADIUS_SM}px;
+    padding: 5px 14px;
+    min-height: {CONTROL_HEIGHT - 12}px;
+    font-size: 13px;
+}}
+
+QPushButton:hover {{
+    background-color: {c['hover']};
+}}
+
+QPushButton:pressed {{
+    background-color: {c['border']};
+}}
+
+QPushButton:disabled {{
+    background-color: {c['panel']};
+    color: {c['text_disabled']};
+    border-color: {c['border']};
+}}
+
+QPushButton#secondary {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+}}
+
+QPushButton#secondary:hover {{
+    background-color: {c['hover']};
+}}
+
+/* 主操作：每页最多一个 */
+QPushButton#primary {{
+    background-color: {c['primary']};
+    color: #FFFFFF;
+    border: 1px solid {c['primary']};
+    font-weight: 600;
+}}
+
+QPushButton#primary:hover {{
+    background-color: {c['primary_hover']};
+    border-color: {c['primary_hover']};
+}}
+
+QPushButton#primary:pressed {{
+    background-color: {c['primary_pressed']};
+    border-color: {c['primary_pressed']};
+}}
+
+QPushButton#primary:disabled {{
+    background-color: {c['track']};
+    color: {c['text_disabled']};
+    border-color: {c['track']};
+}}
+
+QPushButton#ghost {{
+    background-color: transparent;
+    color: {c['text_secondary']};
+    border: 1px solid transparent;
+}}
+
+QPushButton#ghost:hover {{
+    background-color: {c['hover']};
+    color: {c['text_primary']};
+}}
+
+QPushButton#ghost:checked {{
+    background-color: {c['selected']};
+    color: {c['text_primary']};
+}}
+
+QPushButton#danger {{
+    background-color: {c['panel']};
+    color: {c['error']};
+    border: 1px solid {c['border_strong']};
+}}
+
+QPushButton#danger:hover {{
+    background-color: {c['hover']};
+    border-color: {c['error_fill']};
+}}
+
+QPushButton#danger:disabled, QPushButton#ghost:disabled {{
+    color: {c['text_disabled']};
+    border-color: {c['border']};
+}}
+
+QPushButton#link {{
+    background-color: transparent;
+    color: {c['accent_text']};
+    border: none;
+    padding: 2px 4px;
+    text-align: left;
+}}
+
+QPushButton#link:hover {{
+    color: {c['primary']};
+}}
+
+QToolButton {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+    border-radius: {RADIUS_SM}px;
+    padding: 5px 10px;
+}}
+
+QToolButton:hover {{
+    background-color: {c['hover']};
+}}
+
+/* ---------- 输入控件 ---------- */
+QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox, QPlainTextEdit {{
+    background-color: {c['inset']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+    border-radius: {RADIUS_SM}px;
+    padding: 5px 10px;
+    min-height: {CONTROL_HEIGHT - 12}px;
+    selection-background-color: {c['primary']};
+    selection-color: #FFFFFF;
+}}
+
+QLineEdit:focus, QComboBox:focus, QSpinBox:focus,
+QDoubleSpinBox:focus, QPlainTextEdit:focus {{
+    border: 1px solid {c['primary']};
+}}
+
+QLineEdit:disabled, QComboBox:disabled, QSpinBox:disabled, QDoubleSpinBox:disabled {{
+    background-color: {c['background']};
+    color: {c['text_disabled']};
+    border-color: {c['border']};
+}}
+
+/* 下拉箭头交给 Qt 自己画：自定义 ::drop-down 会把箭头一起干掉 */
+
+QComboBox QAbstractItemView {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+    border-radius: {RADIUS_SM}px;
+    padding: 4px;
+    outline: none;
+    selection-background-color: {c['selected']};
+    selection-color: {c['text_primary']};
+}}
+
+QSpinBox::up-button, QDoubleSpinBox::up-button,
+QSpinBox::down-button, QDoubleSpinBox::down-button {{
+    background-color: transparent;
+    border: none;
+    width: 16px;
+}}
+
+QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,
+QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {{
+    background-color: {c['hover']};
+}}
+
+QTextEdit {{
+    background-color: {c['inset']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS_SM}px;
+    padding: 6px;
+    selection-background-color: {c['primary']};
+    selection-color: #FFFFFF;
+}}
+
+/* 勾选框和单选钮：框和填充都得自己画。
+   试过交给系统画（去掉 ::indicator 规则）——不行：控件一旦被样式表接管，
+   Qt 画的对勾/圆点就只剩一个孤零零的字形，外面那个框来自控件继承下来的背景，
+   而背景在这里是 transparent（不设成 transparent，白卡片上每一行都会拖一条灰底）。
+   结果是「勾上的只有一个勾、没勾的什么都没有」，单选钮更是整个圈都不见。
+   所以框自己画，选中态用实心表示——填满 = 选上了，空的 = 没选，不会看错。 */
+QCheckBox, QRadioButton {{
+    background-color: transparent;
+    color: {c['text_primary']};
+    spacing: 8px;
+    padding: 2px 0;
+}}
+
+QCheckBox::indicator, QRadioButton::indicator {{
+    width: 15px;
+    height: 15px;
+    border: 1px solid {c['border_strong']};
+    background-color: {c['inset']};
+}}
+
+QCheckBox::indicator {{
+    border-radius: 4px;
+}}
+
+QRadioButton::indicator {{
+    border-radius: 8px;
+}}
+
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {{
+    background-color: {c['primary']};
+    border-color: {c['primary']};
+}}
+
+QCheckBox::indicator:hover, QRadioButton::indicator:hover {{
+    border-color: {c['primary']};
+}}
+
+QSlider::groove:horizontal {{
+    background-color: {c['track']};
+    height: 4px;
+    border-radius: 2px;
+}}
+
+QSlider::sub-page:horizontal {{
+    background-color: {c['primary']};
+    height: 4px;
+    border-radius: 2px;
+}}
+
+QSlider::handle:horizontal {{
+    background-color: #FFFFFF;
+    border: 1px solid {c['border_strong']};
+    width: 14px;
+    height: 14px;
+    margin: -6px 0;
+    border-radius: 8px;
+}}
+
+/* ---------- 列表 ---------- */
+QListWidget {{
+    background-color: {c['inset']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS_SM}px;
+    padding: 4px;
+    outline: none;
+}}
+
+QListWidget::item {{
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: none;
+}}
+
+QListWidget::item:selected {{
+    background-color: {c['selected']};
+    color: {c['text_primary']};
+}}
+
+QListWidget::item:hover {{
+    background-color: {c['hover']};
+}}
+
+QMenu {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border_strong']};
+    border-radius: {RADIUS_SM}px;
+    padding: 4px;
+}}
+
+QMenu::item {{
+    padding: 6px 20px 6px 12px;
+    border-radius: 5px;
+}}
+
+QMenu::item:selected {{
+    background-color: {c['selected']};
+}}
+
+QMenu::separator {{
+    height: 1px;
+    background-color: {c['border']};
+    margin: 4px 8px;
+}}
+
+/* ---------- 分组框 ---------- */
+/* 标题整行落在卡片外面（margin 区），不再骑在边框线上。
+   原来 margin-top 只有 14px，标题盒子比它高，边框就从字的下半截穿过去——
+   设置页、关于页、批量处理弹窗里每一个分组标题都被划了一道。
+   标题移到卡片上方之后，无论卡片底下是什么颜色都不会重叠。
+   字重只给标题：写在 QGroupBox 上会连里面的按钮和输入框一起加粗。 */
+QGroupBox {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS}px;
+    margin-top: 26px;
+    padding: 16px;
+    font-size: 13px;
+    font-weight: 400;
+}}
+
+QGroupBox::title {{
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 2px;
+    top: 0px;
+    padding: 0 0 8px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: {c['text_primary']};
+    background-color: transparent;
+}}
+
+/* ---------- 进度条 ---------- */
+QProgressBar {{
+    background-color: {c['track']};
+    border: none;
+    border-radius: 3px;
+    text-align: center;
+    color: {c['text_primary']};
+    height: 6px;
+    font-size: 11px;
+}}
+
+QProgressBar::chunk {{
+    background-color: {c['primary']};
+    border-radius: 3px;
+}}
+
+/* ---------- 标签页 ---------- */
+QTabWidget::pane {{
+    background-color: {c['panel']};
+    border: 1px solid {c['border']};
+    border-radius: {RADIUS_SM}px;
+    top: -1px;
+}}
+
+QTabBar::tab {{
+    background-color: transparent;
+    color: {c['text_secondary']};
+    padding: 6px 14px;
+    margin-right: 2px;
+    border: 1px solid transparent;
+    border-top-left-radius: {RADIUS_SM}px;
+    border-top-right-radius: {RADIUS_SM}px;
+}}
+
+QTabBar::tab:selected {{
+    background-color: {c['panel']};
+    color: {c['text_primary']};
+    border-color: {c['border']};
+    border-bottom-color: {c['panel']};
+    font-weight: 600;
+}}
+
+QTabBar::tab:hover:!selected {{
+    color: {c['text_primary']};
+}}
+
+/* ---------- 滚动条 ---------- */
+QScrollBar:vertical {{
+    background-color: transparent;
+    width: 10px;
+    margin: 2px;
+}}
+
+QScrollBar::handle:vertical {{
+    background-color: {c['border_strong']};
+    border-radius: 5px;
+    min-height: 30px;
+}}
+
+QScrollBar::handle:vertical:hover {{
+    background-color: {c['text_disabled']};
+}}
+
+QScrollBar:horizontal {{
+    background-color: transparent;
+    height: 10px;
+    margin: 2px;
+}}
+
+QScrollBar::handle:horizontal {{
+    background-color: {c['border_strong']};
+    border-radius: 5px;
+    min-width: 30px;
+}}
+
+QScrollBar::handle:horizontal:hover {{
+    background-color: {c['text_disabled']};
+}}
+
+QScrollBar::add-line, QScrollBar::sub-line {{
+    height: 0px;
+    width: 0px;
+}}
+
+QScrollBar::add-page, QScrollBar::sub-page {{
+    background: transparent;
+}}
+"""
+
+
+def get_full_stylesheet(theme: str = 'light') -> str:
+    """获取完整样式表。
+
+    应用只有一套浅色外观；theme 参数保留是为了兼容既有调用点。
+    """
+    return generate_stylesheet(COLORS)

--- a/gui/view_zoom.py
+++ b/gui/view_zoom.py
@@ -1,0 +1,71 @@
+"""标注画布缩放的纯数学核心，不依赖 Qt。"""
+
+import math
+
+
+ZOOM_MIN = 0.1
+ZOOM_MAX = 5.0
+
+
+def _is_finite(value) -> bool:
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError):
+        return False
+
+
+def wheel_zoom_factor(delta):
+    """把滚轮方向转换为固定缩放倍率。"""
+    if not _is_finite(delta):
+        return 1.0
+    if delta > 0:
+        return 1.1
+    if delta < 0:
+        return 0.9
+    return 1.0
+
+
+def native_zoom_factor(value):
+    """macOS 原生捏合手势的增量倍率。"""
+    return 1.0 + value if _is_finite(value) else 1.0
+
+
+def pinch_zoom_factor(scale_factor):
+    """Qt PinchGesture 给出的有效增量倍率。"""
+    if _is_finite(scale_factor) and scale_factor > 0:
+        return scale_factor
+    return 1.0
+
+
+def zoom_at(scale, offset_x, offset_y, anchor_x, anchor_y, factor, bounds):
+    """按倍率缩放，并让锚点继续对应缩放前的同一图像坐标。
+
+    输入不完整、非有限或没有实际缩放时原样返回，事件层可据此安全地不刷新画布。
+    """
+    original = (scale, offset_x, offset_y)
+    values = (scale, offset_x, offset_y, anchor_x, anchor_y, factor)
+    if not all(_is_finite(value) for value in values):
+        return original
+    if scale <= 0 or factor <= 0 or factor == 1:
+        return original
+
+    try:
+        minimum, maximum = bounds
+    except (TypeError, ValueError):
+        return original
+    if not _is_finite(minimum) or not _is_finite(maximum):
+        return original
+    if minimum <= 0 or maximum < minimum:
+        return original
+
+    new_scale = min(max(scale * factor, minimum), maximum)
+    if new_scale == scale:
+        return original
+
+    image_x = (anchor_x - offset_x) / scale
+    image_y = (anchor_y - offset_y) / scale
+    return (
+        float(new_scale),
+        float(anchor_x - image_x * new_scale),
+        float(anchor_y - image_y * new_scale),
+    )

--- a/gui/widgets/app_dialog.py
+++ b/gui/widgets/app_dialog.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""应用内统一弹窗（确认 / 提示）
+
+替掉 QMessageBox：系统那个框在 macOS 上是英文 No/Yes 加一个巨大的问号图标，
+跟应用其余部分（浅色、圆角、中文）完全不是一套东西，而且「Yes」放在右边、
+默认还落在它上面——删除这种不可逆操作，回车一下就没了。
+
+这里的规矩：
+    标题说清楚要做什么，正文说清楚后果，细节（数量之类）单独一行；
+    破坏性操作用红字按钮，取消是普通按钮并且拿默认焦点（回车 = 取消）；
+    没有图标。
+
+用法：
+    if confirm_destructive(self, "删除项目", "…会一起删除，无法恢复。", "「安全帽检测」"):
+        ...
+"""
+
+from typing import Optional
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
+)
+
+
+class AppDialog(QDialog):
+    """确认框 / 提示框的共同外壳。
+
+    只有一个按钮时是提示框，两个按钮时是确认框。
+    `exec()` 之外也能用：测试里直接点 `btn_confirm` / `btn_cancel` 就行，
+    结果照样落在 `result()` 上，不用真的开一个模态窗。
+    """
+
+    def __init__(self, parent, title: str, message: str,
+                 detail: str = "",
+                 confirm_text: str = "确定",
+                 cancel_text: Optional[str] = "取消",
+                 destructive: bool = False):
+        super().__init__(parent)
+
+        self.setWindowTitle(title)
+        self.setMinimumWidth(380)
+        self.setMaximumWidth(520)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 18)
+        layout.setSpacing(8)
+
+        self.lbl_title = QLabel(title)
+        self.lbl_title.setObjectName("h2")
+        self.lbl_title.setWordWrap(True)
+        layout.addWidget(self.lbl_title)
+
+        self.lbl_message = QLabel(message)
+        self.lbl_message.setObjectName("subtitle")
+        self.lbl_message.setWordWrap(True)
+        layout.addWidget(self.lbl_message)
+
+        self.lbl_detail = QLabel(detail)
+        self.lbl_detail.setObjectName("caption")
+        self.lbl_detail.setWordWrap(True)
+        self.lbl_detail.setVisible(bool(detail))
+        layout.addWidget(self.lbl_detail)
+
+        button_row = QHBoxLayout()
+        button_row.setContentsMargins(0, 10, 0, 0)
+        button_row.setSpacing(8)
+        button_row.addStretch()
+
+        self.btn_cancel = None
+        if cancel_text:
+            self.btn_cancel = QPushButton(cancel_text)
+            self.btn_cancel.clicked.connect(self.reject)
+            button_row.addWidget(self.btn_cancel)
+
+        self.btn_confirm = QPushButton(confirm_text)
+        self.btn_confirm.setObjectName("danger" if destructive else "primary")
+        self.btn_confirm.clicked.connect(self.accept)
+        button_row.addWidget(self.btn_confirm)
+
+        layout.addLayout(button_row)
+
+        # 默认焦点给「安全的那个」：有取消就是取消，没有就是唯一那个按钮。
+        # 回车键同理——删 164 张图片不该是一个回车就发生的事。
+        safe_button = self.btn_cancel or self.btn_confirm
+        safe_button.setDefault(True)
+        safe_button.setFocus()
+
+
+def confirm_destructive(parent, title: str, message: str, detail: str = "",
+                        confirm_text: str = "删除", cancel_text: str = "取消") -> bool:
+    """不可逆操作的确认框：红色确认按钮，默认焦点在安全的那个按钮。用户确认才返回 True。
+
+    `cancel_text` 要照实说安全按钮到底会做什么：不是每一次「不确认」都等于
+    「什么都不做」——比如导入标注时不覆盖，实际是「保留现有标注」并继续导入。
+    这种时候写「取消」会让人以为整件事都被放弃了。
+    """
+    dialog = AppDialog(
+        parent, title, message, detail,
+        confirm_text=confirm_text, cancel_text=cancel_text, destructive=True,
+    )
+    return dialog.exec() == QDialog.DialogCode.Accepted
+
+
+def confirm(parent, title: str, message: str, detail: str = "",
+            confirm_text: str = "确定", cancel_text: str = "取消") -> bool:
+    """普通的二选一确认框（不是破坏性操作）。
+
+    `cancel_text` 同样照实说：二选一的「另一个选项」未必叫「取消」。
+    """
+    dialog = AppDialog(
+        parent, title, message, detail,
+        confirm_text=confirm_text, cancel_text=cancel_text, destructive=False,
+    )
+    return dialog.exec() == QDialog.DialogCode.Accepted
+
+
+class TextInputDialog(QDialog):
+    """要用户填一行字的框（比如给新项目起名字）。
+
+    替掉 QInputDialog.getText：系统那个框跟抽帧设置用的 getInt 是同一个模子，
+    英文 Cancel/OK、跟应用完全不是一套外观。这里跟 AppDialog 长一个样子。
+
+    确认按钮在输入为空时是灰的——名字都没填就没什么可确认的。
+    """
+
+    def __init__(self, parent, title: str, label: str,
+                 text: str = "", placeholder: str = "",
+                 confirm_text: str = "确定", cancel_text: str = "取消"):
+        super().__init__(parent)
+
+        self.setWindowTitle(title)
+        self.setMinimumWidth(380)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 18)
+        layout.setSpacing(8)
+
+        self.lbl_title = QLabel(title)
+        self.lbl_title.setObjectName("h2")
+        layout.addWidget(self.lbl_title)
+
+        self.lbl_label = QLabel(label)
+        self.lbl_label.setObjectName("subtitle")
+        self.lbl_label.setWordWrap(True)
+        layout.addWidget(self.lbl_label)
+
+        self.edit = QLineEdit(text)
+        self.edit.setPlaceholderText(placeholder)
+        self.edit.textChanged.connect(self._sync_confirm_enabled)
+        self.edit.returnPressed.connect(self._on_return)
+        layout.addWidget(self.edit)
+
+        button_row = QHBoxLayout()
+        button_row.setContentsMargins(0, 10, 0, 0)
+        button_row.setSpacing(8)
+        button_row.addStretch()
+
+        self.btn_cancel = QPushButton(cancel_text)
+        self.btn_cancel.clicked.connect(self.reject)
+        button_row.addWidget(self.btn_cancel)
+
+        self.btn_confirm = QPushButton(confirm_text)
+        self.btn_confirm.setObjectName("primary")
+        self.btn_confirm.setDefault(True)
+        self.btn_confirm.clicked.connect(self.accept)
+        button_row.addWidget(self.btn_confirm)
+
+        layout.addLayout(button_row)
+
+        self.edit.setFocus()
+        self._sync_confirm_enabled()
+
+    def _sync_confirm_enabled(self):
+        self.btn_confirm.setEnabled(bool(self.edit.text().strip()))
+
+    def _on_return(self):
+        """回车 = 点确认，但空输入时什么也不发生（跟按钮灰着是一回事）。"""
+        if self.btn_confirm.isEnabled():
+            self.accept()
+
+    def value(self) -> str:
+        """用户填的内容（首尾空白已经去掉）。"""
+        return self.edit.text().strip()
+
+
+def ask_text(parent, title: str, label: str, text: str = "", placeholder: str = "",
+             confirm_text: str = "确定") -> Optional[str]:
+    """问用户要一行字。取消或没填返回 None。"""
+    dialog = TextInputDialog(
+        parent, title, label, text=text, placeholder=placeholder,
+        confirm_text=confirm_text,
+    )
+    if dialog.exec() != QDialog.DialogCode.Accepted:
+        return None
+    return dialog.value() or None
+
+
+def show_info(parent, title: str, message: str, detail: str = ""):
+    """只有一个「好」按钮的提示框。"""
+    AppDialog(parent, title, message, detail,
+              confirm_text="好", cancel_text=None).exec()
+
+
+def show_warning(parent, title: str, message: str, detail: str = ""):
+    """出问题了，但不需要用户做选择。"""
+    AppDialog(parent, title, message, detail,
+              confirm_text="知道了", cancel_text=None).exec()

--- a/gui/widgets/collapsible_section.py
+++ b/gui/widgets/collapsible_section.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""默认收起的分区。
+
+给「用得着、但不是每次都用」的功能准备的：标注页右栏的样本管理和数据导出
+都属于这一类——常驻展开只会把类别和 AI 入口挤到屏幕外面，可它们又不该被藏进
+菜单里找不着。收起来只留一行标题，点一下才展开。
+
+没有动画，也不记住展开状态：每次进页面都从收起开始，行为可预期。
+"""
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QFrame, QPushButton, QVBoxLayout, QWidget
+
+from gui.styles import COLORS, RADIUS, RADIUS_SM
+
+
+class CollapsibleSection(QFrame):
+    """一张卡片：标题一行，内容默认收起。"""
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        self._title = title
+
+        self.setObjectName("card")
+        self.setStyleSheet(f"""
+            QFrame#card {{
+                background-color: {COLORS['panel']};
+                border: 1px solid {COLORS['border']};
+                border-radius: {RADIUS}px;
+            }}
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(8)
+
+        # 标题即开关。整行都能点，不用去瞄那个小三角。
+        self.toggle = QPushButton()
+        self.toggle.setObjectName("ghost")
+        self.toggle.setCheckable(True)
+        self.toggle.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.toggle.setMinimumHeight(28)
+        self.toggle.setStyleSheet(f"""
+            QPushButton#ghost {{
+                text-align: left;
+                padding: 4px 6px;
+                border-radius: {RADIUS_SM}px;
+                color: {COLORS['text_primary']};
+                font-weight: 600;
+            }}
+            QPushButton#ghost:hover {{
+                background-color: {COLORS['hover']};
+            }}
+            QPushButton#ghost:checked {{
+                background-color: transparent;
+            }}
+        """)
+        self.toggle.toggled.connect(self._on_toggled)
+        layout.addWidget(self.toggle)
+
+        self.content = QWidget()
+        content_layout = QVBoxLayout(self.content)
+        content_layout.setContentsMargins(0, 0, 0, 2)
+        content_layout.setSpacing(8)
+        self.content.setVisible(False)
+        layout.addWidget(self.content)
+
+        self._content_layout = content_layout
+        self._on_toggled(False)
+
+    def _on_toggled(self, checked: bool):
+        self.content.setVisible(checked)
+        self.toggle.setText(f"{'▾' if checked else '▸'}  {self._title}")
+
+    # ==================== 对外 ====================
+
+    def content_layout(self) -> QVBoxLayout:
+        """往里放东西用这个。"""
+        return self._content_layout
+
+    def add_widget(self, widget: QWidget):
+        self._content_layout.addWidget(widget)
+
+    def add_layout(self, layout):
+        self._content_layout.addLayout(layout)
+
+    def set_expanded(self, expanded: bool):
+        self.toggle.setChecked(expanded)
+
+    def is_expanded(self) -> bool:
+        return self.toggle.isChecked()

--- a/gui/widgets/elided_combo.py
+++ b/gui/widgets/elided_combo.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""会省略的下拉框
+
+QComboBox 自己不省略：文字比框宽时它就直接裁掉——中文会被拦腰切掉半个字，
+看着像渲染坏了。项目名是用户随便起的，长度不受控，侧栏又是固定宽度，
+所以这里自己画一遍文字，装不下就用省略号收尾。
+
+同目录的 ElidedLabel 是同一个思路，只是那个针对 QLabel。
+"""
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFontMetrics
+from PyQt6.QtWidgets import QComboBox, QStyle, QStyleOptionComboBox, QStylePainter
+
+
+class ElidedComboBox(QComboBox):
+    """当前选项装不下时以省略号结尾。"""
+
+    def elided_text(self) -> str:
+        """当前选项真正会被画出来的那串字（装得下就是原文）。"""
+        option = QStyleOptionComboBox()
+        self.initStyleOption(option)
+
+        # 文字能用的宽度要问样式要：右边的箭头区是样式表给的内边距，
+        # 自己按控件总宽度算会算多，正好又把最后一个字切掉。
+        text_rect = self.style().subControlRect(
+            QStyle.ComplexControl.CC_ComboBox,
+            option,
+            QStyle.SubControl.SC_ComboBoxEditField,
+            self,
+        )
+        return QFontMetrics(self.font()).elidedText(
+            option.currentText, Qt.TextElideMode.ElideRight, text_rect.width()
+        )
+
+    def paintEvent(self, _event):
+        painter = QStylePainter(self)
+        painter.setPen(self.palette().color(self.foregroundRole()))
+
+        option = QStyleOptionComboBox()
+        self.initStyleOption(option)
+        option.currentText = self.elided_text()
+
+        painter.drawComplexControl(QStyle.ComplexControl.CC_ComboBox, option)
+        painter.drawControl(QStyle.ControlElement.CE_ComboBoxLabel, option)

--- a/gui/widgets/elided_label.py
+++ b/gui/widgets/elided_label.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""单行省略标签
+
+QMacStyle 下 QFormLayout 对「会换行的长值标签」行高计算不可靠：文字折行后
+裁切、与相邻行重叠。长值一律用这个控件——永远单行，宽度不够时按省略模式
+截断，完整内容放 tooltip。高度恒等于一行文字，不会再撑坏或压塌所在行。
+"""
+
+from PyQt6.QtWidgets import QLabel, QSizePolicy
+from PyQt6.QtCore import Qt
+
+
+class ElidedLabel(QLabel):
+    """单行标签：装不下时省略显示，鼠标悬停看全文。"""
+
+    def __init__(self, text: str = "", mode: Qt.TextElideMode = Qt.TextElideMode.ElideRight,
+                 parent=None):
+        super().__init__(parent)
+        self._full_text = ""
+        self._mode = mode
+        # 最小宽度不跟着文字长度走，布局才能自由压缩这一列
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.setMinimumWidth(48)
+        self.setText(text)
+
+    def setText(self, text: str):
+        self._full_text = text
+        self.setToolTip(text)
+        self._update_elided()
+
+    def fullText(self) -> str:
+        return self._full_text
+
+    def minimumSizeHint(self):
+        hint = super().minimumSizeHint()
+        hint.setWidth(48)
+        return hint
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._update_elided()
+
+    def _update_elided(self):
+        rect = self.contentsRect()
+        elided = self.fontMetrics().elidedText(self._full_text, self._mode, max(0, rect.width()))
+        super().setText(elided)

--- a/gui/widgets/group_select_dialog.py
+++ b/gui/widgets/group_select_dialog.py
@@ -1,22 +1,24 @@
 # -*- coding: utf-8 -*-
 """图片分组选择对话框"""
 
-from typing import List, Optional
+from typing import Optional
 
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QComboBox, QLineEdit, QMessageBox, QRadioButton, QButtonGroup
+    QComboBox, QLineEdit, QMessageBox, QRadioButton, QButtonGroup, QWidget
 )
-from PyQt6.QtCore import Qt
 
-from gui.styles import COLORS
 from models.database import db
 
 UNGROUPED_SENTINEL = 0
 
 
 class GroupSelectDialog(QDialog):
-    """选择已有分组、新建分组，或移出分组。"""
+    """选择已有分组、新建分组，或移出分组。
+
+    三种去向各自是一个选项，选中哪个就只有哪个的输入框可用，
+    避免「选了下拉框却在输入框里打了字」这种说不清用哪个的状态。
+    """
 
     def __init__(
         self,
@@ -34,76 +36,104 @@ class GroupSelectDialog(QDialog):
         self._cancelled = True
 
         self.setWindowTitle(title)
-        self.setMinimumWidth(360)
-        self.setStyleSheet(f"""
-            QDialog {{
-                background-color: {COLORS['background']};
-            }}
-            QLabel {{
-                color: {COLORS['text_primary']};
-            }}
-            QLineEdit, QComboBox {{
-                background-color: {COLORS['sidebar']};
-                color: {COLORS['text_primary']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                padding: 6px 8px;
-            }}
-        """)
+        self.setMinimumWidth(420)
 
         layout = QVBoxLayout(self)
-        layout.setSpacing(12)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(10)
 
-        hint = QLabel("选择已有分组，或输入新分组名称：")
-        layout.addWidget(hint)
+        heading = QLabel(title)
+        heading.setObjectName("h2")
+        layout.addWidget(heading)
+
+        self.mode_group = QButtonGroup(self)
+
+        # ---- 选项 1：已有分组 ----
+        self.radio_existing = QRadioButton("放入已有分组")
+        self.mode_group.addButton(self.radio_existing)
+        layout.addWidget(self.radio_existing)
 
         self.group_combo = QComboBox()
-        self._refresh_groups()
-        layout.addWidget(self.group_combo)
+        group_count = self._refresh_groups()
+        layout.addWidget(self._indent(self.group_combo))
 
-        new_row = QHBoxLayout()
-        new_row.addWidget(QLabel("新建分组:"))
+        # ---- 选项 2：新建分组 ----
+        self.radio_new = QRadioButton("新建分组")
+        self.mode_group.addButton(self.radio_new)
+        layout.addWidget(self.radio_new)
+
         self.new_group_input = QLineEdit()
-        self.new_group_input.setPlaceholderText("输入自定义分组名称")
-        new_row.addWidget(self.new_group_input, 1)
-        layout.addLayout(new_row)
+        self.new_group_input.setPlaceholderText("输入新分组名称")
+        layout.addWidget(self._indent(self.new_group_input))
 
+        # ---- 选项 3：移出分组 ----
         if allow_ungroup:
-            self.mode_group = QButtonGroup(self)
-            self.radio_existing = QRadioButton("使用上方选择的分组")
-            self.radio_new = QRadioButton("使用新建分组名称")
             self.radio_ungroup = QRadioButton("移出分组（变为未分组）")
-            self.radio_existing.setChecked(True)
-            for radio in (self.radio_existing, self.radio_new, self.radio_ungroup):
-                self.mode_group.addButton(radio)
-                layout.addWidget(radio)
+            self.mode_group.addButton(self.radio_ungroup)
+            layout.addWidget(self.radio_ungroup)
+
+            ungroup_hint = QLabel("图片仍留在项目里，只是不属于任何分组")
+            ungroup_hint.setObjectName("caption")
+            layout.addWidget(self._indent(ungroup_hint))
         else:
-            self.mode_group = QButtonGroup(self)
-            self.radio_existing = QRadioButton("使用已有分组")
-            self.radio_new = QRadioButton("使用新建分组")
-            self.radio_existing.setChecked(True)
-            for radio in (self.radio_existing, self.radio_new):
-                self.mode_group.addButton(radio)
-                layout.addWidget(radio)
             self.radio_ungroup = None
 
+        # 项目还没有任何分组时，默认停在「新建」，省得用户先选中再改
+        if group_count == 0:
+            self.radio_new.setChecked(True)
+            empty_hint = QLabel("当前项目还没有分组")
+            empty_hint.setObjectName("caption")
+            layout.addWidget(empty_hint)
+        else:
+            self.radio_existing.setChecked(True)
+
+        # 直接操作某个输入控件时，自动选中它对应的选项
+        self.group_combo.activated.connect(lambda _: self.radio_existing.setChecked(True))
+        self.new_group_input.textEdited.connect(lambda _: self.radio_new.setChecked(True))
+        for radio in self.mode_group.buttons():
+            radio.toggled.connect(self._sync_inputs)
+        self._sync_inputs()
+
+        layout.addSpacing(4)
+
         btn_row = QHBoxLayout()
-        btn_row.addStretch()
         if allow_skip:
             skip_btn = QPushButton("不分组")
-            skip_btn.setObjectName("secondary")
+            skip_btn.setObjectName("ghost")
+            skip_btn.setToolTip("继续操作，但图片保持未分组")
             skip_btn.clicked.connect(self._on_skip)
             btn_row.addWidget(skip_btn)
+        btn_row.addStretch()
+
         cancel_btn = QPushButton("取消")
         cancel_btn.setObjectName("secondary")
+        cancel_btn.setToolTip("放弃本次操作，不做任何改动")
         cancel_btn.clicked.connect(self.reject)
-        ok_btn = QPushButton("确定")
-        ok_btn.clicked.connect(self._on_accept)
         btn_row.addWidget(cancel_btn)
+
+        ok_btn = QPushButton("确定")
+        ok_btn.setObjectName("primary")
+        ok_btn.setDefault(True)
+        ok_btn.clicked.connect(self._on_accept)
         btn_row.addWidget(ok_btn)
+
         layout.addLayout(btn_row)
 
-    def _refresh_groups(self):
+    def _indent(self, widget: QWidget) -> QWidget:
+        """把输入控件缩进到所属单选项下面。"""
+        holder = QWidget()
+        row = QHBoxLayout(holder)
+        row.setContentsMargins(24, 0, 0, 0)
+        row.addWidget(widget)
+        return holder
+
+    def _sync_inputs(self):
+        """只让当前选中方式的输入控件可用。"""
+        self.group_combo.setEnabled(self.radio_existing.isChecked())
+        self.new_group_input.setEnabled(self.radio_new.isChecked())
+
+    def _refresh_groups(self) -> int:
+        """填充已有分组下拉框，返回用户自建分组的数量。"""
         self.group_combo.clear()
         groups = db.get_project_image_groups(self.project_id)
         counts = db.get_group_image_counts(self.project_id)
@@ -112,6 +142,7 @@ class GroupSelectDialog(QDialog):
         for group in groups:
             count = counts.get(group['id'], 0)
             self.group_combo.addItem(f"{group['name']} ({count})", group['id'])
+        return len(groups)
 
     def _on_skip(self):
         self._result_group_id = None
@@ -129,6 +160,7 @@ class GroupSelectDialog(QDialog):
             name = self.new_group_input.text().strip()
             if not name:
                 QMessageBox.warning(self, "提示", "请输入新分组名称")
+                self.new_group_input.setFocus()
                 return
             try:
                 self._result_group_id = db.create_image_group(self.project_id, name)
@@ -156,30 +188,21 @@ class GroupSelectDialog(QDialog):
 def ask_import_group(parent, project_id: int) -> tuple[bool, Optional[int]]:
     """导入前询问是否放入分组。
 
+    一个弹窗就能给出三种去向：选分组 / 不分组 / 取消导入，
+    不再先弹一个「要不要分组」的是非框、再弹一个选择框。
+
     Returns:
         (proceed, group_id)
         - proceed=False: 用户取消导入
         - proceed=True, group_id=None: 导入但不分组
         - proceed=True, group_id=int: 导入到指定分组
     """
-    reply = QMessageBox.question(
-        parent,
-        "导入分组",
-        "是否将本次导入的图片放入分组？\n（选择“否”则导入为未分组）",
-        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No | QMessageBox.StandardButton.Cancel,
-        QMessageBox.StandardButton.No,
-    )
-    if reply == QMessageBox.StandardButton.Cancel:
-        return False, None
-    if reply == QMessageBox.StandardButton.No:
-        return True, None
-
     dialog = GroupSelectDialog(
         parent,
         project_id,
         title="选择导入分组",
         allow_ungroup=False,
-        allow_skip=False,
+        allow_skip=True,
     )
     if dialog.exec() != QDialog.DialogCode.Accepted or dialog.was_cancelled():
         return False, None

--- a/gui/widgets/loading_dialog.py
+++ b/gui/widgets/loading_dialog.py
@@ -2,61 +2,96 @@
 """
 加载对话框组件
 显示加载动画和进度信息
+
+两种形态：
+    LoadingDialog  —— 独立的模态加载窗，用于阻塞式等待
+    LoadingOverlay —— 盖在某个控件上的加载遮罩
+
+两者都不带取消：调用方需要让用户中断时，应改用带取消按钮的 QProgressDialog，
+所以这里明确告诉用户「完成后会自动关闭」，而不是留一个看不出能不能停的转圈。
 """
 
 from PyQt6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QProgressBar,
-    QWidget, QGraphicsOpacityEffect
+    QDialog, QVBoxLayout, QLabel, QProgressBar, QWidget, QGraphicsDropShadowEffect
 )
-from PyQt6.QtCore import Qt, QTimer, QSize
-from PyQt6.QtGui import QMovie, QPixmap, QColor, QPainter, QPen
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtGui import QColor, QPainter, QPen
 
-from gui.styles import COLORS
+from gui.styles import COLORS, RADIUS
 
 
 class LoadingSpinner(QLabel):
     """加载旋转动画"""
-    
+
     def __init__(self, size: int = 64, parent=None):
         super().__init__(parent)
         self.setFixedSize(size, size)
+        self.setStyleSheet("background-color: transparent; border: none;")
         self.angle = 0
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.rotate)
         self.timer.start(50)  # 每50ms更新一次
-        
+
     def rotate(self):
         """旋转动画"""
         self.angle = (self.angle + 30) % 360
         self.update()
-    
+
     def paintEvent(self, event):
         """绘制旋转的圆环"""
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
+
         # 绘制背景圆环
         pen = QPen(QColor(COLORS['border']))
         pen.setWidth(4)
         painter.setPen(pen)
         painter.drawEllipse(8, 8, self.width() - 16, self.height() - 16)
-        
+
         # 绘制旋转的弧
         pen = QPen(QColor(COLORS['primary']))
         pen.setWidth(4)
         pen.setCapStyle(Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
-        
+
         painter.translate(self.width() // 2, self.height() // 2)
         painter.rotate(self.angle)
         painter.translate(-self.width() // 2, -self.height() // 2)
-        
+
         painter.drawArc(8, 8, self.width() - 16, self.height() - 16, 0, 120 * 16)
+
+
+def _card_style() -> str:
+    """加载卡片的样式。
+
+    只匹配 #loading_card 本身，不然 QWidget 选择器会把边框和圆角
+    传染给里面的每一个子控件（文字和进度条都会被套上一圈边框）。
+    """
+    return f"""
+        QWidget#loading_card {{
+            background-color: {COLORS['panel']};
+            border: 1px solid {COLORS['border']};
+            border-radius: {RADIUS}px;
+        }}
+    """
+
+
+def _elevate(widget: QWidget):
+    """把卡片从浅色遮罩上托起来。
+
+    浅底白卡只靠 1px 边框分不开，得有一点投影；
+    这也是浅色遮罩能成立的前提——不用压黑背景，照样看得出「上面盖了一层」。
+    """
+    shadow = QGraphicsDropShadowEffect(widget)
+    shadow.setBlurRadius(28)
+    shadow.setOffset(0, 6)
+    shadow.setColor(QColor(0, 0, 0, 46))
+    widget.setGraphicsEffect(shadow)
 
 
 class LoadingDialog(QDialog):
     """加载对话框"""
-    
+
     def __init__(self, parent=None, title: str = "加载中", message: str = "请稍候..."):
         super().__init__(parent)
         self.setWindowTitle(title)
@@ -67,79 +102,67 @@ class LoadingDialog(QDialog):
             Qt.WindowType.WindowStaysOnTopHint
         )
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        
+
         self.init_ui(message)
-        
-        # 设置固定大小
-        self.setFixedSize(300, 180)
-        
+
+        # 内容决定高度：文案长了会换行，不会被截断
+        self.setMinimumWidth(320)
+        self.adjustSize()
+
         # 居中显示
         if parent:
             self.move(
                 parent.x() + (parent.width() - self.width()) // 2,
                 parent.y() + (parent.height() - self.height()) // 2
             )
-    
+
     def init_ui(self, message: str):
         """初始化界面"""
-        # 创建主容器
-        container = QWidget(self)
-        container.setGeometry(0, 0, 300, 180)
-        container.setStyleSheet(f"""
-            QWidget {{
-                background-color: {COLORS['panel']};
-                border: 2px solid {COLORS['border']};
-                border-radius: 12px;
-            }}
-        """)
-        
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+
+        # 圆角卡片容器
+        container = QWidget()
+        container.setObjectName("loading_card")
+        container.setStyleSheet(_card_style())
+        _elevate(container)
+        outer.addWidget(container)
+
         layout = QVBoxLayout(container)
-        layout.setContentsMargins(20, 20, 20, 20)
-        layout.setSpacing(16)
-        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(12)
+
         # 加载动画
-        self.spinner = LoadingSpinner(64, self)
+        self.spinner = LoadingSpinner(56)
         layout.addWidget(self.spinner, alignment=Qt.AlignmentFlag.AlignCenter)
-        
-        # 消息文本
+
+        # 当前状态
         self.message_label = QLabel(message)
-        self.message_label.setStyleSheet(f"""
-            color: {COLORS['text_primary']};
-            font-size: 14px;
-            font-weight: bold;
-        """)
+        self.message_label.setObjectName("title")
+        self.message_label.setWordWrap(True)
         self.message_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.message_label)
-        
-        # 进度条（可选）
+
+        # 说明：不可取消，完成后自动关闭
+        hint = QLabel("完成后会自动关闭")
+        hint.setObjectName("caption")
+        hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(hint)
+
+        # 进度条：只有拿到确定进度时才出现
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
-        self.progress_bar.setStyleSheet(f"""
-            QProgressBar {{
-                background-color: {COLORS['sidebar']};
-                border: 1px solid {COLORS['border']};
-                border-radius: 4px;
-                text-align: center;
-                color: white;
-                height: 8px;
-            }}
-            QProgressBar::chunk {{
-                background-color: {COLORS['primary']};
-                border-radius: 3px;
-            }}
-        """)
         layout.addWidget(self.progress_bar)
-    
+
     def set_message(self, message: str):
         """设置消息文本"""
         self.message_label.setText(message)
-    
+
     def set_progress(self, value: int):
         """设置进度"""
         self.progress_bar.setVisible(True)
         self.progress_bar.setValue(value)
-    
+
     def showEvent(self, event):
         """显示事件"""
         super().showEvent(event)
@@ -154,41 +177,57 @@ class LoadingDialog(QDialog):
 
 class LoadingOverlay(QWidget):
     """加载遮罩层 - 用于在控件上方显示加载状态"""
-    
+
     def __init__(self, parent: QWidget, message: str = "加载中..."):
         super().__init__(parent)
+        self.setObjectName("loading_scrim")
         self.setGeometry(parent.rect())
-        
-        # 半透明背景
+
+        # 遮罩用应用自己的浅色，不是 75% 的黑：整个界面都是浅色的，
+        # 一压黑就像换了个应用。半透明的画布色 + 卡片投影，
+        # 一样看得出「下面的东西现在点不了」，但不砸眼睛。
+        # 只作用在遮罩自身，卡片和文字保持不透明。
         self.setStyleSheet(f"""
-            QWidget {{
-                background-color: rgba(30, 30, 30, 180);
+            QWidget#loading_scrim {{
+                background-color: rgba(245, 245, 247, 216);
             }}
-        """)
-        
+        """ + _card_style())
+
         layout = QVBoxLayout(self)
         layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
+
+        card = QWidget()
+        card.setObjectName("loading_card")
+        card.setMinimumWidth(240)
+        _elevate(card)
+        layout.addWidget(card, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(24, 20, 24, 20)
+        card_layout.setSpacing(10)
+
         # 加载动画
-        self.spinner = LoadingSpinner(48, self)
-        layout.addWidget(self.spinner, alignment=Qt.AlignmentFlag.AlignCenter)
-        
-        # 消息文本
+        self.spinner = LoadingSpinner(48)
+        card_layout.addWidget(self.spinner, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        # 当前状态
         self.label = QLabel(message)
-        self.label.setStyleSheet(f"""
-            color: {COLORS['text_primary']};
-            font-size: 13px;
-            margin-top: 12px;
-        """)
+        self.label.setObjectName("title")
+        self.label.setWordWrap(True)
         self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(self.label)
-        
+        card_layout.addWidget(self.label)
+
+        hint = QLabel("完成后会自动消失")
+        hint.setObjectName("caption")
+        hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        card_layout.addWidget(hint)
+
         self.hide()
-        
+
         # 使用定时器确保动画流畅
         self.update_timer = QTimer(self)
         self.update_timer.timeout.connect(self.update)
-    
+
     def show_loading(self, message: str = None):
         """显示加载遮罩"""
         if message:
@@ -197,7 +236,7 @@ class LoadingOverlay(QWidget):
         self.show()
         self.raise_()
         self.update_timer.start(16)  # 约60fps
-    
+
     def hide_loading(self):
         """隐藏加载遮罩"""
         self.update_timer.stop()

--- a/gui/widgets/task_type_dialog.py
+++ b/gui/widgets/task_type_dialog.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+任务类型选择对话框
+
+原来新建项目、修改任务类型、导入标注三处各写了一份一模一样的对话框，
+这里合并成一个，顺便给每种任务补一句大白话解释。
+"""
+
+from typing import Optional
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QRadioButton,
+)
+
+# (值, 标题, 解释)
+TASK_TYPES = [
+    ('detect', '目标检测 detect', '用方框圈出目标的位置，最常用，新手从这个开始。'),
+    ('segment', '实例分割 segment', '沿着目标的轮廓描边，能得到精确形状。'),
+    ('pose', '关键点检测 pose', '标出目标身上的若干个点，比如人体骨骼关节。'),
+    ('classify', '图像分类 classify', '只判断整张图属于哪一类，不定位。'),
+]
+
+TASK_LABELS = {value: title for value, title, _ in TASK_TYPES}
+
+
+def task_type_label(value: str) -> str:
+    """把 detect 这种内部值翻成给人看的名字。"""
+    return TASK_LABELS.get(value, value or '未设置')
+
+
+def ask_task_type(parent, current: str = 'detect', title: str = "选择任务类型") -> Optional[str]:
+    """弹出任务类型选择框。用户取消时返回 None。"""
+    dialog = QDialog(parent)
+    dialog.setWindowTitle(title)
+    dialog.setMinimumWidth(420)
+
+    layout = QVBoxLayout(dialog)
+    layout.setContentsMargins(24, 20, 24, 20)
+    layout.setSpacing(12)
+
+    hint = QLabel("这个项目要让模型做什么？决定了标注工具和训练方式。")
+    hint.setObjectName("subtitle")
+    hint.setWordWrap(True)
+    layout.addWidget(hint)
+
+    # pose 在旧数据里可能存成 point
+    normalized = 'pose' if current == 'point' else (current or 'detect')
+
+    buttons = {}
+    for value, label, explain in TASK_TYPES:
+        radio = QRadioButton(label)
+        radio.setChecked(value == normalized)
+        layout.addWidget(radio)
+
+        note = QLabel(explain)
+        note.setObjectName("caption")
+        note.setWordWrap(True)
+        note.setContentsMargins(24, 0, 0, 6)
+        layout.addWidget(note)
+
+        buttons[value] = radio
+
+    if not any(radio.isChecked() for radio in buttons.values()):
+        buttons['detect'].setChecked(True)
+
+    btn_row = QHBoxLayout()
+    btn_row.setContentsMargins(0, 8, 0, 0)
+    btn_row.addStretch()
+
+    cancel_btn = QPushButton("取消")
+    cancel_btn.clicked.connect(dialog.reject)
+    btn_row.addWidget(cancel_btn)
+
+    ok_btn = QPushButton("确定")
+    ok_btn.setObjectName("primary")
+    ok_btn.setDefault(True)
+    ok_btn.clicked.connect(dialog.accept)
+    btn_row.addWidget(ok_btn)
+
+    layout.addLayout(btn_row)
+
+    if dialog.exec() != QDialog.DialogCode.Accepted:
+        return None
+
+    for value, radio in buttons.items():
+        if radio.isChecked():
+            return value
+    return 'detect'

--- a/gui/widgets/video_extract_dialog.py
+++ b/gui/widgets/video_extract_dialog.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+"""抽帧设置对话框
+
+替掉 QInputDialog.getInt：那个框只问「间隔多少帧」，可用户想知道的是
+「我最后能得到几张图」——一段 30fps 的视频填 30，到底是 20 张还是 200 张？
+原来的框既不说总帧数，也不说预计张数，只能靠猜。
+
+这里在开抽之前先读一遍视频元信息（只读属性，不解码），然后：
+    固定间隔  每 N 帧取 1 张 —— 边填边算「预计 X 张」，并按 fps 折算成时间间隔
+    随机抽取  随机取 N 张    —— 直接要张数，按视频时长给一句人话建议
+
+总帧数读不到时（有些流式录制的视频就是不写这个值），固定间隔照常能用
+（只是算不出预计张数），随机抽取则整个禁掉：不知道有多少帧，就没法从里面随机取 N 张。
+"""
+
+import math
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QRadioButton, QSpinBox, QWidget, QFrame,
+)
+
+from core.import_manager import (
+    VIDEO_MODE_INTERVAL, VIDEO_MODE_RANDOM,
+    probe_video_metadata, estimate_interval_frame_count,
+)
+from gui.styles import COLORS, RADIUS_SM
+
+# 间隔上限跟原来的 QInputDialog 保持一致
+MAX_INTERVAL = 1000
+
+# 够放下「每 [30] 帧取 1 张   → 预计 10 张，约每 1.0 秒 1 张」一整行，
+# 又不至于让下面那段说明稀稀拉拉铺成一整片
+DIALOG_WIDTH = 480
+_DIALOG_MARGIN = 24          # 对话框左右边距
+_RESULT_PADDING = 12         # 说明块自己的左右内边距
+
+# 会换行的文字实际能用多宽。Qt 不会自己把「换行之后要多高」算进对话框的高度——
+# QLabel 报的 sizeHint 是按不换行算的，于是框子按一行的高度开出来，
+# 三行字就画到按钮上去了。所以这里按真实宽度把高度算出来，显式钉给标签。
+TEXT_WIDTH = DIALOG_WIDTH - 2 * _DIALOG_MARGIN
+RESULT_TEXT_WIDTH = TEXT_WIDTH - 2 * _RESULT_PADDING
+
+
+def _fit_wrapped_height(label: QLabel, width: int):
+    """按给定宽度把换行后的高度算出来，钉成标签的最小高度。"""
+    label.setMinimumHeight(label.heightForWidth(width))
+
+
+def format_duration(seconds: Optional[float]) -> str:
+    """把秒数说成人话：72.5 → 「1 分 12 秒」。"""
+    if not seconds or seconds <= 0:
+        return ""
+    total = int(round(seconds))
+    minutes, secs = divmod(total, 60)
+    if minutes:
+        return f"{minutes} 分 {secs} 秒"
+    return f"{secs} 秒"
+
+
+class VideoExtractDialog(QDialog):
+    """抽帧设置：选方式 → 填数 → 看预计张数。"""
+
+    def __init__(self, parent, metadata: dict, filename: str = ""):
+        super().__init__(parent)
+
+        self.setWindowTitle("抽帧设置")
+        self.setFixedWidth(DIALOG_WIDTH)
+
+        self.total_frames = int(metadata.get('total_frames') or 0)
+        self.fps = float(metadata.get('fps') or 0.0)
+        self.duration = metadata.get('duration')
+        self.knows_total = self.total_frames > 0
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(_DIALOG_MARGIN, 20, _DIALOG_MARGIN, 18)
+        layout.setSpacing(10)
+
+        heading = QLabel("从视频里抽帧")
+        heading.setObjectName("h2")
+        layout.addWidget(heading)
+
+        self.lbl_meta = QLabel(self._metadata_text(filename))
+        self.lbl_meta.setObjectName("subtitle")
+        self.lbl_meta.setWordWrap(True)
+        # 文件名可以很长，这一行本来就可能折成两行——高度得先算出来
+        _fit_wrapped_height(self.lbl_meta, TEXT_WIDTH)
+        layout.addWidget(self.lbl_meta)
+
+        # --- 方式一：固定间隔 ---
+        self.rbtn_interval = QRadioButton("固定间隔：每 N 帧取 1 张")
+        self.rbtn_interval.setChecked(True)
+        self.rbtn_interval.toggled.connect(self._on_mode_changed)
+        layout.addWidget(self.rbtn_interval)
+
+        # 预计张数就跟在输入框后面：用户改的是这个数，想知道的结果也在这一行，
+        # 眼睛不用往下跑。右边那片空白本来什么都不放，现在正好给它。
+        self.interval_row = QWidget()
+        interval_layout = QHBoxLayout(self.interval_row)
+        interval_layout.setContentsMargins(24, 0, 0, 0)
+        interval_layout.setSpacing(8)
+
+        interval_layout.addWidget(QLabel("每"))
+        self.sb_interval = QSpinBox()
+        self.sb_interval.setRange(1, MAX_INTERVAL)
+        self.sb_interval.setValue(30)
+        self.sb_interval.setFixedWidth(88)
+        self.sb_interval.valueChanged.connect(self._refresh_estimate)
+        interval_layout.addWidget(self.sb_interval)
+        interval_layout.addWidget(QLabel("帧取 1 张"))
+
+        self.lbl_interval_estimate = QLabel()
+        self.lbl_interval_estimate.setObjectName("caption")
+        interval_layout.addWidget(self.lbl_interval_estimate, 1)
+
+        layout.addWidget(self.interval_row)
+
+        # --- 方式二：随机抽取 ---
+        self.rbtn_random = QRadioButton("随机抽取：随机取 N 张")
+        self.rbtn_random.toggled.connect(self._on_mode_changed)
+        layout.addWidget(self.rbtn_random)
+
+        self.random_row = QWidget()
+        random_layout = QHBoxLayout(self.random_row)
+        random_layout.setContentsMargins(24, 0, 0, 0)
+        random_layout.setSpacing(8)
+
+        random_layout.addWidget(QLabel("随机取"))
+        self.sb_random_count = QSpinBox()
+        self.sb_random_count.setRange(1, max(self.total_frames, 1))
+        self.sb_random_count.setValue(self._recommended_count())
+        self.sb_random_count.setFixedWidth(88)
+        self.sb_random_count.valueChanged.connect(self._refresh_estimate)
+        random_layout.addWidget(self.sb_random_count)
+        random_layout.addWidget(QLabel("张"))
+
+        self.lbl_random_estimate = QLabel()
+        self.lbl_random_estimate.setObjectName("caption")
+        random_layout.addWidget(self.lbl_random_estimate, 1)
+
+        layout.addWidget(self.random_row)
+
+        # 总帧数未知：随机抽取没法用，说清楚为什么，而不是让它看着能点却报错
+        if not self.knows_total:
+            self.rbtn_random.setEnabled(False)
+            self.sb_random_count.setEnabled(False)
+            self.rbtn_random.setToolTip("读不到视频总帧数，无法随机取固定张数")
+
+        # --- 说明块：只在真有话说的时候出现 ---
+        # 固定间隔 + 总帧数已知时，该说的话上面那行已经说完了，这里再重复一遍
+        # 「预计 10 张」只是把框撑高。所以它平时是收起来的，只有随机模式要给建议、
+        # 或者总帧数读不到要解释一句时才露面。
+        # 底色比对话框画布再深一点点。用 background 的话跟画布同色，
+        # 这个「块」就只是一段浮在那儿的灰字，根本不成块。
+        self.result_box = QFrame()
+        self.result_box.setStyleSheet(f"""
+            QFrame {{
+                background-color: {COLORS['hover']};
+                border: none;
+                border-radius: {RADIUS_SM}px;
+            }}
+        """)
+        result_layout = QVBoxLayout(self.result_box)
+        result_layout.setContentsMargins(_RESULT_PADDING, 10, _RESULT_PADDING, 10)
+        result_layout.setSpacing(0)
+
+        self.lbl_estimate = QLabel()
+        self.lbl_estimate.setObjectName("caption")
+        self.lbl_estimate.setWordWrap(True)
+        result_layout.addWidget(self.lbl_estimate)
+
+        layout.addWidget(self.result_box)
+
+        button_row = QHBoxLayout()
+        button_row.setContentsMargins(0, 10, 0, 0)
+        button_row.setSpacing(8)
+        button_row.addStretch()
+
+        self.btn_cancel = QPushButton("取消")
+        self.btn_cancel.clicked.connect(self.reject)
+        button_row.addWidget(self.btn_cancel)
+
+        self.btn_confirm = QPushButton("开始抽帧")
+        self.btn_confirm.setObjectName("primary")
+        self.btn_confirm.setDefault(True)
+        self.btn_confirm.clicked.connect(self.accept)
+        button_row.addWidget(self.btn_confirm)
+
+        layout.addLayout(button_row)
+
+        self._on_mode_changed()
+
+    # ==================== 文案 ====================
+
+    def _metadata_text(self, filename: str) -> str:
+        """抬头那行：这段视频是什么样的。读不到就直说读不到。"""
+        name = filename or "视频"
+        if not self.knows_total:
+            return f"{name}：读不到总帧数（有些视频不写这个信息），只能按固定间隔抽。"
+
+        parts = [f"共 {self.total_frames} 帧"]
+        if self.fps:
+            parts.append(f"{self.fps:.0f} fps")
+        length = format_duration(self.duration)
+        if length:
+            parts.append(f"时长约 {length}")
+        return f"{name}：" + "，".join(parts) + "。"
+
+    def _recommended_count(self) -> int:
+        """随机张数的默认值：按「每秒 1 张」估，没有时长信息就给 20 张。"""
+        if self.duration and self.duration > 0:
+            recommended = int(math.ceil(self.duration))
+        else:
+            recommended = 20
+        upper = self.total_frames if self.knows_total else recommended
+        return max(1, min(recommended, max(upper, 1)))
+
+    def _random_advice(self) -> str:
+        """随机模式下给一句建议，用时长说话，不让用户自己换算帧。"""
+        length = format_duration(self.duration)
+        if not length:
+            return "建议先少抽一些看看效果，不够再补。"
+
+        per_second = int(math.ceil(self.duration))
+        sparse = max(1, per_second // 2)
+        return (
+            f"这段视频约 {length}：想每秒大约 1 张，填 {per_second} 张；"
+            f"画面变化不大的话，{sparse} 张通常也够用。"
+        )
+
+    def _set_result(self, text: str):
+        """说明块：没话说就整块收起来，不留一条空白的灰条。"""
+        self.lbl_estimate.setText(text)
+        self.result_box.setVisible(bool(text))
+        if text:
+            _fit_wrapped_height(self.lbl_estimate, RESULT_TEXT_WIDTH)
+
+        # 已经摆出来之后再换模式（一行的说明变成三行，或者整块收起）：
+        # 高度要重新收敛到当前内容。宽度是钉死的，adjustSize 只会动高度。
+        if self.isVisible():
+            self.adjustSize()
+
+    def _refresh_estimate(self):
+        """预计张数 / 建议，跟着输入实时更新。
+
+        当前这一行给「几张」（短、就在输入框旁边），
+        下面的说明块只在还有别的话要说时才出现。
+        """
+        if self.rbtn_random.isChecked():
+            count = self.sb_random_count.value()
+            self.lbl_interval_estimate.setText("")
+            self.lbl_random_estimate.setText(f"→ 预计 {count} 张")
+            # 随机模式下「抽几张」全靠用户拍脑袋，这里必须给个参照
+            self._set_result(
+                f"将随机抽取 {count} 张（帧号不重复，按先后顺序导入）。{self._random_advice()}"
+            )
+            return
+
+        self.lbl_random_estimate.setText("")
+
+        interval = self.sb_interval.value()
+        estimated = estimate_interval_frame_count(self.total_frames, interval)
+
+        if estimated is None:
+            self.lbl_interval_estimate.setText("→ 张数未知")
+            self._set_result(
+                f"每 {interval} 帧取 1 张。总帧数未知，抽完才知道是几张。"
+            )
+            return
+
+        text = f"→ 预计 {estimated} 张"
+        if self.fps:
+            spacing = interval / self.fps
+            text += f"，约每 {spacing:.1f} 秒 1 张"
+        self.lbl_interval_estimate.setText(text)
+        # 张数和时间间隔上面那行都写了，这里没有新东西可说
+        self._set_result("")
+
+    def _on_mode_changed(self, *_args):
+        random_mode = self.rbtn_random.isChecked()
+        self.interval_row.setEnabled(not random_mode)
+        self.random_row.setEnabled(random_mode and self.knows_total)
+        self._refresh_estimate()
+
+    # ==================== 结果 ====================
+
+    def get_plan(self) -> dict:
+        """用户选的抽帧方案，直接喂给 ImportManager.import_video。"""
+        if self.rbtn_random.isChecked():
+            return {
+                'mode': VIDEO_MODE_RANDOM,
+                'sample_count': self.sb_random_count.value(),
+                'frame_interval': 1,
+            }
+        return {
+            'mode': VIDEO_MODE_INTERVAL,
+            'frame_interval': self.sb_interval.value(),
+            'sample_count': None,
+        }
+
+
+def ask_video_extract_plan(parent, video_path: str) -> Optional[dict]:
+    """读元信息 → 弹抽帧设置框。用户取消返回 None。
+
+    元信息读不出来（文件损坏、格式不认）时抛 ValueError，由调用方报错。
+    """
+    metadata = probe_video_metadata(video_path)
+    dialog = VideoExtractDialog(parent, metadata, filename=Path(video_path).name)
+    if dialog.exec() != QDialog.DialogCode.Accepted:
+        return None
+    return dialog.get_plan()

--- a/gui/widgets/workflow_widgets.py
+++ b/gui/widgets/workflow_widgets.py
@@ -1,0 +1,432 @@
+# -*- coding: utf-8 -*-
+"""
+主流程相关的通用控件
+
+StepNavItem / StepNav —— 侧边栏的流程导航，每一步显示序号、名称和进展数字
+PageHeader           —— 每页顶部：当前是第几步、一句说明、下一步去哪
+StepGate             —— 前置条件不满足时挡在页面前面：缺什么 + 一个补上的入口
+NoticeBar            —— 窗口内的一条轻量通知，可关闭，不打断操作
+EmptyState           —— 页面内的空状态：一句话 + 主按钮
+"""
+
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
+    QSizePolicy,
+)
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFont, QFontMetrics
+
+from gui.styles import COLORS, CONTROL_HEIGHT_LG
+from gui.workflow import (
+    WORKFLOW_STEPS, STEP_BY_INDEX,
+    DONE, CURRENT, READY, LOCKED,
+)
+
+# 每种状态用一个字符表示，不堆图标：做完了 / 正在做 / 可以做 / 还进不去
+STATE_MARK = {
+    DONE: '✓',
+    CURRENT: '●',
+    READY: '○',
+    LOCKED: '○',
+}
+
+STATE_COLOR = {
+    DONE: COLORS['success'],
+    CURRENT: COLORS['primary'],
+    READY: COLORS['text_secondary'],
+    LOCKED: COLORS['text_disabled'],
+}
+
+
+class StepNavItem(QPushButton):
+    """侧边栏中的一步：一个把两行字装在自己里面的按钮。
+
+    按钮里放布局有个坑：QPushButton 的 sizeHint / minimumSizeHint 只按它自己那段
+    文本算（这里是空的），根本不看子布局。父布局照这个值给高度，里面两行字就被
+    压扁——13px 的中文一行要 18px，控件却只有 11px，名称和状态上下都被削掉。
+    QSS 的 padding 也帮不上忙：它只影响按钮自绘的文本，子布局的 contentsRect
+    一点没变（实测 contentsRect == rect）。
+
+    所以尺寸只认一个来源——子布局：
+      · 内边距写在布局的 contentsMargins 里，QSS 那边不再写 padding；
+      · sizeHint / minimumSizeHint 直接返回布局算出来的尺寸，字体多大、
+        缩放多少、平台是不是 Cocoa，高度都跟着字体度量走。
+
+    字体用 QFont 直接设，不写在样式表里：样式表里的 font-size 要等控件 polish
+    之后才反映到 fontMetrics()，构造期按它算宽度会拿到应用默认字体的度量。
+    QFont 一设就生效，度量当场可信——下面 mark 的宽度就是这么算出来的。
+    """
+
+    NAME_PX = 13
+    STATUS_PX = 11
+
+    def __init__(self, step: dict, parent=None):
+        super().__init__(parent)
+        self.step = step
+        self.setObjectName("step_item")
+        self.setCheckable(True)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+        layout = QHBoxLayout(self)
+        # 视觉内边距（原来写在 QSS 的 padding 里，对子布局无效）+ 1px 边框
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(10)
+
+        self.mark = QLabel()
+        self.mark.setFont(self._sized_font(self.NAME_PX))
+        # 宽度按字形算，不写死：'✓' 这类符号在 Cocoa 上会落到别的字体里，
+        # 实际字宽跟着系统走。写死 16px 的话，字形一宽就被竖着切掉半个。
+        mark_metrics = QFontMetrics(self.mark.font())
+        widest_mark = max(
+            mark_metrics.horizontalAdvance(m) for m in STATE_MARK.values()
+        )
+        self.mark.setMinimumWidth(widest_mark + 4)
+        self.mark.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.mark)
+
+        text_col = QVBoxLayout()
+        text_col.setContentsMargins(0, 0, 0, 0)
+        text_col.setSpacing(1)
+
+        self.name = QLabel(f"{step['num']}. {step['name']}")
+        self.name.setFont(self._sized_font(self.NAME_PX, bold=True))
+        self.name.setStyleSheet(f"color: {COLORS['text_primary']};")
+        text_col.addWidget(self.name)
+
+        self.status = QLabel("")
+        self.status.setFont(self._sized_font(self.STATUS_PX))
+        self.status.setStyleSheet(f"color: {COLORS['text_secondary']};")
+        text_col.addWidget(self.status)
+
+        layout.addLayout(text_col)
+        layout.addStretch()
+
+    def _sized_font(self, pixel_size: int, bold: bool = False) -> QFont:
+        font = QFont(self.font())
+        font.setPixelSize(pixel_size)
+        if bold:
+            font.setWeight(QFont.Weight.DemiBold)
+        return font
+
+    def sizeHint(self):
+        return self.layout().sizeHint()
+
+    def minimumSizeHint(self):
+        return self.layout().minimumSize()
+
+    def apply_state(self, state: str, status_text: str):
+        self.mark.setText(STATE_MARK.get(state, '○'))
+        self.mark.setStyleSheet(
+            f"color: {STATE_COLOR.get(state, COLORS['text_secondary'])};"
+        )
+
+        if state == LOCKED:
+            name_color = COLORS['text_disabled']
+        else:
+            name_color = COLORS['text_primary']
+        self.name.setStyleSheet(f"color: {name_color};")
+
+        self.status.setText(status_text)
+        self.status.setStyleSheet(f"color: {COLORS['text_secondary']};")
+
+        # 状态文字从无到有会让内容变高，得让父布局重新问一次尺寸
+        self.updateGeometry()
+
+
+class StepNav(QWidget):
+    """侧边栏的流程导航。锁住的步骤仍可点开——点进去会看到为什么进不去、怎么补。"""
+
+    step_clicked = pyqtSignal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.items = {}
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+
+        for step in WORKFLOW_STEPS:
+            item = StepNavItem(step)
+            item.clicked.connect(
+                lambda _checked, index=step['index']: self.step_clicked.emit(index)
+            )
+            layout.addWidget(item)
+            self.items[step['index']] = item
+
+    def update_states(self, states: dict, status_texts: dict, current_index: int):
+        for index, item in self.items.items():
+            item.apply_state(states.get(index, LOCKED), status_texts.get(index, ''))
+            item.setChecked(index == current_index)
+
+
+class PageHeader(QWidget):
+    """页面顶栏：你在第几步、这一步是干什么的、下一步去哪。"""
+
+    next_clicked = pyqtSignal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("page_header")
+        self._next_index = None
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(24, 12, 24, 12)
+        layout.setSpacing(16)
+
+        text_col = QVBoxLayout()
+        text_col.setContentsMargins(0, 0, 0, 0)
+        text_col.setSpacing(2)
+
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(8)
+
+        self.title = QLabel()
+        self.title.setObjectName("h1")
+        title_row.addWidget(self.title)
+
+        self.badge = QLabel()
+        self.badge.setObjectName("step_badge")
+        title_row.addWidget(self.badge, 0, Qt.AlignmentFlag.AlignVCenter)
+        title_row.addStretch()
+
+        text_col.addLayout(title_row)
+
+        # 说明只有一句：允许换行，但不给它撑高页头的机会
+        self.desc = QLabel()
+        self.desc.setObjectName("subtitle")
+        self.desc.setWordWrap(True)
+        text_col.addWidget(self.desc)
+
+        layout.addLayout(text_col, 1)
+
+        self.next_btn = QPushButton()
+        self.next_btn.setObjectName("primary")
+        self.next_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.next_btn.setMinimumHeight(CONTROL_HEIGHT_LG)
+        # 按钮不能被长标题挤扁，也不该抢走标题的宽度
+        self.next_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.next_btn.clicked.connect(self._on_next)
+        self.next_btn.hide()
+        layout.addWidget(self.next_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+
+    def _on_next(self):
+        if self._next_index is not None:
+            self.next_clicked.emit(self._next_index)
+
+    def set_step(self, index: int, title: str = None, desc: str = None):
+        step = STEP_BY_INDEX.get(index)
+        if step:
+            self.badge.show()
+            self.badge.setText(f"{step['num']} / {len(WORKFLOW_STEPS)}")
+            self.title.setText(title or step['name'])
+            self.desc.setText(desc or step['desc'])
+        else:
+            self.badge.hide()
+            self.title.setText(title or "")
+            self.desc.setText(desc or "")
+        self.desc.setVisible(bool(self.desc.text()))
+
+    def set_next_action(self, action):
+        """action: {'text', 'index'} 或 None"""
+        if not action:
+            self._next_index = None
+            self.next_btn.hide()
+            return
+        self._next_index = action['index']
+        self.next_btn.setText(action['text'])
+        self.next_btn.show()
+
+
+class NoticeBar(QFrame):
+    """窗口内的一条轻量通知：一句话 + 可选详情 + 关闭。
+
+    用来替代启动时的弹窗——有事说一句，没事根本不出现，
+    任何情况下都不打断用户，也不代替用户做决定。
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("notice")
+        self.setStyleSheet(
+            f"QFrame#notice {{"
+            f"  background-color: {COLORS['selected']};"
+            f"  border: none;"
+            f"  border-bottom: 1px solid {COLORS['border']};"
+            f"  border-radius: 0px;"
+            f"}}"
+        )
+        self.hide()
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(24, 8, 16, 8)
+        layout.setSpacing(10)
+
+        self.text = QLabel()
+        self.text.setWordWrap(True)
+        self.text.setStyleSheet(f"color: {COLORS['text_primary']}; font-size: 12px;")
+        layout.addWidget(self.text, 1)
+
+        self.close_btn = QPushButton("知道了")
+        self.close_btn.setObjectName("ghost")
+        self.close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.close_btn.clicked.connect(self.hide)
+        layout.addWidget(self.close_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+
+    def show_message(self, message: str, detail: str = ""):
+        self.text.setText(message)
+        self.text.setToolTip(detail)
+        self.show()
+
+
+class StepGate(QWidget):
+    """前置条件不满足时显示：缺什么、去哪补。不解释概念。"""
+
+    goto_requested = pyqtSignal(int)
+    bypass_requested = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._goto_index = None
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(24, 24, 24, 24)
+        outer.addStretch()
+
+        card = QFrame()
+        card.setObjectName("card")
+        # 上限不是定值：容器比它窄时卡片要能跟着缩，否则右边会被切掉
+        card.setMaximumWidth(460)
+        card.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(24, 22, 24, 22)
+        card_layout.setSpacing(8)
+
+        self.title = QLabel()
+        self.title.setObjectName("h2")
+        self.title.setWordWrap(True)
+        card_layout.addWidget(self.title)
+
+        self.reason = QLabel()
+        self.reason.setObjectName("subtitle")
+        self.reason.setWordWrap(True)
+        card_layout.addWidget(self.reason)
+
+        btn_row = QHBoxLayout()
+        btn_row.setContentsMargins(0, 8, 0, 0)
+        btn_row.setSpacing(8)
+
+        self.goto_btn = QPushButton()
+        self.goto_btn.setObjectName("primary")
+        self.goto_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.goto_btn.setMinimumHeight(CONTROL_HEIGHT_LG)
+        self.goto_btn.clicked.connect(self._on_goto)
+        btn_row.addWidget(self.goto_btn)
+
+        self.bypass_btn = QPushButton()
+        self.bypass_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.bypass_btn.setMinimumHeight(CONTROL_HEIGHT_LG)
+        self.bypass_btn.clicked.connect(self.bypass_requested.emit)
+        self.bypass_btn.hide()
+        btn_row.addWidget(self.bypass_btn)
+
+        btn_row.addStretch()
+        card_layout.addLayout(btn_row)
+
+        row = QHBoxLayout()
+        row.addStretch()
+        row.addWidget(card)
+        row.addStretch()
+        outer.addLayout(row)
+        outer.addStretch()
+
+    def _on_goto(self):
+        if self._goto_index is not None:
+            self.goto_requested.emit(self._goto_index)
+
+    def set_blocker(self, blocker: dict):
+        self.title.setText(blocker['title'])
+        self.reason.setText(blocker['reason'])
+        self._goto_index = blocker['action_index']
+        self.goto_btn.setText(blocker['action_text'])
+
+        bypass_text = blocker.get('bypass_text')
+        if bypass_text:
+            self.bypass_btn.setText(bypass_text)
+            self.bypass_btn.show()
+        else:
+            self.bypass_btn.hide()
+
+
+def _wrapping_label(text: str, width: int = 480) -> QLabel:
+    """居中、会自动换行、并且高度算得对的说明文字。
+
+    width 是上限不是定值：setFixedWidth 会让 min == max，容器比它窄的时候
+    标签缩不下去，文字就被横向切掉——窗口拉到 1100 宽时，测试页右边那句
+    「结果会显示在这里，同时保存到 outputs 文件夹」中间会缺一截。
+    改成 maximumWidth 之后布局能把它压窄，heightForWidth 再按换行后的实际
+    行数给高度，横竖都不会切。
+    """
+    label = QLabel(text)
+    label.setObjectName("subtitle")
+    label.setWordWrap(True)
+    label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    label.setMaximumWidth(width)
+
+    policy = label.sizePolicy()
+    policy.setHorizontalPolicy(QSizePolicy.Policy.Preferred)
+    policy.setVerticalPolicy(QSizePolicy.Policy.Minimum)
+    policy.setHeightForWidth(True)
+    label.setSizePolicy(policy)
+    return label
+
+
+class EmptyState(QFrame):
+    """页面内的空状态：标题 + 一句说明 + 一个主按钮（可选若干次按钮）。"""
+
+    def __init__(self, title: str, message: str, parent=None):
+        super().__init__(parent)
+        self.setObjectName("card")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(32, 32, 32, 32)
+        layout.setSpacing(12)
+
+        layout.addStretch()
+
+        self.title = QLabel(title)
+        self.title.setObjectName("h2")
+        self.title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.title)
+
+        self.message = _wrapping_label(message)
+        msg_row = QHBoxLayout()
+        msg_row.addStretch()
+        msg_row.addWidget(self.message)
+        msg_row.addStretch()
+        layout.addLayout(msg_row)
+
+        self.btn_row = QHBoxLayout()
+        self.btn_row.setContentsMargins(0, 8, 0, 0)
+        self.btn_row.setSpacing(10)
+        self.btn_row.addStretch()
+        self.btn_row.addStretch()
+        layout.addLayout(self.btn_row)
+
+        layout.addStretch()
+
+    def add_action(self, text: str, callback, primary: bool = False) -> QPushButton:
+        btn = QPushButton(text)
+        if primary:
+            btn.setObjectName("primary")
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.setMinimumHeight(34)
+        btn.clicked.connect(callback)
+        self.btn_row.insertWidget(self.btn_row.count() - 1, btn)
+        return btn
+
+    def set_text(self, title: str, message: str):
+        self.title.setText(title)
+        self.message.setText(message)

--- a/gui/workflow.py
+++ b/gui/workflow.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""
+主流程定义与状态计算
+
+整个应用围绕一条固定的流程组织：
+    ① 数据导入 → ② 数据标注 → ③ 模型训练 → ④ 结果分析 → ⑤ 模型测试
+
+这里只负责「回答问题」：每一步做完了没有、能不能进、为什么不能进、下一步该干什么。
+界面（侧边栏、页头、前置条件页）读取这些结果来显示，不再各自去猜。
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from models.database import db
+
+APP_ROOT = Path(__file__).parent.parent
+
+# 步骤在 QStackedWidget 中的索引，也是流程顺序
+STEP_IMPORT = 0
+STEP_ANNOTATE = 1
+STEP_TRAIN = 2
+STEP_RESULT = 3
+STEP_TEST = 4
+
+# 辅助页面（不属于主流程）
+PAGE_SETTINGS = 5
+PAGE_ABOUT = 6
+
+# 每一步的文案。desc 是页头那一行说明——一句，不解释概念。
+WORKFLOW_STEPS: List[Dict] = [
+    {
+        'index': STEP_IMPORT,
+        'num': '1',
+        'name': '数据导入',
+        'short': '导入',
+        'desc': '导入图片、视频或已有标注。',
+    },
+    {
+        'index': STEP_ANNOTATE,
+        'num': '2',
+        'name': '数据标注',
+        'short': '标注',
+        'desc': '在图片上框出目标并指定类别。',
+    },
+    {
+        'index': STEP_TRAIN,
+        'num': '3',
+        'name': '模型训练',
+        'short': '训练',
+        'desc': '用标注好的图片训练模型。',
+    },
+    {
+        'index': STEP_RESULT,
+        'num': '4',
+        'name': '结果分析',
+        'short': '结果',
+        'desc': '查看曲线与指标，导出模型。',
+    },
+    {
+        'index': STEP_TEST,
+        'num': '5',
+        'name': '模型测试',
+        'short': '测试',
+        'desc': '用新的图片或视频检验模型。',
+    },
+]
+
+STEP_BY_INDEX = {step['index']: step for step in WORKFLOW_STEPS}
+
+# 步骤状态
+DONE = 'done'          # 这一步已经有成果
+CURRENT = 'current'    # 可以进，但还没做完
+READY = 'ready'        # 前置条件满足，可以进
+LOCKED = 'locked'      # 前置条件不满足
+
+
+def get_project_snapshot(project_id: Optional[int]) -> Dict:
+    """读取一个项目当前的进度事实（图片数、标注数、类别数、训练结果）。"""
+    snapshot = {
+        'project_id': project_id,
+        'project': None,
+        'name': '',
+        'task_type': '',
+        'image_count': 0,
+        'annotated_count': 0,
+        'class_count': 0,
+        'run_dirs': [],
+        'weights': None,
+    }
+
+    if not project_id:
+        return snapshot
+
+    project = db.get_project(project_id)
+    if not project:
+        return snapshot
+
+    snapshot['project'] = project
+    snapshot['name'] = project.get('name', '')
+    snapshot['task_type'] = project.get('type', '') or ''
+
+    raw_classes = project.get('classes') or '[]'
+    try:
+        classes = json.loads(raw_classes) if isinstance(raw_classes, str) else raw_classes
+    except (ValueError, TypeError):
+        classes = []
+    snapshot['class_count'] = len(classes) if isinstance(classes, list) else 0
+
+    images = db.get_project_images(project_id)
+    snapshot['image_count'] = len(images)
+    snapshot['annotated_count'] = sum(
+        1 for image in images if image.get('status') == 'annotated'
+    )
+
+    snapshot['run_dirs'] = find_project_runs(project_id)
+    snapshot['weights'] = find_project_weights(project_id)
+
+    return snapshot
+
+
+def find_project_runs(project_id: Optional[int]) -> List[Path]:
+    """找出这个项目的训练输出目录（runs/**/exp_<id>*，含 weights 子目录的才算）。"""
+    if not project_id:
+        return []
+
+    runs_root = APP_ROOT / "runs"
+    if not runs_root.exists():
+        return []
+
+    matches = []
+    for weights_dir in runs_root.glob("**/weights"):
+        run_dir = weights_dir.parent
+        if run_dir.name.startswith(f"exp_{project_id}"):
+            matches.append(run_dir)
+    return sorted(matches)
+
+
+def find_project_weights(project_id: Optional[int]) -> Optional[Path]:
+    """找出这个项目最新一次训练产出的 best.pt。"""
+    for run_dir in reversed(find_project_runs(project_id)):
+        best = run_dir / "weights" / "best.pt"
+        if best.exists():
+            return best
+    return None
+
+
+def compute_step_states(snapshot: Dict) -> Dict[int, str]:
+    """由项目事实推出每一步的状态。"""
+    has_project = bool(snapshot.get('project_id'))
+    images = snapshot.get('image_count', 0)
+    annotated = snapshot.get('annotated_count', 0)
+    has_model = snapshot.get('weights') is not None
+    has_runs = bool(snapshot.get('run_dirs'))
+
+    states = {}
+
+    if not has_project:
+        states[STEP_IMPORT] = CURRENT
+        for index in (STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST):
+            states[index] = LOCKED
+        return states
+
+    states[STEP_IMPORT] = DONE if images > 0 else CURRENT
+
+    if images == 0:
+        states[STEP_ANNOTATE] = LOCKED
+    elif annotated == 0:
+        states[STEP_ANNOTATE] = CURRENT
+    elif annotated < images:
+        states[STEP_ANNOTATE] = CURRENT
+    else:
+        states[STEP_ANNOTATE] = DONE
+
+    if annotated == 0:
+        states[STEP_TRAIN] = LOCKED
+    elif has_model or has_runs:
+        states[STEP_TRAIN] = DONE
+    else:
+        states[STEP_TRAIN] = CURRENT
+
+    states[STEP_RESULT] = READY if has_runs else LOCKED
+    states[STEP_TEST] = READY if has_model else LOCKED
+
+    return states
+
+
+def step_status_text(index: int, snapshot: Dict, states: Dict[int, str]) -> str:
+    """侧边栏每一步下面那行小字：用数字说明当前进展。"""
+    state = states.get(index, LOCKED)
+    images = snapshot.get('image_count', 0)
+    annotated = snapshot.get('annotated_count', 0)
+
+    if not snapshot.get('project_id'):
+        return "先创建项目" if index == STEP_IMPORT else "等待前一步"
+
+    if index == STEP_IMPORT:
+        return f"{images} 张图片" if images else "还没有图片"
+
+    if index == STEP_ANNOTATE:
+        if images == 0:
+            return "等待导入图片"
+        return f"已标注 {annotated}/{images}"
+
+    if index == STEP_TRAIN:
+        if state == LOCKED:
+            return "等待标注"
+        runs = len(snapshot.get('run_dirs', []))
+        return f"已训练 {runs} 次" if runs else "还没训练过"
+
+    if index == STEP_RESULT:
+        return "等待训练" if state == LOCKED else "可以查看"
+
+    if index == STEP_TEST:
+        return "等待模型" if state == LOCKED else "模型已就绪"
+
+    return ""
+
+
+def get_blocker(index: int, snapshot: Dict) -> Optional[Dict]:
+    """这一步能不能进？不能进就返回原因和「去哪里补」的入口。
+
+    返回 None 表示可以进；否则返回:
+        {'title', 'reason', 'action_text', 'action_index', 'bypass_text'(可选)}
+    """
+    has_project = bool(snapshot.get('project_id'))
+    images = snapshot.get('image_count', 0)
+    annotated = snapshot.get('annotated_count', 0)
+    has_model = snapshot.get('weights') is not None
+    has_runs = bool(snapshot.get('run_dirs'))
+
+    if index in (PAGE_SETTINGS, PAGE_ABOUT, STEP_IMPORT):
+        return None
+
+    if not has_project:
+        return {
+            'title': '还没有选择项目',
+            'reason': '先新建或选择一个项目。',
+            'action_text': '去数据导入',
+            'action_index': STEP_IMPORT,
+        }
+
+    if index == STEP_ANNOTATE and images == 0:
+        return {
+            'title': '项目里还没有图片',
+            'reason': '先导入图片、视频或已有标注。',
+            'action_text': '去导入图片',
+            'action_index': STEP_IMPORT,
+        }
+
+    if index == STEP_TRAIN and annotated == 0:
+        return {
+            'title': '还没有标注好的图片',
+            'reason': '至少标注一张图片再来训练。',
+            'action_text': '去标注图片',
+            'action_index': STEP_ANNOTATE,
+        }
+
+    if index == STEP_RESULT and not has_runs:
+        return {
+            'title': '还没有训练记录',
+            'reason': '完成一次训练后，结果会出现在这里。',
+            'action_text': '去训练模型',
+            'action_index': STEP_TRAIN,
+        }
+
+    if index == STEP_TEST and not has_model:
+        return {
+            'title': '还没有可用的模型',
+            'reason': '完成一次训练，或直接加载已有的权重文件（.pt）。',
+            'action_text': '去训练模型',
+            'action_index': STEP_TRAIN,
+            'bypass_text': '加载已有模型',
+        }
+
+    return None
+
+
+def get_next_action(snapshot: Dict, states: Dict[int, str], current_index: int) -> Optional[Dict]:
+    """页头右上角那个「下一步」按钮：从当前这一步出发，接下来该去哪。
+
+    原则：一页只催一个前进动作。如果这一步的动作就在页面里（比如训练页的
+    「开始训练」），页头就不再放按钮跟它抢，返回 None。
+    """
+    if not snapshot.get('project_id'):
+        return None
+
+    images = snapshot.get('image_count', 0)
+    annotated = snapshot.get('annotated_count', 0)
+    has_runs = bool(snapshot.get('run_dirs'))
+    has_model = snapshot.get('weights') is not None
+
+    # 前置条件还没满足时，先把人送回该补的那一步
+    if images == 0:
+        target = STEP_IMPORT
+    elif annotated == 0:
+        target = STEP_ANNOTATE
+    elif current_index == STEP_IMPORT:
+        target = STEP_ANNOTATE if annotated < images else STEP_TRAIN
+    elif current_index == STEP_ANNOTATE:
+        target = STEP_TRAIN
+    elif current_index == STEP_TRAIN:
+        # 还没训练过：动作是页面里的「开始训练」，页头不插手
+        target = STEP_RESULT if has_runs else None
+    elif current_index == STEP_RESULT:
+        target = STEP_TEST if has_model else None
+    else:
+        # 测试页是最后一步；设置/关于不属于主流程
+        target = None
+
+    if target is None or target == current_index:
+        return None
+
+    step = STEP_BY_INDEX[target]
+    return {'text': f"下一步：{step['name']}", 'index': target}

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from PyQt6.QtCore import Qt, qInstallMessageHandler, QtMsgType
 from PyQt6.QtGui import QIcon
 
 from gui.main_window import MainWindow
+from gui.styles import get_primary_font_family
 
 
 def qt_message_handler(msg_type, context, message):
@@ -48,7 +49,15 @@ def main():
     app = QApplication(sys.argv)
     app.setApplicationName("EzYOLO")
     app.setApplicationVersion("1.0.0")
-    
+
+    # 按当前系统真实存在的字体设置界面字体：
+    # macOS/Linux 上不会再去请求 Windows 才有的 "Microsoft YaHei"，字体缺失警告随之消失
+    font_family = get_primary_font_family()
+    if font_family:
+        app_font = app.font()
+        app_font.setFamily(font_family)
+        app.setFont(app_font)
+
     # 设置应用图标（使用相对路径）
     icon_path = app_root / "icon.png"
     if icon_path.exists():

--- a/models/database.py
+++ b/models/database.py
@@ -4,6 +4,7 @@
 使用SQLite作为本地数据库
 """
 
+import os
 import sqlite3
 import json
 from datetime import datetime
@@ -764,119 +765,131 @@ class Database:
                 jobs.append(job)
             return jobs
 
-    def sync_files_with_database(self) -> Dict:
-        """同步数据库与真实文件
-        
-        清理数据库中不存在的真实文件，确保数据库记录与实际文件一致
-        
+    def sync_files_with_database(self, projects_dir: str = None) -> Dict:
+        """扫描数据库与 projects/ 目录之间的差异
+
+        只读扫描，绝不删除任何数据库记录或磁盘文件。第一阶段的数据保护要求
+        任何不一致都必须交给用户查看后再决定，而不是自动清理。
+
+        Args:
+            projects_dir: 仅供测试使用，指定要扫描的 projects 目录；
+                默认为软件所在目录下的 projects/。
+
         Returns:
-            Dict: 同步结果，包含删除的文件数量等信息
+            Dict: 扫描结果。deleted_db_count/deleted_file_count/total_deleted
+                为兼容旧字段，永远为 0；orphan_db_count/orphan_disk_count/issues
+                描述发现的不一致，供 UI 提示用户。
         """
-        import os
-        import shutil
-        
-        deleted_db_count = 0
-        deleted_file_count = 0
-        deleted_db_files = []
-        deleted_actual_files = []
-        
-        # 获取所有图像记录
-        images = self.get_all_images()
-        
-        # 构建数据库中存在的文件路径集合
+        def _normalize(raw_path: str) -> str:
+            return str(Path(raw_path).expanduser().resolve(strict=False))
+
+        issues = []
+
+        orphan_db_count = 0
         db_files = set()
+        try:
+            images = self.get_all_images()
+        except Exception as exc:
+            images = []
+            issues.append({'type': 'scan_error', 'detail': str(exc)})
+
         for image in images:
             storage_path = image.get('storage_path')
-            if storage_path:
-                db_files.add(storage_path)
-        
-        # 第一部分：清理数据库中不存在的文件记录
-        for image in images:
-            storage_path = image.get('storage_path')
-            if storage_path:
-                # 检查文件是否存在
-                if not os.path.exists(storage_path):
-                    # 文件不存在，删除数据库记录
-                    image_id = image.get('id')
-                    if image_id:
-                        try:
-                            # 删除相关标注
-                            self.delete_image_annotations(image_id)
-                            # 删除图像记录
-                            with self.get_connection() as conn:
-                                cursor = conn.cursor()
-                                cursor.execute("DELETE FROM images WHERE id = ?", (image_id,))
-                            deleted_db_count += 1
-                            deleted_db_files.append(storage_path)
-                        except Exception:
-                            pass  # 忽略删除失败的情况
-        
-        # 第二部分：清理文件夹中不存在于数据库的文件
-        # 获取所有项目目录
-        import glob
-        from pathlib import Path
-        
-        # 查找所有projects目录下的文件夹
-        projects_dir = Path(__file__).parent.parent / "projects"
-        if projects_dir.exists():
-            # 获取数据库中存在的项目列表
+            if not storage_path:
+                continue
+            try:
+                normalized_image_path = _normalize(storage_path)
+            except Exception as exc:
+                issues.append({'type': 'scan_error', 'detail': str(exc), 'path': storage_path})
+                continue
+            db_files.add(normalized_image_path)
+            try:
+                exists = os.path.exists(storage_path)
+            except Exception as exc:
+                issues.append({'type': 'scan_error', 'detail': str(exc), 'path': storage_path})
+                continue
+            if not exists:
+                orphan_db_count += 1
+                issues.append({
+                    'type': 'missing_file',
+                    'image_id': image.get('id'),
+                    'project_id': image.get('project_id'),
+                    'path': storage_path,
+                })
+
+        if projects_dir is None:
+            projects_dir_path = Path(__file__).parent.parent / "projects"
+        else:
+            projects_dir_path = Path(projects_dir)
+
+        orphan_disk_count = 0
+        try:
             db_projects = self.get_all_projects()
-            db_project_ids = set()
+
+            known_project_dirs = {}
             for project in db_projects:
-                db_project_ids.add(project.get('id'))
-            
-            # 遍历所有项目文件夹
-            for project_folder in projects_dir.iterdir():
-                if project_folder.is_dir():
-                    # 检查项目文件夹是否在数据库中存在
-                    # 从文件夹名中提取项目ID（格式：project_123 或 test_20260203_142707）
-                    folder_name = project_folder.name
-                    
-                    # 检查是否为项目文件夹（包含下划线）
-                    if '_' in folder_name:
-                        # 尝试从文件夹名中提取项目ID
-                        project_exists = False
-                        
-                        # 检查是否有对应的项目ID
-                        for project in db_projects:
-                            project_name = project.get('name', '')
-                            # 如果文件夹名包含项目名，认为是对应的项目文件夹
-                            if project_name in folder_name:
-                                project_exists = True
-                                break
-                        
-                        # 如果项目不在数据库中，删除整个项目文件夹
-                        if not project_exists:
-                            try:
-                                # 记录要删除的文件数量
-                                for root, dirs, files in os.walk(project_folder):
-                                    deleted_file_count += len(files)
-                                    deleted_actual_files.extend([os.path.join(root, f) for f in files])
-                                # 删除整个文件夹
-                                shutil.rmtree(project_folder)
-                            except Exception:
-                                pass  # 忽略删除失败的情况
-                        else:
-                            # 项目存在，清理项目文件夹中不存在于数据库的文件
-                            for root, dirs, files in os.walk(project_folder):
-                                for file in files:
-                                    file_path = os.path.join(root, file)
-                                    # 检查文件是否在数据库中存在
-                                    if file_path not in db_files:
-                                        # 文件不在数据库中，删除实际文件
-                                        try:
-                                            os.remove(file_path)
-                                            deleted_file_count += 1
-                                            deleted_actual_files.append(file_path)
-                                        except Exception:
-                                            pass  # 忽略删除失败的情况
-        
+                project_storage_path = project.get('storage_path')
+                if not project_storage_path:
+                    continue
+                try:
+                    normalized_project_path = _normalize(project_storage_path)
+                except Exception as exc:
+                    issues.append({
+                        'type': 'scan_error',
+                        'detail': str(exc),
+                        'path': project_storage_path,
+                    })
+                    continue
+                known_project_dirs[normalized_project_path] = project
+
+                if not Path(normalized_project_path).exists():
+                    orphan_db_count += 1
+                    issues.append({
+                        'type': 'missing_project_dir',
+                        'project_id': project.get('id'),
+                        'path': project_storage_path,
+                    })
+
+            if projects_dir_path.exists():
+                for project_folder in projects_dir_path.iterdir():
+                    if not project_folder.is_dir():
+                        continue
+
+                    normalized_folder_path = _normalize(str(project_folder))
+                    project = known_project_dirs.get(normalized_folder_path)
+
+                    if project is None:
+                        orphan_disk_count += 1
+                        issues.append({'type': 'orphan_project_dir', 'path': str(project_folder)})
+                    else:
+                        for root, dirs, files in os.walk(project_folder):
+                            for file in files:
+                                file_path = os.path.join(root, file)
+                                try:
+                                    normalized_file_path = _normalize(file_path)
+                                except Exception as exc:
+                                    issues.append({
+                                        'type': 'scan_error',
+                                        'detail': str(exc),
+                                        'path': file_path,
+                                    })
+                                    continue
+                                if normalized_file_path not in db_files:
+                                    orphan_disk_count += 1
+                                    issues.append({'type': 'orphan_file', 'path': file_path})
+        except Exception as exc:
+            issues.append({'type': 'scan_error', 'detail': str(exc)})
+
         return {
-            'deleted_db_count': deleted_db_count,
-            'deleted_file_count': deleted_file_count,
-            'deleted_db_files': deleted_db_files,
-            'deleted_actual_files': deleted_actual_files,
-            'total_deleted': deleted_db_count + deleted_file_count
+            'deleted_db_count': 0,
+            'deleted_file_count': 0,
+            'deleted_db_files': [],
+            'deleted_actual_files': [],
+            'total_deleted': 0,
+            'orphan_db_count': orphan_db_count,
+            'orphan_disk_count': orphan_disk_count,
+            'issues': issues,
+            'has_issues': bool(issues),
         }
 
 

--- a/tests/_bootstrap.py
+++ b/tests/_bootstrap.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""测试沙箱：在 import 任何 gui.* 之前，把会碰真实数据的东西全部换掉。
+
+每个测试文件的第一行都是 `import _bootstrap`。顺序是硬要求：
+页面模块在 import 时就把 `db` 和 `QSettings` 绑到自己的模块名字上，晚了就换不掉。
+
+挡住三样东西：
+  QSettings   → 临时目录里的 ini 文件，不碰用户真实设置
+  数据库      → 临时 .db，不碰 data/EzYOLO.db
+  启动期同步  → 只替换临时数据库实例，避免测试扫描真实 projects/ 目录
+
+QSettings 为什么要换掉整个类，而不是 setDefaultFormat + setPath：
+macOS 上 NativeFormat 走的是 CFPreferences（cfprefsd），既不认 setPath，也不认
+$HOME——QSettings.fileName() 会报一个临时路径，实际却仍然写进用户真实的
+~/Library/Preferences/com.ezyolo.Settings.plist。只有强制 IniFormat + 显式文件路径
+才真的隔离得掉。
+"""
+
+import os
+import json
+import sqlite3
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+APP_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(APP_ROOT))
+
+SETTINGS_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-settings-"))
+
+import PyQt6.QtCore as _qtcore  # noqa: E402
+
+_RealQSettings = _qtcore.QSettings
+
+
+class _TempQSettings(_RealQSettings):
+    """把 QSettings("EzYOLO", "X") 重定向到 <tmp>/EzYOLO-X.ini。"""
+
+    def __init__(self, *args, **kwargs):
+        name = "-".join(a for a in args if isinstance(a, str)) or "default"
+        super().__init__(
+            str(SETTINGS_DIR / f"{name}.ini"),
+            _RealQSettings.Format.IniFormat,
+        )
+
+
+_qtcore.QSettings = _TempQSettings
+
+# --- 数据库：必须在 gui.* 被 import 之前换掉 ---
+from models.database import Database  # noqa: E402
+import models.database as database_module  # noqa: E402
+
+_tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+_tmp_db.close()
+DB_PATH = _tmp_db.name
+database_module.db = Database(db_path=DB_PATH)
+
+# 真实实现现在是只读扫描，但界面测试仍不应读取真实 projects/。只替换这个
+# 临时实例，不能修改 Database 类本身，否则同一 pytest 进程中的安全测试会被污染。
+database_module.db.sync_files_with_database = lambda projects_dir=None: {
+    'deleted_db_count': 0,
+    'deleted_file_count': 0,
+    'total_deleted': 0,
+    'orphan_db_count': 0,
+    'orphan_disk_count': 0,
+    'issues': [],
+    'has_issues': False,
+}
+
+db = database_module.db
+
+# 测试项目必须连目录也落在临时区。Database.create_project() 的存储目录固定指向
+# APP_ROOT/projects，即使数据库本身是临时的也会在真实项目区留下文件；测试被中止时
+# atexit 来不及清理。统一从这里直写临时 DB，并把 storage_path 放进 /tmp。
+TEMP_PROJECTS_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-test-projects-"))
+
+
+def create_temp_project(name="测试项目", project_type="detect", classes=None):
+    storage = TEMP_PROJECTS_DIR / f"project-{uuid.uuid4().hex}"
+    storage.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO projects (name, description, type, classes, storage_path) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (name, "", project_type, json.dumps(classes or [], ensure_ascii=False), str(storage)),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+# Database.create_project 总会在 APP_ROOT/projects 下 mkdir 一个真目录——临时数据库
+# 拦不住它（路径是按 models/../projects 硬算的）。所以记下开跑前已有的目录，
+# 退出时把测试新建的那些删掉，仓库里不留垃圾。只动「本进程新出现的」目录。
+_PROJECTS_DIR = APP_ROOT / "projects"
+_PREEXISTING_PROJECTS = (
+    {p.name for p in _PROJECTS_DIR.iterdir()} if _PROJECTS_DIR.exists() else set()
+)
+
+
+def _cleanup_test_projects():
+    import shutil
+    shutil.rmtree(TEMP_PROJECTS_DIR, ignore_errors=True)
+    if not _PROJECTS_DIR.exists():
+        return
+    for entry in _PROJECTS_DIR.iterdir():
+        if entry.is_dir() and entry.name not in _PREEXISTING_PROJECTS:
+            shutil.rmtree(entry, ignore_errors=True)
+
+
+import atexit  # noqa: E402
+atexit.register(_cleanup_test_projects)
+
+
+def app():
+    """拿到（必要时创建）离屏 QApplication。"""
+    from PyQt6.QtWidgets import QApplication
+    return QApplication.instance() or QApplication([])
+
+
+def run_module_tests(namespace) -> int:
+    """支持 `python tests/test_xxx.py` 直接跑，不依赖 pytest。"""
+    failures = 0
+    for name, func in sorted(namespace.items()):
+        if name.startswith("test_") and callable(func):
+            try:
+                func()
+                print(f"PASS {name}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"FAIL {name}: {exc!r}")
+    print(f"\n{'all passed' if not failures else f'{failures} failed'}")
+    return 1 if failures else 0

--- a/tests/test_annotate_gestures.py
+++ b/tests/test_annotate_gestures.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""标注画布的 wheel / 原生手势 / PinchGesture 入口。
+
+    python tests/test_annotate_gestures.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+
+from PyQt6.QtCore import QPoint, QPointF, Qt  # noqa: E402
+from PyQt6.QtGui import (  # noqa: E402
+    QColor, QNativeGestureEvent, QPointingDevice, QPixmap, QWheelEvent,
+)
+from PyQt6.QtWidgets import QApplication, QGestureEvent, QPinchGesture  # noqa: E402
+
+from gui.pages.annotate_page import AnnotationCanvas  # noqa: E402
+
+_app = _bootstrap.app()
+
+
+def _settle():
+    for _ in range(2):
+        _app.processEvents()
+
+
+def _canvas(with_image=True):
+    canvas = AnnotationCanvas()
+    canvas.resize(420, 320)
+    canvas.show()
+    _settle()
+    if with_image:
+        image = QPixmap(800, 600)
+        image.fill(QColor(120, 120, 130))
+        canvas.current_image = image
+        canvas.image_scale = 1.0
+        canvas.image_offset = QPoint(20, 15)
+    return canvas
+
+
+def _wheel_event(canvas, angle_delta=0, pixel_delta=0, local=QPoint(100, 80)):
+    position = QPointF(local)
+    global_position = QPointF(canvas.mapToGlobal(local))
+    return QWheelEvent(
+        position,
+        global_position,
+        QPoint(0, pixel_delta),
+        QPoint(0, angle_delta),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+
+
+def _native_event(canvas, gesture_type, value=0.0, local=QPoint(100, 80)):
+    position = QPointF(local)
+    global_position = QPointF(canvas.mapToGlobal(local))
+    return QNativeGestureEvent(
+        gesture_type,
+        QPointingDevice.primaryPointingDevice(),
+        0,
+        position,
+        position,
+        global_position,
+        value,
+        QPointF(),
+        1,
+    )
+
+
+def _pinch_event(canvas, scale_factor, local=QPoint(100, 80)):
+    pinch = QPinchGesture()
+    pinch.setScaleFactor(scale_factor)
+    pinch.setCenterPoint(QPointF(canvas.mapToGlobal(local)))
+    return QGestureEvent([pinch]), pinch
+
+
+def _send_pinch(canvas, event):
+    """macOS 运行时不 grab PinchGesture；合成事件直接交给覆盖的 event。"""
+    if canvas.pinch_gesture_registered:
+        return QApplication.sendEvent(canvas, event)
+    return canvas.event(event)
+
+
+def _image_point(canvas, local):
+    return canvas.widget_to_image(local.x(), local.y())
+
+
+def test_wheel_angle_pixel_and_zero_delta_use_one_zoom_path():
+    canvas = _canvas()
+    local = QPoint(100, 80)
+    before = _image_point(canvas, local)
+
+    angle = _wheel_event(canvas, angle_delta=120, pixel_delta=-12, local=local)
+    assert QApplication.sendEvent(canvas, angle)
+    assert angle.isAccepted()
+    assert canvas.image_scale == 1.1, "angleDelta 应优先于相反方向的 pixelDelta"
+    after = _image_point(canvas, local)
+    assert abs(after[0] - before[0]) <= 1 and abs(after[1] - before[1]) <= 1
+
+    pixel = _wheel_event(canvas, pixel_delta=-12, local=local)
+    assert QApplication.sendEvent(canvas, pixel)
+    assert pixel.isAccepted()
+    assert canvas.image_scale < 1.1, "angleDelta 为零时 pixelDelta 负方向没有缩小"
+
+    before_zero = (canvas.image_scale, QPoint(canvas.image_offset))
+    zero = _wheel_event(canvas, local=local)
+    assert QApplication.sendEvent(canvas, zero)
+    assert zero.isAccepted()
+    assert (canvas.image_scale, canvas.image_offset) == before_zero, "零 delta 不该改视图"
+    canvas.close()
+
+
+def test_native_zoom_begin_end_and_other_types_have_the_expected_handling():
+    canvas = _canvas()
+    local = QPoint(130, 90)
+    before = _image_point(canvas, local)
+
+    zoom_in = _native_event(canvas, Qt.NativeGestureType.ZoomNativeGesture, 0.25, local)
+    zoom_in.ignore()
+    assert QApplication.sendEvent(canvas, zoom_in)
+    assert zoom_in.isAccepted()
+    assert canvas.image_scale == 1.25
+    after = _image_point(canvas, local)
+    assert abs(after[0] - before[0]) <= 1 and abs(after[1] - before[1]) <= 1
+
+    scale_after_zoom = canvas.image_scale
+    zoom_out = _native_event(canvas, Qt.NativeGestureType.ZoomNativeGesture, -0.2, local)
+    zoom_out.ignore()
+    assert QApplication.sendEvent(canvas, zoom_out)
+    assert zoom_out.isAccepted()
+    assert canvas.image_scale < scale_after_zoom
+
+    before_boundary = (canvas.image_scale, QPoint(canvas.image_offset))
+    for gesture_type in (
+        Qt.NativeGestureType.BeginNativeGesture,
+        Qt.NativeGestureType.EndNativeGesture,
+    ):
+        boundary = _native_event(canvas, gesture_type, local=local)
+        boundary.ignore()
+        assert QApplication.sendEvent(canvas, boundary)
+        assert boundary.isAccepted()
+        assert (canvas.image_scale, canvas.image_offset) == before_boundary
+
+    other = _native_event(canvas, Qt.NativeGestureType.PanNativeGesture, local=local)
+    other.ignore()
+    assert not QApplication.sendEvent(canvas, other), "非缩放 NativeGesture 不该由画布吞掉"
+    assert not other.isAccepted(), "非缩放 NativeGesture 应交给 Qt 父类处理"
+    canvas.close()
+
+
+def test_pinch_gesture_uses_global_center_as_a_canvas_anchor():
+    canvas = _canvas()
+    local = QPoint(160, 100)
+    before = _image_point(canvas, local)
+
+    event, pinch = _pinch_event(canvas, 1.2, local)
+    event.ignore()
+    assert _send_pinch(canvas, event)
+    assert event.isAccepted(pinch)
+    assert canvas.image_scale == 1.2
+    after = _image_point(canvas, local)
+    assert abs(after[0] - before[0]) <= 1 and abs(after[1] - before[1]) <= 1
+
+    outside_event, outside_pinch = _pinch_event(canvas, 1.1, QPoint(-20, -20))
+    outside_event.ignore()
+    before_center = _image_point(canvas, canvas.rect().center())
+    assert _send_pinch(canvas, outside_event)
+    assert outside_event.isAccepted(outside_pinch)
+    after_center = _image_point(canvas, canvas.rect().center())
+    assert abs(after_center[0] - before_center[0]) <= 1
+    assert abs(after_center[1] - before_center[1]) <= 1
+    canvas.close()
+
+
+def test_no_image_events_are_accepted_without_changing_view():
+    canvas = _canvas(with_image=False)
+    wheel = _wheel_event(canvas, pixel_delta=12)
+    native = _native_event(canvas, Qt.NativeGestureType.ZoomNativeGesture, 0.2)
+    pinch_event, pinch = _pinch_event(canvas, 1.2)
+    native.ignore()
+    pinch_event.ignore()
+
+    assert QApplication.sendEvent(canvas, wheel) and wheel.isAccepted()
+    assert QApplication.sendEvent(canvas, native) and native.isAccepted()
+    assert _send_pinch(canvas, pinch_event) and pinch_event.isAccepted(pinch)
+    assert canvas.image_scale == 1.0
+    assert canvas.image_offset == QPoint(0, 0)
+    canvas.close()
+
+
+def test_pinch_registration_matches_the_platform_without_double_zoom_on_macos():
+    canvas = _canvas()
+    accepts_touch = canvas.testAttribute(Qt.WidgetAttribute.WA_AcceptTouchEvents)
+    if sys.platform == 'darwin':
+        assert not canvas.pinch_gesture_registered
+        assert not accepts_touch, "macOS 不应注册 Qt PinchGesture，以免与 NativeGesture 双缩放"
+    else:
+        assert canvas.pinch_gesture_registered
+        assert accepts_touch
+    canvas.close()
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_annotate_topbar_layout.py
+++ b/tests/test_annotate_topbar_layout.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""标注页顶栏：图片、工具和标注方式在同一值行内对齐。
+
+    python tests/test_annotate_topbar_layout.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import tempfile
+from pathlib import Path
+
+from PyQt6.QtCore import QPoint  # noqa: E402
+from PyQt6.QtGui import QColor, QImage  # noqa: E402
+from PyQt6.QtWidgets import QLabel  # noqa: E402
+
+from gui.main_window import MainWindow  # noqa: E402
+from gui.workflow import STEP_ANNOTATE  # noqa: E402
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+_IMAGE_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-topbar-"))
+SIZES = ((1100, 720), (1470, 832))
+
+
+def _settle():
+    for _ in range(3):
+        _app.processEvents()
+
+
+def _seed_project():
+    project_id = _bootstrap.create_temp_project(
+        name="顶栏布局测试项目",
+        project_type="detect",
+        classes=[{'id': 0, 'name': '猫', 'color': '#FF3B30'}],
+    )
+    filename = "这一张图片的文件名特别特别特别长但工具栏不能被它推走.jpg"
+    image_path = _IMAGE_DIR / filename
+    image = QImage(320, 240, QImage.Format.Format_RGB888)
+    image.fill(QColor(120, 120, 130))
+    image.save(str(image_path))
+    db.add_image(project_id, filename, str(image_path), width=320, height=240)
+    return project_id
+
+
+def _open_page(width, height):
+    project_id = _seed_project()
+    from gui import main_window as main_window_module
+    main_window_module.db = db
+
+    window = MainWindow()
+    window.load_projects(select_id=project_id)
+    window.resize(width, height)
+    window.show()
+    window.switch_page(STEP_ANNOTATE)
+    _settle()
+    page = window.annotate_page
+    page._set_image_list_collapsed(False)
+    page.image_list.setCurrentRow(0)
+    page.on_image_selected(page.image_list.item(0))
+    _settle()
+    return window, page, project_id
+
+
+def _close(window, project_id):
+    window.close()
+    db.delete_project(project_id)
+
+
+def _assert_values_share_a_row_without_overlap(page, size):
+    values = (page.image_name_label, page.toolbar, page.task_combo)
+    y_positions = {widget.y() for widget in values}
+    assert len(y_positions) == 1, f"[{size}] 顶栏值行没有对齐：{[(w.objectName(), w.y()) for w in values]}"
+
+    left_to_right = sorted(values, key=lambda widget: widget.x())
+    for left, right in zip(left_to_right, left_to_right[1:]):
+        assert left.geometry().right() < right.geometry().left(), (
+            f"[{size}] 顶栏值重叠：{left.geometry()} 与 {right.geometry()}"
+        )
+
+    for caption in page.context_bar.findChildren(QLabel):
+        if caption.objectName() == "caption":
+            assert caption.width() >= caption.fontMetrics().horizontalAdvance(caption.text()), (
+                f"[{size}] 顶栏说明被裁字：{caption.text()}"
+            )
+
+
+def _assert_visible_toolbar_text_fits(page, size, task_type):
+    visible = [button for button in page.toolbar_buttons if button.isVisible()]
+    assert len(visible) >= 3, f"[{size}/{task_type}] 工具栏少了基础操作"
+    assert len({button.y() for button in visible}) == 1, (
+        f"[{size}/{task_type}] 工具按钮没有同一行：{[(b.text(), b.y()) for b in visible]}"
+    )
+    for button in visible:
+        assert button.width() >= button.minimumSizeHint().width(), (
+            f"[{size}/{task_type}] 工具按钮被裁字：{button.text()}"
+        )
+
+
+def test_topbar_owns_the_toolbar_and_keeps_values_aligned_at_supported_sizes():
+    for size in SIZES:
+        window, page, project_id = _open_page(*size)
+        try:
+            captions = [
+                label.text() for label in page.context_bar.findChildren(QLabel)
+                if label.objectName() == "caption"
+            ]
+            assert captions == ["当前图片", "工具", "标注方式"], f"[{size}] 顶栏说明不对：{captions}"
+            assert page.toolbar.parentWidget() is page.context_bar
+            assert not page.center_panel.isAncestorOf(page.toolbar)
+            assert page.context_bar.height() < 73, (
+                f"[{size}] 顶栏还有旧布局的高度：{page.context_bar.height()}px"
+            )
+            canvas_top = page.canvas.mapTo(page.center_panel, QPoint(0, 0)).y()
+            assert canvas_top <= 10, f"[{size}] 画布顶部还有工具栏占位：{canvas_top}px"
+
+            _assert_values_share_a_row_without_overlap(page, size)
+            assert page.image_name_label.width() <= 320
+            long_image_name = page.images[0]['filename']
+            assert page.image_name_label.text() != page.image_name_label.property('_full_text'), (
+                f"[{size}] 长文件名应该省略显示"
+            )
+            assert page.image_name_label.toolTip().splitlines()[0] == long_image_name, (
+                f"[{size}] 长文件名的完整 tooltip 丢失"
+            )
+            assert page.toolbar.geometry().right() < page.task_combo.geometry().left(), (
+                f"[{size}] 长图片名把工具或标注方式挤重叠了"
+            )
+
+            if size[0] == 1100:
+                common_summary = "第 600/600 张 · 帧 81800 · 已标注"
+                page._set_elided_text(page.image_name_label, common_summary)
+                _settle()
+                assert page.image_name_label.width() >= page.image_name_label.fontMetrics().horizontalAdvance(
+                    common_summary
+                ), f"[{size}] 常见图片摘要被无必要省略：{page.image_name_label.width()}px"
+                assert page.image_name_label.text() == common_summary
+
+            for collapsed in (False, True):
+                if collapsed:
+                    page.btn_collapse_image_list.click()
+                    _settle()
+                    assert page.btn_expand_image_list.parentWidget() is page.toolbar
+                    assert page.btn_expand_image_list.isVisible(), f"[{size}] 收起后顶栏没有展开入口"
+                else:
+                    assert page.left_panel.isVisible(), f"[{size}] 图片栏初始状态不该收起"
+
+                for task_type in ("detect", "segment", "pose", "classify"):
+                    page.task_combo.setCurrentText(task_type)
+                    _settle()
+                    _assert_values_share_a_row_without_overlap(page, size)
+                    _assert_visible_toolbar_text_fits(page, size, task_type)
+
+                if collapsed:
+                    page.btn_expand_image_list.click()
+                    _settle()
+                    assert page.left_panel.isVisible(), f"[{size}] 顶栏展开入口没有恢复图片栏"
+        finally:
+            _close(window, project_id)
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_annotate_view_state.py
+++ b/tests/test_annotate_view_state.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+"""标注页的响应式状态：信息栏 / 翻页按钮 / 图片栏 / 类别按钮 / 画布视图锁。
+
+这些断言都只检查用户能直接看到或操作到的结果：
+  顶部 / 底部  —— 顶部只留图片、工具和标注方式，状态完整沉到底部
+  翻页按钮      —— 上一张和下一张同尺寸，不裁字
+  收起图片栏  —— 让出来的宽度必须真的给到画布，展开要能还回去
+  等宽按钮    —— 「添加类别」和「改为选中类别」同排，1:1，不许一个宽一个窄
+  视图锁      —— 锁上之后切图保持缩放和位置，没锁就照旧适配窗口
+
+    python tests/test_annotate_view_state.py
+    python -m pytest tests/test_annotate_view_state.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import tempfile
+from pathlib import Path
+
+from PyQt6.QtCore import QPoint, Qt  # noqa: E402
+from PyQt6.QtGui import QImage, QColor  # noqa: E402
+from PyQt6.QtWidgets import QProgressBar, QSizePolicy  # noqa: E402
+
+from gui.workflow import STEP_ANNOTATE  # noqa: E402
+from gui.main_window import MainWindow  # noqa: E402
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+_IMAGE_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-viewstate-"))
+
+# 两张同尺寸 + 一张尺寸差得离谱的，用来分别验证「保持」和「不跑出画布」
+IMAGE_SIZES = [(320, 240), (320, 240), (4000, 300)]
+
+
+def seed_project() -> int:
+    project_id = _bootstrap.create_temp_project(
+        name="视图状态测试项目",
+        project_type="detect",
+        classes=[
+            {'id': 0, 'name': '猫', 'color': '#FF3B30'},
+            {'id': 1, 'name': '用于验证省略提示的超长类别名称', 'color': '#007AFF'},
+        ],
+    )
+    for index, (width, height) in enumerate(IMAGE_SIZES):
+        path = _IMAGE_DIR / f"view{index}.jpg"
+        image = QImage(width, height, QImage.Format.Format_RGB888)
+        image.fill(QColor(120, 120, 130))
+        image.save(str(path))
+        db.add_image(project_id, path.name, str(path), width=width, height=height)
+    return project_id
+
+
+def open_annotate_page():
+    """打开一个装着三张图的标注页。"""
+    project_id = seed_project()
+    from gui import main_window as mw
+    mw.db = db
+
+    window = MainWindow()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    window.switch_page(STEP_ANNOTATE)
+    settle()
+
+    return window, project_id
+
+
+def settle():
+    for _ in range(3):
+        _app.processEvents()
+
+
+def close(window, project_id):
+    window.close()
+    db.delete_project(project_id)
+
+
+def select_image(page, index: int):
+    page.image_list.setCurrentRow(index)
+    page.on_image_selected(page.image_list.item(index))
+    settle()
+
+
+# ---------- 图片栏收起 ----------
+
+def test_collapsing_image_list_gives_the_width_to_the_canvas():
+    """收起：左栏藏起来，宽度进了中栏；展开：三栏宽度回到原样。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+
+    before = page.splitter.sizes()
+    center_before = page.center_panel.width()
+
+    page.btn_collapse_image_list.click()
+    settle()
+
+    assert not page.left_panel.isVisible(), "收起后左侧图片栏还在占位"
+    assert page.btn_expand_image_list.isVisible(), "收起后工具栏上没有展开入口"
+    assert page.center_panel.width() > center_before, (
+        f"左栏让出的宽度没给到画布：{center_before} -> {page.center_panel.width()}"
+    )
+
+    page.btn_expand_image_list.click()
+    settle()
+
+    assert page.left_panel.isVisible()
+    assert not page.btn_expand_image_list.isVisible()
+    after = page.splitter.sizes()
+    # 窗口约束下允许几个像素的出入，但不能整栏跑偏
+    assert all(abs(a - b) <= 4 for a, b in zip(after, before)), \
+        f"展开后三栏宽度没还回去：{before} -> {after}"
+
+    close(window, project_id)
+
+
+def test_collapsed_state_is_persisted():
+    """收起状态写进 QSettings，下次进来还是收着的。"""
+    from PyQt6.QtCore import QSettings
+
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+
+    page.btn_collapse_image_list.click()
+    settle()
+
+    settings = QSettings("EzYOLO", "Settings")
+    assert str(settings.value("annotate_image_list_collapsed")).lower() in ('true', '1')
+
+    page.btn_expand_image_list.click()
+    settle()
+    assert str(settings.value("annotate_image_list_collapsed")).lower() in ('false', '0')
+
+    close(window, project_id)
+
+
+# ---------- 类别区两个按钮 ----------
+
+def test_class_buttons_are_exactly_equal_width():
+    """「添加类别」和「改为选中类别」同排等宽，1100 宽窗口下都不切字。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+
+    add = page.btn_add_class
+    apply_ = page.btn_apply_attr
+
+    assert abs(add.width() - apply_.width()) <= 1, \
+        f"两个按钮不等宽：添加类别 {add.width()} vs 改为选中类别 {apply_.width()}"
+    assert add.y() == apply_.y(), "两个按钮不在同一排"
+
+    for button in (add, apply_):
+        needed = button.fontMetrics().horizontalAdvance(button.text())
+        assert button.width() >= needed, \
+            f"{button.text()} 被切字：需要 {needed}px，只有 {button.width()}px"
+
+    close(window, project_id)
+
+
+# ---------- 顶部 / 底部信息 ----------
+
+def test_context_bar_keeps_image_tools_and_annotation_mode():
+    """顶部不再有进度和类别，图片、工具和标注方式各有固定职责。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+
+    captions = [
+        label.text() for label in page.context_bar.findChildren(type(page.image_name_label))
+        if label.objectName() == "caption"
+    ]
+    assert captions == ["当前图片", "工具", "标注方式"], f"顶部列不对：{captions}"
+    assert not page.context_bar.findChildren(QProgressBar), "顶部不该再有标注进度条"
+    assert page.image_name_label.sizePolicy().horizontalPolicy() == QSizePolicy.Policy.Preferred
+    assert page.image_name_label.minimumWidth() >= 180
+    assert page.image_name_label.maximumWidth() <= 320
+
+    close(window, project_id)
+
+
+def test_status_bar_shows_and_refreshes_progress_category_and_batch_state():
+    """底栏实时显示位置、标注进度、类别、本图标注、工具和批处理状态。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+
+    select_image(page, 0)
+    assert page.status_image.text() == "当前: 1/3"
+    assert page.status_progress.text() == "标注: 0/3"
+    assert page.status_annotation.text() == "本图标注: 0"
+    assert page.status_tool.text() == "工具: 矩形"
+    assert page.current_class_chip.text().startswith("类别: ■ "), "当前类别缺少文字和颜色方块线索"
+    assert page.btn_shortcut_help.isVisible(), "状态栏缺少快捷键入口"
+    for label in (
+        page.status_image,
+        page.status_progress,
+        page.status_annotation,
+        page.status_tool,
+    ):
+        assert label.width() >= label.fontMetrics().horizontalAdvance(label.text()), (
+            f"1100px 宽度下状态栏文字被裁切：{label.text()}"
+        )
+
+    page.images[0]['status'] = 'annotated'
+    page.update_status_bar()
+    assert page.status_progress.text() == "标注: 1/3", "图片标注状态变化后底栏进度没有刷新"
+
+    page.current_class_id = -1
+    page._update_current_class_chip()
+    assert page.current_class_chip.text() == "类别: 未选择"
+
+    page.class_list.setCurrentRow(1)
+    page.on_class_selected()
+    settle()
+    assert "超长类别名称" in page.current_class_chip.toolTip(), "长类别名没有完整 tooltip"
+    assert page.current_class_chip.text().startswith("类别: ■ ")
+
+    def assert_status_widgets_do_not_overlap():
+        layout = page.status_bar.layout()
+        widgets = [
+            layout.itemAt(index).widget()
+            for index in range(layout.count())
+            if layout.itemAt(index).widget() is not None
+            and layout.itemAt(index).widget().isVisible()
+        ]
+        for previous, following in zip(widgets, widgets[1:]):
+            assert previous.geometry().right() < following.geometry().left(), (
+                "状态栏控件重叠："
+                f"{previous.text()!r} {previous.geometry()} 与 "
+                f"{following.text()!r} {following.geometry()}"
+            )
+
+    assert_status_widgets_do_not_overlap()
+    window.resize(1470, 832)
+    settle()
+    assert_status_widgets_do_not_overlap()
+
+    page.on_batch_inference_progress(1, 2, 3, "正在处理的超长文件名.jpg")
+    assert page.status_batch.text().startswith("批处理: 2/3"), "批处理状态没有显示在独立底栏字段"
+    page.update_status_bar()
+    assert page.status_batch.text() == "", "常规状态刷新后批处理临时状态没有清空"
+
+    close(window, project_id)
+
+
+# ---------- 翻页按钮 ----------
+
+def test_navigation_buttons_have_equal_size_without_cutting_text():
+    """上一张和下一张保持左右位置及样式，但尺寸严格一致。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+
+    previous = page.btn_prev
+    next_ = page.btn_next
+    assert previous.size() == next_.size(), (
+        f"翻页按钮尺寸不一致：上一张 {previous.size()}，下一张 {next_.size()}"
+    )
+    assert previous.x() < next_.x(), "翻页按钮左右位置反了"
+    assert next_.objectName() == "primary", "下一张主按钮样式丢失"
+    for button in (previous, next_):
+        assert button.width() >= button.sizeHint().width(), f"{button.text()} 被切字"
+
+    close(window, project_id)
+
+
+# ---------- 画布视图锁 ----------
+
+def test_lock_button_is_hidden_without_an_image_and_sits_at_top_right():
+    """没图片时锁按钮不出现；有图片时贴着画布右上角 8px。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+    canvas = page.canvas
+
+    assert not canvas.lock_button.isVisible(), "还没选图片就冒出一把锁"
+
+    select_image(page, 0)
+    assert canvas.lock_button.isVisible()
+    assert canvas.lock_button.size().width() == 28
+    assert canvas.lock_button.size().height() == 28
+
+    def assert_geometry():
+        button = canvas.lock_button
+        assert button.y() == 8, f"锁离画布上边 {button.y()}px，应该是 8px"
+        gap = canvas.width() - (button.x() + button.width())
+        assert gap == 8, f"锁离画布右边 {gap}px，应该是 8px"
+
+    assert_geometry()
+
+    # 窗口变了，锁还得贴着右上角
+    window.resize(1360, 800)
+    settle()
+    assert_geometry()
+
+    close(window, project_id)
+
+
+def test_locked_view_keeps_scale_and_offset_across_same_sized_images():
+    """锁上之后切到同尺寸的图：缩放和位置原样保留，不再重新适配。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+    canvas = page.canvas
+
+    select_image(page, 0)
+
+    canvas.lock_button.setChecked(True)
+    settle()
+    assert canvas.view_locked
+
+    # 先手动缩放并平移，制造一个「用户调过」的视图
+    canvas.image_scale = 0.75
+    canvas.image_offset = QPoint(30, 20)
+
+    select_image(page, 1)  # 同为 320x240
+
+    assert abs(canvas.image_scale - 0.75) < 1e-6, \
+        f"锁定后切图缩放变了：{canvas.image_scale}"
+    assert abs(canvas.image_offset.x() - 30) <= 1 and abs(canvas.image_offset.y() - 20) <= 1, \
+        f"锁定后切图位置变了：{canvas.image_offset}"
+
+    close(window, project_id)
+
+
+def test_unlocked_switch_resets_the_view():
+    """没锁：切图照旧回到「适配窗口并居中」。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+    canvas = page.canvas
+
+    select_image(page, 0)
+    assert not canvas.view_locked
+
+    canvas.image_scale = 0.5
+    canvas.image_offset = QPoint(5, 5)
+
+    select_image(page, 1)
+
+    expected_scale = canvas.image_scale
+    expected_offset = QPoint(canvas.image_offset)
+    canvas.reset_view()
+    assert abs(canvas.image_scale - expected_scale) < 1e-6, "切图后没有重置视图"
+    assert canvas.image_offset == expected_offset, "切图后没有重新居中"
+
+    close(window, project_id)
+
+
+def test_locked_switch_to_a_wildly_different_size_keeps_the_image_on_canvas():
+    """锁定 + 新图尺寸差得离谱：不许抛错，也不许整张图跑出画布。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+    canvas = page.canvas
+
+    select_image(page, 0)  # 320x240
+    canvas.lock_button.setChecked(True)
+    settle()
+
+    canvas.image_scale = 2.0
+    canvas.image_offset = QPoint(-100, -60)
+
+    select_image(page, 2)  # 4000x300
+
+    scaled_width = canvas.current_image.width() * canvas.image_scale
+    scaled_height = canvas.current_image.height() * canvas.image_scale
+    left = canvas.image_offset.x()
+    top = canvas.image_offset.y()
+
+    assert left < canvas.width() and left + scaled_width > 0, \
+        f"图片横向跑出了画布：offset.x={left}, 宽 {scaled_width}, 画布 {canvas.width()}"
+    assert top < canvas.height() and top + scaled_height > 0, \
+        f"图片纵向跑出了画布：offset.y={top}, 高 {scaled_height}, 画布 {canvas.height()}"
+    assert abs(canvas.image_scale - 2.0) < 1e-6, "锁定时缩放不该被改掉"
+
+    close(window, project_id)
+
+
+def test_reset_view_shortcut_does_not_unlock():
+    """按 R 只重置当前这一张的视图，锁还是锁着的。"""
+    window, project_id = open_annotate_page()
+    page = window.annotate_page
+    canvas = page.canvas
+
+    select_image(page, 0)
+    canvas.lock_button.setChecked(True)
+    settle()
+
+    canvas.image_scale = 0.4
+    canvas.reset_view()
+
+    assert canvas.view_locked, "重置视图把锁也解开了"
+    assert canvas.lock_button.isChecked()
+
+    close(window, project_id)
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(dict(globals())))

--- a/tests/test_app_dialogs.py
+++ b/tests/test_app_dialogs.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+"""应用内弹窗 + 自动标注配置的保存反馈。
+
+覆盖的真实问题：
+    1. 删除类操作弹的是系统 QMessageBox：英文 No/Yes、一个巨大的问号图标，
+       而且默认焦点落在「Yes」上——回车一下 164 张图片就没了。
+       现在换成应用内弹窗：中文按钮、红色破坏性操作、默认焦点在「取消」、没有图标。
+    2. 自动标注配置点「保存设置」：原来不管有没有真的写进文件都直接关窗，
+       写失败时用户看到的是「点了保存，什么都没发生」，下次打开发现设置根本没存上。
+    3. 从设置页打开配置窗口，保存完应该还在设置页，并且能看见「已保存」，
+       而不是被甩到别的步骤去。
+
+运行：
+    python tests/test_app_dialogs.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from PyQt6.QtWidgets import QDialog, QLabel, QMessageBox
+
+import gui.pages.auto_label_dialog as auto_label_module
+from gui.widgets.app_dialog import AppDialog, TextInputDialog, ask_text
+from gui.pages.auto_label_dialog import AutoLabelDialog
+from gui.main_window import MainWindow
+from gui.workflow import PAGE_SETTINGS, STEP_IMPORT
+
+_app = _bootstrap.app()
+
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-app-dialogs-"))
+
+
+# ==================== 破坏性确认框 ====================
+
+def _destructive_dialog() -> AppDialog:
+    return AppDialog(
+        None, "清空图片", "当前项目里的图片会全部删除，无法恢复。",
+        detail="共 164 张图片。",
+        confirm_text="删除 164 张", cancel_text="取消", destructive=True,
+    )
+
+
+def test_destructive_dialog_speaks_chinese_and_has_no_giant_icon():
+    """按钮是中文，不是 Yes/No；框里没有那个巨大的系统问号图标。"""
+    dialog = _destructive_dialog()
+
+    assert dialog.btn_confirm.text() == "删除 164 张"
+    assert dialog.btn_cancel.text() == "取消"
+    for button in (dialog.btn_confirm, dialog.btn_cancel):
+        assert button.text() not in ("Yes", "No", "OK", "Cancel"), button.text()
+
+    assert not isinstance(dialog, QMessageBox), "不能再用系统消息框"
+    # 系统那个问号图标是一个带 pixmap 的 QLabel；我们这里所有标签都只有文字
+    for label in dialog.findChildren(QLabel):
+        pixmap = label.pixmap()
+        assert pixmap is None or pixmap.isNull(), "弹窗里不该有图标"
+
+    # 数量单独一行，用户点之前看得见到底要删多少
+    assert "164" in dialog.lbl_detail.text()
+    assert dialog.lbl_detail.isVisible() or dialog.lbl_detail.text()
+
+
+def test_destructive_dialog_defaults_to_the_safe_action():
+    """默认焦点和回车都落在「取消」上：删除不该是一个回车就发生的事。"""
+    dialog = _destructive_dialog()
+
+    assert dialog.btn_cancel.isDefault(), "默认按钮必须是取消"
+    assert not dialog.btn_confirm.isDefault(), "破坏性按钮不能是默认按钮"
+    assert dialog.btn_confirm.objectName() == "danger", "破坏性操作要用红色样式"
+
+
+def test_destructive_dialog_returns_accepted_only_when_confirmed():
+    """点确认 = Accepted，点取消 = Rejected。（不用真开模态窗，直接点按钮）"""
+    confirmed = _destructive_dialog()
+    confirmed.btn_confirm.click()
+    assert confirmed.result() == QDialog.DialogCode.Accepted
+
+    cancelled = _destructive_dialog()
+    cancelled.btn_cancel.click()
+    assert cancelled.result() == QDialog.DialogCode.Rejected
+
+
+def test_info_dialog_has_a_single_button_and_no_cancel():
+    dialog = AppDialog(None, "已删除", "删除了 12 张图片。", confirm_text="好", cancel_text=None)
+
+    assert dialog.btn_cancel is None
+    assert dialog.btn_confirm.text() == "好"
+    assert dialog.btn_confirm.isDefault()
+
+
+def test_safe_button_label_can_say_what_it_actually_does():
+    """安全按钮不一定叫「取消」：二选一时它是「另一个选项」，必须照实说。
+
+    导入标注时不覆盖，实际是「保留现有标注」并继续导入——写「取消」会让人
+    以为整件事都放弃了。这里确认两个 helper 都能自定义这个标签，
+    而且默认焦点还是落在这个安全按钮上。
+    """
+    seen = {}
+
+    class _Spy(AppDialog):
+        def exec(self):
+            seen['confirm'] = self.btn_confirm.text()
+            seen['cancel'] = self.btn_cancel.text()
+            seen['cancel_is_default'] = self.btn_cancel.isDefault()
+            return QDialog.DialogCode.Rejected
+
+    with patch("gui.widgets.app_dialog.AppDialog", _Spy):
+        from gui.widgets.app_dialog import confirm as _confirm
+        from gui.widgets.app_dialog import confirm_destructive as _confirm_destructive
+
+        assert _confirm_destructive(
+            None, "覆盖已有标注", "…", confirm_text="覆盖", cancel_text="保留现有标注",
+        ) is False
+        assert seen == {
+            'confirm': "覆盖", 'cancel': "保留现有标注", 'cancel_is_default': True,
+        }, seen
+
+        _confirm(None, "图像文件夹", "…", confirm_text="去选择", cancel_text="不用")
+        assert seen['cancel'] == "不用", seen
+
+
+# ==================== 文字输入框（新建项目） ====================
+
+def test_text_input_dialog_is_chinese_and_blocks_empty_input():
+    """替掉 QInputDialog.getText：中文按钮，名字没填时确认按钮点不动。"""
+    dialog = TextInputDialog(
+        None, "新建项目", "给项目起个名字。",
+        placeholder="比如：安全帽检测", confirm_text="创建项目",
+    )
+
+    assert dialog.btn_confirm.text() == "创建项目"
+    assert dialog.btn_cancel.text() == "取消"
+    assert not dialog.btn_confirm.isEnabled(), "还没填名字，创建按钮不该能点"
+
+    dialog.edit.setText("   ")
+    assert not dialog.btn_confirm.isEnabled(), "只有空格也算没填"
+
+    dialog.edit.setText("  安全帽检测  ")
+    assert dialog.btn_confirm.isEnabled()
+    assert dialog.value() == "安全帽检测", "首尾空格要去掉"
+
+    # 跟别的应用内弹窗一样：没有系统那个大图标
+    for label in dialog.findChildren(QLabel):
+        pixmap = label.pixmap()
+        assert pixmap is None or pixmap.isNull()
+
+
+def test_ask_text_returns_none_when_cancelled_or_blank():
+    """取消 → None；点了确认但内容是空白 → 也当成没填。"""
+    with patch.object(TextInputDialog, "exec",
+                      lambda self: QDialog.DialogCode.Rejected):
+        assert ask_text(None, "新建项目", "名字") is None
+
+    def _accept_blank(self):
+        self.edit.setText("   ")
+        return QDialog.DialogCode.Accepted
+
+    with patch.object(TextInputDialog, "exec", _accept_blank):
+        assert ask_text(None, "新建项目", "名字") is None
+
+    def _accept_name(self):
+        self.edit.setText(" 安全帽检测 ")
+        return QDialog.DialogCode.Accepted
+
+    with patch.object(TextInputDialog, "exec", _accept_name):
+        assert ask_text(None, "新建项目", "名字") == "安全帽检测"
+
+
+# ==================== 自动标注配置：保存反馈 ====================
+
+def _auto_label_dialog(tmp_name: str):
+    """建一个配置窗口，并把两份配置文件指到临时目录，不碰仓库里的 config/。"""
+    sam_path = _TMP_DIR / tmp_name / "sam_config.json"
+    llm_path = _TMP_DIR / tmp_name / "llm_config.json"
+    sam_path.parent.mkdir(parents=True, exist_ok=True)
+    return AutoLabelDialog(None), str(sam_path), str(llm_path)
+
+
+def test_save_writes_both_configs_and_closes():
+    """保存成功：两份配置都落盘，窗口关掉并返回 Accepted。"""
+    dialog, sam_path, llm_path = _auto_label_dialog("ok")
+
+    with patch.object(auto_label_module, "SAM_CONFIG_FILE", sam_path), \
+         patch.object(auto_label_module, "LLM_CONFIG_FILE", llm_path), \
+         patch.object(auto_label_module, "_sam_model_exists", lambda _f: True):
+        dialog.le_llm_api_key.setText("test-key")
+        dialog.on_save_clicked()
+
+    assert dialog.result() == QDialog.DialogCode.Accepted, "保存成功应该关窗"
+    assert json.loads(Path(sam_path).read_text())['sam_type']
+    assert json.loads(Path(llm_path).read_text())['api_key'] == "test-key"
+
+
+def test_save_failure_keeps_the_dialog_open_and_says_why():
+    """写不进去时：不能默默关窗，要留在原地并说清楚哪份配置没存上。"""
+    dialog, _sam_path, llm_path = _auto_label_dialog("fail")
+
+    # 把 SAM 配置的路径指到「一个文件底下」——目录建不出来，写必然失败
+    blocker = _TMP_DIR / "fail" / "not_a_dir"
+    blocker.write_text("我是一个文件，不是目录")
+    unwritable_sam = str(blocker / "sam_config.json")
+
+    with patch.object(auto_label_module, "SAM_CONFIG_FILE", unwritable_sam), \
+         patch.object(auto_label_module, "LLM_CONFIG_FILE", llm_path), \
+         patch.object(auto_label_module, "_sam_model_exists", lambda _f: True):
+        dialog.on_save_clicked()
+
+    assert dialog.result() != QDialog.DialogCode.Accepted, "保存失败时窗口不能关掉"
+
+    notice = dialog.lbl_notice.text()
+    assert "保存失败" in notice, notice
+    assert "SAM" in notice, notice
+
+
+def test_partial_save_says_which_one_failed_and_which_one_got_written():
+    """一份写成功、一份写失败：不能笼统说「设置没有写入」。
+
+    磁盘上此刻是半新半旧的状态，用户必须知道到底哪一份进去了，
+    否则他会以为可以放心重试或干脆放弃。
+    """
+    dialog, _sam_path, llm_path = _auto_label_dialog("partial")
+
+    # SAM 的路径指到「一个文件底下」——目录建不出来，必然写失败；LLM 正常可写
+    blocker = _TMP_DIR / "partial" / "not_a_dir"
+    blocker.write_text("我是一个文件，不是目录")
+    unwritable_sam = str(blocker / "sam_config.json")
+
+    with patch.object(auto_label_module, "SAM_CONFIG_FILE", unwritable_sam), \
+         patch.object(auto_label_module, "LLM_CONFIG_FILE", llm_path), \
+         patch.object(auto_label_module, "_sam_model_exists", lambda _f: True):
+        dialog.le_llm_api_key.setText("half-written")
+        dialog.on_save_clicked()
+
+    assert dialog.result() != QDialog.DialogCode.Accepted, "有一份没写成就不该关窗"
+
+    notice = dialog.lbl_notice.text()
+    assert "SAM 配置" in notice and "没有写入" in notice, notice
+    assert "LLM 配置 已经写入" in notice, f"写成功的那一份必须说出来: {notice!r}"
+    assert "设置没有写入" not in notice, f"不能谎称什么都没写: {notice!r}"
+
+    # 而且 LLM 那一份是真的落盘了——提示说的是事实
+    assert json.loads(Path(llm_path).read_text())['api_key'] == "half-written"
+
+
+def test_custom_model_without_a_file_is_refused_inline():
+    """选了自定义模型却没选文件：就地说明，不弹系统框，也不保存一个用不了的配置。"""
+    dialog, sam_path, llm_path = _auto_label_dialog("custom")
+
+    dialog.rbtn_custom.setChecked(True)
+    dialog.custom_model_path = ""
+
+    with patch.object(auto_label_module, "SAM_CONFIG_FILE", sam_path), \
+         patch.object(auto_label_module, "LLM_CONFIG_FILE", llm_path):
+        dialog.on_save_clicked()
+
+    assert dialog.result() != QDialog.DialogCode.Accepted
+    assert "模型文件" in dialog.lbl_notice.text(), dialog.lbl_notice.text()
+    assert not Path(sam_path).exists(), "校验没过就不该写配置"
+
+
+# ==================== 保存后回到打开它的那个页面 ====================
+
+def _window_with_stubbed_config_dialog(accepted: bool, side_effect=None):
+    """开一个主窗口，把配置窗口的 exec() 换成替身（离屏跑不能真开模态窗）。"""
+    window = MainWindow()
+    window.switch_page(PAGE_SETTINGS)
+    _app.processEvents()
+
+    page = window.annotate_page
+    page.init_auto_label_components()
+    dialog = page.auto_label_dialog
+
+    def fake_exec():
+        if side_effect:
+            side_effect(window)
+        return (QDialog.DialogCode.Accepted if accepted else QDialog.DialogCode.Rejected)
+
+    dialog.exec = fake_exec
+    return window
+
+
+def test_saving_from_settings_stays_on_settings_and_shows_it_saved():
+    """从设置页打开配置、点保存 → 还留在设置页，并且底部明确说「已保存」。"""
+    window = _window_with_stubbed_config_dialog(accepted=True)
+
+    window.settings_page.btn_config_sam.click()
+    _app.processEvents()
+
+    assert window.current_index == PAGE_SETTINGS, "保存后不该跳到别的步骤"
+    assert window.content_stack.currentIndex() == PAGE_SETTINGS
+
+    status = window.settings_page.status_label.text()
+    assert "已保存" in status, f"保存完什么都不说，跟没保存一样：{status!r}"
+
+
+def test_cancelling_from_settings_says_nothing_was_changed():
+    """点取消：也留在设置页，但不能谎称「已保存」。"""
+    window = _window_with_stubbed_config_dialog(accepted=False)
+
+    window.settings_page.btn_config_llm.click()
+    _app.processEvents()
+
+    assert window.current_index == PAGE_SETTINGS
+    status = window.settings_page.status_label.text()
+    assert "已保存" not in status, f"没保存却说保存了：{status!r}"
+    assert "没有改动" in status, status
+
+
+def test_a_page_jump_during_config_is_undone_on_close():
+    """配置窗口开着时页面被换走（比如跳去第 1 步数据导入），关窗后必须回到设置页。
+
+    用户抱怨的就是这个：在设置页点保存，回来人却站在「数据导入」上。
+    """
+    def jump_to_import(window):
+        window.switch_page(STEP_IMPORT)
+
+    window = _window_with_stubbed_config_dialog(accepted=True, side_effect=jump_to_import)
+
+    window.settings_page.btn_open_auto_label.click()
+    _app.processEvents()
+
+    assert window.current_index == PAGE_SETTINGS, "关窗后应该回到打开它的设置页"
+    assert window.content_stack.currentIndex() == PAGE_SETTINGS
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(dict(globals())))

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""批处理弹窗的清理契约。
+
+BatchProcessDialog 是非模态的：用户一边在画布上点像素点，一边在弹窗里设置。
+只要弹窗没了，画布就必须退出点选模式——否则用户每点一下还在继续加点，而且是
+加给一个已经关掉的对话框。
+
+三条退出路径都必须走同一个幂等 helper：
+    确认执行(process_requested) / 取消(reject) / 直接关窗(close)
+
+运行：
+    python -m pytest tests/test_batch_process.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+
+from PyQt6.QtWidgets import QMessageBox
+
+from gui.pages import batch_process_dialog as bpd
+from gui.pages.annotate_page import AnnotatePage
+
+_app = _bootstrap.app()
+
+
+class _AutoYesBox:
+    """把弹出的确认框直接当成「是」，测试里不停在模态对话框上。"""
+
+    StandardButton = QMessageBox.StandardButton
+
+    @staticmethod
+    def question(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Yes
+
+    @staticmethod
+    def warning(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Ok
+
+    @staticmethod
+    def information(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Ok
+
+
+def make_page() -> AnnotatePage:
+    """直接摆好页面状态。set_project 是开线程异步加载的，测试里不等它。"""
+    page = AnnotatePage()
+    page.current_project_id = 1
+    page.images = [{'id': 1, 'file_name': 'a.jpg'}]
+    page.classes = [{'id': 0, 'name': 'cat', 'color': '#ff0000'}]
+    return page
+
+
+def assert_batch_mode_clean(page):
+    """点选模式的四个状态位必须全部收干净。"""
+    assert page.batch_process_dialog is None, "页面还攥着弹窗引用"
+    assert page.canvas.batch_process_mode is False, "画布还在点选模式"
+    assert page.canvas.batch_process_points == [], "画布还留着上次的点"
+    assert page.canvas.batch_process_dialog is None, "画布还指着已关闭的弹窗"
+
+
+def test_opening_dialog_enters_batch_mode():
+    page = make_page()
+    page.show_batch_process_dialog()
+
+    assert page.batch_process_dialog is not None
+    assert page.canvas.batch_process_mode is True
+    assert page.canvas.batch_process_dialog is page.batch_process_dialog
+
+    page.batch_process_dialog.reject()
+
+
+def test_cancel_exits_batch_mode():
+    page = make_page()
+    page.show_batch_process_dialog()
+    page.canvas.batch_process_points.append((3, 4))
+
+    page.batch_process_dialog.reject()  # 「取消」按钮走的就是 reject
+    assert_batch_mode_clean(page)
+
+
+def test_closing_window_exits_batch_mode():
+    page = make_page()
+    page.show_batch_process_dialog()
+    page.canvas.batch_process_points.append((3, 4))
+
+    page.batch_process_dialog.close()  # 点窗口的关闭按钮
+    assert_batch_mode_clean(page)
+
+
+def test_execute_runs_once_and_exits_batch_mode():
+    page = make_page()
+
+    calls = []
+    page.execute_batch_process = lambda config: calls.append(config)
+
+    page.show_batch_process_dialog()
+    dialog = page.batch_process_dialog
+
+    dialog.add_point(5, 5)
+    dialog.delete_class_list.setCurrentRow(0)
+    assert dialog.btn_execute.isEnabled()
+
+    real_box = bpd.QMessageBox
+    bpd.QMessageBox = _AutoYesBox
+    try:
+        dialog.execute_process()
+    finally:
+        bpd.QMessageBox = real_box
+
+    # 确认执行只跑一次：process_requested 和 accept() 触发的 finished
+    # 都会调 _exit_batch_process_mode，但批处理本身不能跑两遍
+    assert len(calls) == 1, f"批处理执行了 {len(calls)} 次"
+    assert calls[0]['operation'] == 'delete'
+    assert calls[0]['points'] == [(5, 5)]
+    assert_batch_mode_clean(page)
+
+
+def test_exit_helper_is_idempotent():
+    page = make_page()
+    page.show_batch_process_dialog()
+
+    page._exit_batch_process_mode()
+    page._exit_batch_process_mode()  # 重复调用不该炸，也不该有副作用
+    assert_batch_mode_clean(page)
+
+
+def test_reopening_does_not_leak_previous_dialog():
+    page = make_page()
+    page.show_batch_process_dialog()
+    first = page.batch_process_dialog
+
+    # 弹窗还开着就再点一次「批处理」：上一个要被收掉，不能两个弹窗抢画布
+    page.show_batch_process_dialog()
+    second = page.batch_process_dialog
+
+    assert second is not first
+    assert page.canvas.batch_process_dialog is second
+    assert page.canvas.batch_process_mode is True
+
+    second.reject()
+    assert_batch_mode_clean(page)
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_database_sync_safety.py
+++ b/tests/test_database_sync_safety.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""Database.sync_files_with_database 必须是只读扫描，绝不删除任何东西。
+
+背景：旧实现会直接删掉数据库里指向缺失文件的记录，以及 projects/ 目录下
+不在数据库中的文件夹/文件。main_window 启动时无参数调用它——一旦文件系统
+和数据库出现任何不一致（哪怕只是权限问题、正在写入的临时文件），用户的
+项目、图片、标注就会被无声删除。
+
+这里只测 models.database.Database，不走 tests/_bootstrap（它会把
+sync_files_with_database 整个换成空 lambda，测不出真实行为），所以自己
+造临时数据库 + 临时 projects 目录，绝不碰真实 data/EzYOLO.db 或 projects/。
+
+运行：
+    python tests/test_database_sync_safety.py
+"""
+
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+APP_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(APP_ROOT))
+
+from models.database import Database  # noqa: E402
+
+
+def _new_db():
+    """临时 sqlite 文件，不落在真实 data/ 目录下。"""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    return Database(db_path=tmp.name), tmp.name
+
+
+def _new_projects_dir():
+    return Path(tempfile.mkdtemp(prefix="ezyolo-projects-test-"))
+
+
+def _insert_project(db_path, name, storage_path):
+    """直接向临时 db 的 projects 表插入一行。
+
+    不能用 Database.create_project()：它无视 db_path，永远在真实
+    APP_ROOT/projects 下 mkdir（见 tests/_bootstrap.py 的同一个坑），
+    这个安全测试必须从一开始就不碰真实 projects/。
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO projects (name, description, type, classes, storage_path) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (name, "", "detection", "[]", storage_path),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def test_consistent_state_reports_no_issues():
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        folder = projects_dir / "proj_a_20260101_000000"
+        pid = _insert_project(db_path, "proj_a", str(folder))
+        folder.mkdir(parents=True, exist_ok=True)
+        image_path = folder / "img.jpg"
+        image_path.write_bytes(b"fake")
+        db.add_image(pid, "img.jpg", str(image_path))
+
+        result = db.sync_files_with_database(projects_dir=str(projects_dir))
+
+        assert result['deleted_db_count'] == 0
+        assert result['deleted_file_count'] == 0
+        assert result['total_deleted'] == 0
+        assert result['orphan_db_count'] == 0
+        assert result['orphan_disk_count'] == 0
+        assert result['issues'] == []
+        assert result['has_issues'] is False
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+def test_missing_file_is_reported_but_db_row_survives():
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        project_folder = projects_dir / "proj_b_20260101_000000"
+        project_folder.mkdir(parents=True, exist_ok=True)
+        pid = _insert_project(db_path, "proj_b", str(project_folder))
+        image_id = db.add_image(pid, "gone.jpg", str(projects_dir / "does_not_exist.jpg"))
+
+        result = db.sync_files_with_database(projects_dir=str(projects_dir))
+
+        assert result['deleted_db_count'] == 0
+        assert result['total_deleted'] == 0
+        assert result['orphan_db_count'] == 1
+        assert result['has_issues'] is True
+        assert any(i.get('type') == 'missing_file' and i.get('image_id') == image_id
+                   for i in result['issues'])
+
+        # 记录必须原封不动地还在数据库里
+        assert db.get_image(image_id) is not None
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+def test_orphan_project_dir_is_reported_but_kept_on_disk():
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        orphan_folder = projects_dir / "mystery_project_20260101_000000"
+        orphan_folder.mkdir(parents=True, exist_ok=True)
+        sentinel = orphan_folder / "sentinel.jpg"
+        sentinel.write_bytes(b"keep me")
+
+        result = db.sync_files_with_database(projects_dir=str(projects_dir))
+
+        assert result['deleted_file_count'] == 0
+        assert result['total_deleted'] == 0
+        assert result['orphan_disk_count'] >= 1
+        assert result['has_issues'] is True
+        assert any(i.get('type') == 'orphan_project_dir' for i in result['issues'])
+
+        # 文件夹和哨兵文件必须原封不动
+        assert orphan_folder.exists()
+        assert sentinel.exists()
+        assert sentinel.read_bytes() == b"keep me"
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+def test_default_call_without_arguments_is_safe():
+    """main_window 启动时是无参数调用，签名必须兼容且默认路径依旧只读。"""
+    db, db_path = _new_db()
+    try:
+        result = db.sync_files_with_database()
+
+        assert result['deleted_db_count'] == 0
+        assert result['deleted_file_count'] == 0
+        assert result['total_deleted'] == 0
+        assert 'orphan_db_count' in result
+        assert 'orphan_disk_count' in result
+        assert 'issues' in result
+    finally:
+        os.unlink(db_path)
+
+
+def test_repeated_scan_is_idempotent():
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        pid = _insert_project(db_path, "proj_c", str(projects_dir / "proj_c_20260101_000000"))
+        db.add_image(pid, "gone.jpg", str(projects_dir / "missing.jpg"))
+        orphan_folder = projects_dir / "orphan_20260101_000000"
+        orphan_folder.mkdir(parents=True, exist_ok=True)
+
+        first = db.sync_files_with_database(projects_dir=str(projects_dir))
+        second = db.sync_files_with_database(projects_dir=str(projects_dir))
+
+        assert first['orphan_db_count'] == second['orphan_db_count']
+        assert first['orphan_disk_count'] == second['orphan_disk_count']
+        assert first['deleted_db_count'] == second['deleted_db_count'] == 0
+        assert first['deleted_file_count'] == second['deleted_file_count'] == 0
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+def test_short_project_name_does_not_claim_unrelated_folder():
+    """项目名是短片段（如 "a"）时，不能靠子串匹配误认领别的目录。"""
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        pid = _insert_project(db_path, "a", str(projects_dir / "proj_a_20260101_000000"))
+        (projects_dir / "proj_a_20260101_000000").mkdir(parents=True, exist_ok=True)
+
+        # 这个目录名里包含 "a"，但它不是数据库项目 "a" 的 storage_path
+        unrelated_folder = projects_dir / "banana_20260101_000000"
+        unrelated_folder.mkdir(parents=True, exist_ok=True)
+        sentinel = unrelated_folder / "sentinel.jpg"
+        sentinel.write_bytes(b"keep me")
+
+        result = db.sync_files_with_database(projects_dir=str(projects_dir))
+
+        assert result['deleted_file_count'] == 0
+        assert result['has_issues'] is True
+        assert any(
+            i.get('type') == 'orphan_project_dir' and i.get('path') == str(unrelated_folder)
+            for i in result['issues']
+        )
+        # 无关目录必须原封不动
+        assert unrelated_folder.exists()
+        assert sentinel.exists()
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+def test_missing_project_storage_dir_is_reported():
+    """项目在数据库里存在但 storage_path 目录不存在（且没有任何图片）时必须被发现。"""
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        missing_storage = projects_dir / "proj_e_20260101_000000"
+        pid = _insert_project(db_path, "proj_e", str(missing_storage))
+        # 故意不 mkdir missing_storage，且不给这个项目添加任何图片
+
+        result = db.sync_files_with_database(projects_dir=str(projects_dir))
+
+        assert result['deleted_db_count'] == 0
+        assert result['orphan_db_count'] >= 1
+        assert result['has_issues'] is True
+        assert any(
+            i.get('type') == 'missing_project_dir' and i.get('project_id') == pid
+            for i in result['issues']
+        )
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+def test_scan_exception_does_not_trigger_any_deletion():
+    db, db_path = _new_db()
+    projects_dir = _new_projects_dir()
+    try:
+        pid = _insert_project(db_path, "proj_d", str(projects_dir / "proj_d_20260101_000000"))
+        image_path = projects_dir / "flaky.jpg"
+        image_path.write_bytes(b"fake")
+        image_id = db.add_image(pid, "flaky.jpg", str(image_path))
+
+        with patch("models.database.os.path.exists", side_effect=OSError("boom")):
+            try:
+                result = db.sync_files_with_database(projects_dir=str(projects_dir))
+            except Exception:
+                result = None
+
+        # 无论是抛异常还是把异常收进 issues，都不能删任何东西
+        assert db.get_image(image_id) is not None
+        assert image_path.exists()
+        if result is not None:
+            assert result['deleted_db_count'] == 0
+            assert result['deleted_file_count'] == 0
+            assert result['total_deleted'] == 0
+    finally:
+        shutil.rmtree(projects_dir, ignore_errors=True)
+        os.unlink(db_path)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            try:
+                func()
+                print(f"PASS {name}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"FAIL {name}: {exc!r}")
+    print(f"\n{'all passed' if not failures else f'{failures} failed'}")
+    sys.exit(1 if failures else 0)

--- a/tests/test_display_names.py
+++ b/tests/test_display_names.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""图片显示名：把抽帧生成的文件名念成人话，同时不丢原始文件名。
+
+覆盖的真实问题：
+    1. 视频抽帧落库的名字是 20260712_000602_575947_frame_000223.jpg。
+       一屏几十行，前 22 个字符完全一样——列表里等于每张图都没有名字。
+    2. 只截尾巴不行：两段视频都抽到第 223 帧时，两行会长得一模一样。
+    3. 别名只是显示层的事：文件名和数据库不能被改写，完整名字必须还找得到（tooltip）。
+
+运行：
+    python tests/test_display_names.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+
+from gui.display_names import display_name, display_names, parse_frame_name
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+
+# ==================== 纯函数 ====================
+
+def test_generated_frame_name_is_spoken_as_frame_number():
+    """抽帧名 → 「帧 223」：前导零去掉，时间戳不念。"""
+    assert display_name("20260712_000602_575947_frame_000223.jpg") == "帧 223"
+    assert display_name("20260712_000602_575947_frame_000001.jpg") == "帧 1"
+
+
+def test_all_zero_frame_number_stays_zero_not_empty():
+    """第 0 帧是「帧 0」，不能把零全去掉变成「帧 」。"""
+    assert display_name("20260712_000602_575947_frame_000000.jpg") == "帧 0"
+
+
+def test_user_filenames_are_left_alone():
+    """普通图片的文件名是用户自己起的，本来就可读——原样返回，不替他改写。"""
+    for name in ("cat.jpg", "IMG_2024.png", "安全帽-01.jpeg", "frame_000223.jpg"):
+        assert display_name(name) == name, name
+
+
+def test_unrecognized_names_degrade_to_themselves():
+    """认不出来的名字宁可难看也不能念错——退回原样，不猜。"""
+    assert display_name("") == ""
+    assert display_name("2026_frame_1.jpg") == "2026_frame_1.jpg"
+    assert parse_frame_name("cat.jpg") is None
+
+
+def test_parse_exposes_the_pieces_for_discriminating():
+    parsed = parse_frame_name("20260712_000602_575947_frame_000223.jpg")
+    assert parsed['date'] == "20260712"
+    assert parsed['time'] == "000602"
+    assert parsed['frame'] == "000223"
+
+
+# ==================== 重名 ====================
+
+def test_frames_from_one_video_need_no_discriminator():
+    """同一段视频里帧号本来就不会重复，别名保持最短。"""
+    names = [
+        "20260712_000602_575947_frame_000000.jpg",
+        "20260712_000602_575948_frame_000030.jpg",
+        "20260712_000602_575949_frame_000060.jpg",
+    ]
+    assert display_names(names) == ["帧 0", "帧 30", "帧 60"]
+
+
+def test_same_frame_number_from_different_days_is_split_by_date():
+    """两段视频都抽到第 223 帧：先用日期分，别名不能一模一样。"""
+    names = [
+        "20260712_000602_575947_frame_000223.jpg",
+        "20260713_101500_000001_frame_000223.jpg",
+    ]
+    aliases = display_names(names)
+
+    assert aliases == ["帧 223 · 07-12", "帧 223 · 07-13"], aliases
+    assert len(set(aliases)) == 2
+
+
+def test_same_day_falls_through_to_time():
+    """同一天导入的两段视频：日期分不开，用时间分。"""
+    names = [
+        "20260712_000602_575947_frame_000223.jpg",
+        "20260712_183000_000001_frame_000223.jpg",
+    ]
+    aliases = display_names(names)
+
+    assert aliases == ["帧 223 · 00:06:02", "帧 223 · 18:30:00"], aliases
+
+
+def test_same_second_falls_back_to_a_stable_ordinal():
+    """同一秒也分不开（微秒不同）：给序号。顺序稳定，不随调用次数变。"""
+    names = [
+        "20260712_000602_575947_frame_000223.jpg",
+        "20260712_000602_575999_frame_000223.jpg",
+    ]
+    aliases = display_names(names)
+
+    assert aliases == ["帧 223 (1)", "帧 223 (2)"], aliases
+    assert display_names(names) == aliases, "同样的输入必须给同样的别名"
+
+
+def test_duplicate_user_filenames_also_get_ordinals():
+    """普通文件名重了一样要能分开（没有时间戳可用 → 序号）。"""
+    aliases = display_names(["cat.jpg", "cat.jpg", "dog.jpg"])
+    assert aliases == ["cat.jpg (1)", "cat.jpg (2)", "dog.jpg"], aliases
+
+
+def test_aliases_line_up_one_to_one_with_the_input():
+    """别名列表和输入列表一一对应——错位就会把 A 的名字挂到 B 头上。"""
+    names = [
+        "cat.jpg",
+        "20260712_000602_575947_frame_000223.jpg",
+        "20260713_101500_000001_frame_000223.jpg",
+        "dog.png",
+    ]
+    aliases = display_names(names)
+
+    assert len(aliases) == len(names)
+    assert aliases[0] == "cat.jpg"
+    assert aliases[3] == "dog.png"
+    assert aliases[1].startswith("帧 223") and aliases[2].startswith("帧 223")
+    assert aliases[1] != aliases[2]
+
+
+# ==================== 页面里用起来 ====================
+
+def _seed_frames(project_id, filenames):
+    for name in filenames:
+        db.add_image(project_id, name, f"/tmp/{name}", width=640, height=480)
+
+
+def test_import_grid_shows_aliases_but_keeps_the_real_name_in_the_tooltip():
+    """导入页网格：格子上写别名，完整文件名和分辨率留在 tooltip 里。"""
+    from PyQt6.QtCore import Qt
+    from gui.pages.import_page import ImportPage
+
+    project_id = _bootstrap.create_temp_project(name="别名测试", project_type="detect")
+    original = "20260712_000602_575947_frame_000223.jpg"
+    _seed_frames(project_id, [original])
+
+    page = ImportPage()
+    page.set_project(project_id)
+    _app.processEvents()
+
+    item = page.image_list.item(0)
+    assert item.text() == "帧 223", item.text()
+    assert original in item.toolTip(), item.toolTip()
+    assert "640x480" in item.toolTip(), item.toolTip()
+
+    # 数据库里存的还是原来那个名字——别名只是显示层的事
+    stored = db.get_project_images(project_id)[0]['filename']
+    assert stored == original
+
+    page.stop_image_loading()
+    db.delete_project(project_id)
+
+
+def test_annotate_list_and_context_bar_use_aliases_and_put_position_first():
+    """标注页：左边列表用别名（保留 ✓/○），顶上先说第几张，再说是哪张。"""
+    from gui.pages.annotate_page import AnnotatePage
+
+    project_id = _bootstrap.create_temp_project(name="别名测试2", project_type="detect")
+    original = "20260712_000602_575947_frame_000223.jpg"
+    _seed_frames(project_id, [original])
+
+    page = AnnotatePage()
+    page.current_project_id = project_id
+    page.load_image_list()
+    _app.processEvents()
+
+    item = page.image_list.item(0)
+    assert item.text() == "○ 帧 223", item.text()
+    assert original in item.toolTip(), item.toolTip()
+
+    page.load_image(page.images[0]['id'])
+    _app.processEvents()
+
+    text = str(page.image_name_label.property('_full_text'))
+    assert text.startswith("第 1/1 张"), f"位置要排在最前面：{text!r}"
+    assert "帧 223" in text, text
+    assert original not in text, f"长文件名不该出现在信息条上：{text!r}"
+    # 完整文件名还找得到
+    assert original in page.image_name_label.toolTip()
+
+    page.shutdown()
+    db.delete_project(project_id)
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(dict(globals())))

--- a/tests/test_import_manager.py
+++ b/tests/test_import_manager.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+"""core.import_manager 的取消 / 进度契约测试。
+
+只测纯逻辑（不起 GUI 线程），用临时项目 + 临时文件，不碰真实 data/projects/outputs。
+
+运行：
+    python -m pytest tests/test_import_manager.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import cv2
+import numpy as np
+from PyQt6.QtGui import QImage, QColor
+
+from core.import_manager import ImportManager
+
+db = _bootstrap.db
+
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-import-manager-"))
+
+
+def _make_project() -> int:
+    return _bootstrap.create_temp_project(name="导入管理器测试项目", project_type="detect", classes=[])
+
+
+def _make_images(folder: Path, count: int) -> list:
+    folder.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(count):
+        path = folder / f"img_{i:03d}.jpg"
+        image = QImage(32, 32, QImage.Format.Format_RGB888)
+        image.fill(QColor(10 * i % 255, 20, 30))
+        image.save(str(path))
+        paths.append(str(path))
+    return paths
+
+
+def _make_video(path: Path, frame_count: int = 15, size=(64, 48)) -> Path:
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, 10.0, size)
+    for i in range(frame_count):
+        frame = np.zeros((size[1], size[0], 3), dtype=np.uint8)
+        frame[:] = (i * 10 % 255, 0, 0)
+        writer.write(frame)
+    writer.release()
+    return path
+
+
+def test_import_folder_reports_scan_busy_state_before_total_known():
+    """扫描阶段（还不知道总数）必须先给一个忙碌态回调，而不是干等。"""
+    project_id = _make_project()
+    folder = _TMP_DIR / "folder_scan"
+    _make_images(folder, 3)
+
+    manager = ImportManager(project_id)
+    calls = []
+    manager.import_folder(str(folder), progress_callback=lambda p, m: calls.append((p, m)))
+
+    assert calls, "没有任何进度回调"
+    first_progress, first_message = calls[0]
+    assert first_progress == -1, "扫描阶段应该是总量未知的忙碌态（-1），不是具体百分比"
+    assert "扫描" in first_message
+
+
+def test_import_folder_cancel_stops_before_all_files_done():
+    """取消后最迟在下一张图片边界停止，不会把剩下的也导入。"""
+    project_id = _make_project()
+    folder = _TMP_DIR / "folder_cancel"
+    _make_images(folder, 10)
+
+    manager = ImportManager(project_id)
+    cancel_event = threading.Event()
+    seen = []
+
+    def progress_callback(progress, message):
+        seen.append((progress, message))
+        # 处理完第 2 张之后请求取消
+        if len(seen) == 3:
+            cancel_event.set()
+
+    imported, skipped = manager.import_folder(
+        str(folder), progress_callback=progress_callback, cancel_event=cancel_event
+    )
+
+    assert imported < 10, f"取消没有生效，全部 10 张都导入了: imported={imported}"
+    assert imported > 0, "取消发生前已经成功导入的部分应该保留"
+    final_message = seen[-1][1]
+    assert "已取消" in final_message
+
+
+def test_import_images_cancel_stops_before_all_files_done():
+    """import_images 的取消行为跟 import_folder 一致。"""
+    project_id = _make_project()
+    folder = _TMP_DIR / "images_cancel"
+    file_paths = _make_images(folder, 8)
+
+    manager = ImportManager(project_id)
+    cancel_event = threading.Event()
+    seen = []
+
+    def progress_callback(progress, message):
+        seen.append((progress, message))
+        if len(seen) == 2:
+            cancel_event.set()
+
+    imported, skipped = manager.import_images(
+        file_paths, progress_callback=progress_callback, cancel_event=cancel_event
+    )
+
+    assert imported < 8
+    assert imported > 0
+    assert "已取消" in seen[-1][1]
+
+
+def test_import_video_reports_open_and_metadata_before_extraction():
+    """视频导入：先报「正在打开」，拿到元数据后再报总帧数/间隔/预计抽取数。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "meta.mp4", frame_count=15)
+
+    manager = ImportManager(project_id)
+    calls = []
+    manager.import_video(
+        str(video_path), frame_interval=5,
+        progress_callback=lambda p, m: calls.append((p, m)),
+    )
+
+    assert len(calls) >= 2
+    open_progress, open_message = calls[0]
+    assert open_progress == -1
+    assert "正在打开视频" in open_message
+    assert video_path.name in open_message
+
+    meta_progress, meta_message = calls[1]
+    assert "帧" in meta_message
+    assert "间隔 5" in meta_message
+    assert "预计抽取" in meta_message
+
+
+def test_import_video_unknown_total_frames_does_not_divide_by_zero():
+    """总帧数拿不到（0 或负数）时不能除零，且要退化成忙碌态。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "unknown_total.mp4", frame_count=6)
+
+    real_video_capture = cv2.VideoCapture
+
+    class _FakeCap:
+        """包一层真的 VideoCapture，只是把 FRAME_COUNT 汇报成 0。"""
+
+        def __init__(self, path):
+            self._real = real_video_capture(path)
+
+        def isOpened(self):
+            return self._real.isOpened()
+
+        def get(self, prop):
+            if prop == cv2.CAP_PROP_FRAME_COUNT:
+                return 0
+            return self._real.get(prop)
+
+        def read(self):
+            return self._real.read()
+
+        def release(self):
+            self._real.release()
+
+    manager = ImportManager(project_id)
+    calls = []
+
+    with patch("core.import_manager.cv2.VideoCapture", lambda p: _FakeCap(p)):
+        imported, skipped = manager.import_video(
+            str(video_path), frame_interval=2,
+            progress_callback=lambda p, m: calls.append((p, m)),
+        )
+
+    assert imported > 0, "总帧数未知也应该正常抽帧，不能因为除零而整个失败"
+    # 抽帧阶段的进度必须全部是忙碌态（-1），不能算出一个假的百分比
+    extraction_calls = calls[2:-1]  # 去掉「打开」「元数据」和最后一条「完成」
+    assert extraction_calls, "没有抽帧阶段的进度回调"
+    for progress, message in extraction_calls:
+        assert progress == -1, f"总帧数未知时不应该出现具体百分比: {progress}"
+
+
+def test_import_video_estimated_extraction_count_rounds_up():
+    """预计抽取数应该向上取整：31 帧、间隔 30，第 0 帧和第 30 帧都会被抽到，预计 2 张。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "ceil_estimate.mp4", frame_count=31)
+
+    manager = ImportManager(project_id)
+    calls = []
+    manager.import_video(
+        str(video_path), frame_interval=30,
+        progress_callback=lambda p, m: calls.append((p, m)),
+    )
+
+    meta_progress, meta_message = calls[1]
+    assert "预计抽取 2 张" in meta_message, meta_message
+
+
+def test_import_folder_cancelled_final_progress_is_not_misleading_full_completion():
+    """取消后的最终进度应该停在中断时的真实位置，不能显示成 100% 已完成。"""
+    project_id = _make_project()
+    folder = _TMP_DIR / "folder_cancel_progress"
+    _make_images(folder, 10)
+
+    manager = ImportManager(project_id)
+    cancel_event = threading.Event()
+    seen = []
+
+    def progress_callback(progress, message):
+        seen.append((progress, message))
+        if len(seen) == 3:
+            cancel_event.set()
+
+    manager.import_folder(str(folder), progress_callback=progress_callback, cancel_event=cancel_event)
+
+    final_progress, final_message = seen[-1]
+    assert "已取消" in final_message
+    assert final_progress < 100, f"取消后不应该报告 100% 完成，实际: {final_progress}"
+
+
+def test_import_video_cancelled_final_progress_is_not_misleading_full_completion():
+    """视频抽帧取消时同理：最终进度不能是误导性的 100%。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "cancel_progress.mp4", frame_count=40)
+
+    manager = ImportManager(project_id)
+    cancel_event = threading.Event()
+    seen = []
+
+    def progress_callback(progress, message):
+        seen.append((progress, message))
+        if len(seen) == 3:
+            cancel_event.set()
+
+    manager.import_video(
+        str(video_path), frame_interval=1,
+        progress_callback=progress_callback, cancel_event=cancel_event,
+    )
+
+    final_progress, final_message = seen[-1]
+    assert "已取消" in final_message
+    assert final_progress < 100, f"取消后不应该报告 100% 完成，实际: {final_progress}"
+
+
+def test_import_video_cancel_stops_before_reading_all_frames():
+    """视频抽帧的取消：最迟在下一帧边界停止。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "cancel.mp4", frame_count=40)
+
+    manager = ImportManager(project_id)
+    cancel_event = threading.Event()
+    seen = []
+
+    def progress_callback(progress, message):
+        seen.append((progress, message))
+        if len(seen) == 3:
+            cancel_event.set()
+
+    imported, skipped = manager.import_video(
+        str(video_path), frame_interval=1,
+        progress_callback=progress_callback, cancel_event=cancel_event,
+    )
+
+    assert imported < 40
+    assert "已取消" in seen[-1][1]
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_import_page.py
+++ b/tests/test_import_page.py
@@ -1,0 +1,451 @@
+# -*- coding: utf-8 -*-
+"""导入页交互连续性测试。
+
+覆盖的真实问题：
+    1. 点了导入之后，一个事件循环内必须看到明确状态（不是干等一个空进度条）。
+    2. 导入任务状态和缩略图加载状态是两套东西，互相不能把对方隐藏掉——
+       切到别的页面再回来（refresh_project_images）、缩略图加载完成，
+       都不该让还在跑的导入状态条消失。
+    3. 图片 / 文件夹导入的实际工作必须在后台线程，不能卡住调用者（GUI 主线程）。
+    4. 任务结束（成功/取消/失败）后必须恢复被禁用的按钮。
+    5. 取消按钮要真的能喊停后台线程。
+
+运行：
+    python -m pytest tests/test_import_page.py -q
+    或
+    python tests/test_import_page.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import time
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from PyQt6.QtGui import QImage, QColor
+from PyQt6.QtWidgets import QMessageBox, QInputDialog
+
+from gui.pages.import_page import ImportPage
+from gui.main_window import MainWindow
+from gui.workflow import PAGE_SETTINGS, STEP_IMPORT
+from core.import_manager import ImportManager
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-import-page-"))
+
+
+class _SilentMessageBox:
+    """吞掉成功/失败弹窗，测试不该被模态框卡住。"""
+
+    StandardButton = QMessageBox.StandardButton
+    Icon = QMessageBox.Icon
+
+    @staticmethod
+    def information(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Ok
+
+    @staticmethod
+    def warning(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Ok
+
+    @staticmethod
+    def critical(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Ok
+
+    @staticmethod
+    def question(*_args, **_kwargs):
+        return QMessageBox.StandardButton.Yes
+
+
+def _make_project() -> int:
+    return _bootstrap.create_temp_project(name="导入页测试项目", project_type="detect", classes=[])
+
+
+def _make_images(folder: Path, count: int) -> list:
+    folder.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(count):
+        path = folder / f"img_{i:03d}.jpg"
+        image = QImage(32, 32, QImage.Format.Format_RGB888)
+        image.fill(QColor(10 * i % 255, 20, 30))
+        image.save(str(path))
+        paths.append(str(path))
+    return paths
+
+
+def _make_video(path: Path, frame_count: int = 30, size=(64, 48)) -> Path:
+    import cv2
+    import numpy as np
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, 10.0, size)
+    for i in range(frame_count):
+        frame = np.zeros((size[1], size[0], 3), dtype=np.uint8)
+        frame[:] = (i * 5 % 255, 0, 0)
+        writer.write(frame)
+    writer.release()
+    return path
+
+
+def _pump_until(predicate, timeout=10.0):
+    """跑事件循环直到条件成立或超时，返回是否成立。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        _app.processEvents()
+        if predicate():
+            return True
+    return False
+
+
+def _wait_import_done(page):
+    ok = _pump_until(lambda: not page._import_busy)
+    assert ok, "导入任务没有在超时时间内收尾"
+
+
+def test_video_import_shows_busy_state_within_same_call():
+    """确认导入后，一个事件循环内（同一次调用里）就要看到明确状态。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    video_path = _make_video(_TMP_DIR / "busy.mp4", frame_count=40)
+
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(QInputDialog, "getInt", return_value=(5, True)):
+        page.process_video_import(str(video_path), group_id=None)
+
+        # 不经过任何 processEvents，直接检查：必须已经是「导入中」状态
+        assert page._import_busy is True
+        assert page.import_status_frame.isHidden() is False
+        assert page.import_progress_bar.maximum() == 0, "总帧数还不知道时应该是忙碌态（indeterminate）"
+        assert "打开视频" in page.import_status_label.text()
+        assert page.btn_cancel_import.isHidden() is False
+
+        for button in (
+            page.btn_import_folder, page.btn_import_images,
+            page.btn_import_video, page.btn_import_annotations,
+            page.btn_delete_project, page.btn_clear,
+        ):
+            assert not button.isEnabled(), f"{button.text()} 导入中应该被禁用"
+
+        _wait_import_done(page)
+
+    assert len(page.images) > 0
+    for button in (page.btn_import_folder, page.btn_import_video, page.btn_delete_project):
+        assert button.isEnabled(), "导入结束后按钮应该恢复可用"
+
+
+def test_images_import_shows_determinate_progress_immediately():
+    """已知总量（选好的图片列表）应该立刻是确定进度，不是转圈忙碌态。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    file_paths = _make_images(_TMP_DIR / "determinate", 5)
+
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox):
+        page.process_image_import(file_paths, group_id=None)
+
+        assert page._import_busy is True
+        assert page.import_progress_bar.maximum() == 100, "已知总量应该切到确定进度"
+        assert "0/5" in page.import_status_label.text()
+
+        _wait_import_done(page)
+
+    assert len(page.images) == 5
+
+
+def test_page_switch_refresh_does_not_hide_active_import():
+    """切到别的页面再回来时会调 refresh_project_images，不该把导入状态藏起来。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    page._start_import_ui("正在准备导入: demo.mp4")
+    assert page.import_status_frame.isHidden() is False
+
+    # 主窗口从别的页面切回导入页时调用的正是这个方法
+    page.refresh_project_images()
+
+    assert page.import_status_frame.isHidden() is False, "切页刷新不该隐藏正在进行的导入状态"
+    assert page._import_busy is True
+
+    # 清理，避免影响后面的测试
+    page._end_import_ui()
+
+
+def test_real_main_window_settings_round_trip_keeps_import_status():
+    """复现用户路径：导入中点设置，再点回第 1 步，状态和文字仍在。"""
+    project_id = _make_project()
+    window = MainWindow()
+    window.load_projects(select_id=project_id)
+    window.show()
+    _app.processEvents()
+    page = window.import_page
+
+    page._start_import_ui("正在打开视频: demo.mp4")
+
+    window.switch_page(PAGE_SETTINGS)
+    window.switch_page(STEP_IMPORT)
+    _app.processEvents()
+
+    assert page._import_busy is True
+    assert page.import_status_frame.isVisible(), "从设置返回后导入状态条消失了"
+    assert "demo.mp4" in page.import_status_label.text(), "返回后丢失了当前任务说明"
+
+    page._end_import_ui()
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_thumbnail_load_finish_does_not_hide_active_import():
+    """缩略图加载完成（on_load_finished）不该把导入状态条带下去。"""
+    project_id = _make_project()
+    image_paths = _make_images(_TMP_DIR / "thumb_independent", 3)
+    for path in image_paths:
+        db.add_image(project_id, Path(path).name, path, width=32, height=32)
+
+    page = ImportPage()
+    page.set_project(project_id)
+    _pump_until(lambda: page.load_worker is None)  # 等 set_project 触发的初始缩略图加载先跑完
+
+    page._start_import_ui("正在导入其它内容…")
+    assert page.import_status_frame.isHidden() is False
+
+    # 触发一次独立的缩略图刷新（不是通过 load_project_images，模拟纯缩略图加载场景）
+    page.force_refresh_images()
+    ok = _pump_until(lambda: page.load_worker is None)
+    assert ok, "缩略图加载线程没有在超时时间内结束"
+
+    assert page.import_status_frame.isHidden() is False, "缩略图加载完成不该隐藏导入状态"
+    assert page._import_busy is True
+
+    page._end_import_ui()
+
+
+def test_cancel_button_stops_active_thread():
+    """点取消按钮要真的调用到后台线程的 cancel()。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    calls = []
+
+    class _FakeThread:
+        def cancel(self):
+            calls.append("cancelled")
+
+    page._active_import_thread = _FakeThread()
+    page._start_import_ui("正在导入…")
+
+    page._cancel_active_import()
+
+    assert calls == ["cancelled"]
+    assert not page.btn_cancel_import.isEnabled()
+    assert "取消" in page.import_status_label.text()
+
+    page._end_import_ui()
+
+
+def test_folder_and_images_import_do_not_block_caller_thread():
+    """process_folder_import / process_image_import 必须立刻返回，实际工作在后台线程。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    folder = _TMP_DIR / "slow_folder"
+    _make_images(folder, 3)
+
+    real_import_folder = ImportManager.import_folder
+
+    def slow_import_folder(self, *args, **kwargs):
+        time.sleep(0.5)
+        return real_import_folder(self, *args, **kwargs)
+
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(ImportManager, "import_folder", slow_import_folder):
+        start = time.monotonic()
+        page.process_folder_import(str(folder), group_id=None)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.2, f"process_folder_import 阻塞了调用者线程: {elapsed:.3f}s"
+
+        _wait_import_done(page)
+
+    assert len(page.images) == 3
+
+
+def test_unknown_total_frames_video_import_completes_without_crash():
+    """总帧数未知的视频也要能正常导入完，不因为除零而崩掉（GUI 层串联真实场景）。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    video_path = _make_video(_TMP_DIR / "unknown_gui.mp4", frame_count=20)
+
+    import cv2
+    real_video_capture = cv2.VideoCapture
+
+    class _FakeCap:
+        def __init__(self, path):
+            self._real = real_video_capture(path)
+
+        def isOpened(self):
+            return self._real.isOpened()
+
+        def get(self, prop):
+            if prop == cv2.CAP_PROP_FRAME_COUNT:
+                return 0
+            return self._real.get(prop)
+
+        def read(self):
+            return self._real.read()
+
+        def release(self):
+            self._real.release()
+
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(QInputDialog, "getInt", return_value=(5, True)), \
+         patch("core.import_manager.cv2.VideoCapture", lambda p: _FakeCap(p)):
+        page.process_video_import(str(video_path), group_id=None)
+        assert page.import_progress_bar.maximum() == 0
+        _wait_import_done(page)
+
+    assert len(page.images) > 0
+
+
+def test_project_switch_keeps_old_thread_alive_until_it_actually_finishes():
+    """切换项目时取消旧导入：QThread 对象必须活到它真正退出为止，
+    不能在还在运行时就丢掉引用（否则触发 "QThread: Destroyed while thread
+    is still running"）。旧线程收尾后要真正释放，且不能污染新项目的数据。
+    """
+    project_a = _make_project()
+    project_b = _make_project()
+    page = ImportPage()
+    page.set_project(project_a)
+
+    folder = _TMP_DIR / "switch_slow_worker"
+    _make_images(folder, 5)
+
+    real_import_folder = ImportManager.import_folder
+
+    def slow_import_folder(self, *args, **kwargs):
+        # 真实导入很快就跑完，额外多睡一会儿，确保切项目那一刻线程仍在运行
+        result = real_import_folder(self, *args, **kwargs)
+        time.sleep(0.3)
+        return result
+
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(ImportManager, "import_folder", slow_import_folder):
+        page.process_folder_import(str(folder), group_id=None)
+        old_thread = page._active_import_thread
+        assert old_thread is not None
+
+        page.set_project(project_b)
+
+        # 切换后：不再是「当前活跃」导入，但对象必须还活着、还在跑，
+        # 不能被提前 GC / deleteLater
+        assert page._active_import_thread is None
+        assert old_thread in page._retired_import_threads, "旧线程应该被继续持有，直到它真正退出"
+        assert old_thread.isRunning() is True, "此刻旧线程应该还没跑完（被 mock 多睡了 0.3s）"
+        assert page._import_busy is False
+
+        ok = _pump_until(lambda: old_thread not in page._retired_import_threads, timeout=5.0)
+        assert ok, "旧线程没有在超时时间内被正确收尾"
+
+    assert old_thread.isRunning() is False, "旧线程收尾后必须真的已经退出"
+    assert page.current_project_id == project_b
+    assert page.images == [], "旧项目的导入结果不能污染新项目"
+
+
+def test_normal_cancel_and_failure_paths_all_release_thread_reference():
+    """正常完成 / 失败 / 取消三条路径，导入收尾后都不能残留线程引用（不泄漏）。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    # 路径一：正常完成
+    file_paths = _make_images(_TMP_DIR / "release_normal", 3)
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox):
+        page.process_image_import(file_paths, group_id=None)
+        _wait_import_done(page)
+        ok = _pump_until(lambda: page._active_import_thread is None and not page._retired_import_threads)
+        assert ok, "正常完成后线程引用没有被释放"
+    assert page._active_import_thread is None
+    assert page._retired_import_threads == []
+
+    # 路径二：失败（后台抛异常）
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(ImportManager, "import_images", side_effect=RuntimeError("boom")):
+        page.process_image_import(file_paths, group_id=None)
+        _wait_import_done(page)
+        ok = _pump_until(lambda: page._active_import_thread is None and not page._retired_import_threads)
+        assert ok, "失败后线程引用没有被释放"
+    assert page._active_import_thread is None
+    assert page._retired_import_threads == []
+
+    # 路径三：取消
+    video_path = _make_video(_TMP_DIR / "release_cancel.mp4", frame_count=40)
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(QInputDialog, "getInt", return_value=(1, True)):
+        page.process_video_import(str(video_path), group_id=None)
+        page._cancel_active_import()
+        _wait_import_done(page)
+        ok = _pump_until(lambda: page._active_import_thread is None and not page._retired_import_threads)
+        assert ok, "取消后线程引用没有被释放"
+    assert page._active_import_thread is None
+    assert page._retired_import_threads == []
+
+
+def test_cancelled_import_progress_bar_is_not_shown_as_full_completion():
+    """取消导入后，页面进度条和 summary 不应该被显示成「100% 已完成」。"""
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    video_path = _make_video(_TMP_DIR / "cancel_ui_progress.mp4", frame_count=40)
+
+    import cv2
+    real_video_capture = cv2.VideoCapture
+
+    class _SlowCap:
+        """跟真实 VideoCapture 行为一致，只是每帧多睡一点，留出取消的窗口。"""
+
+        def __init__(self, path):
+            self._real = real_video_capture(path)
+
+        def isOpened(self):
+            return self._real.isOpened()
+
+        def get(self, prop):
+            return self._real.get(prop)
+
+        def read(self):
+            time.sleep(0.03)
+            return self._real.read()
+
+        def release(self):
+            self._real.release()
+
+    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+         patch.object(QInputDialog, "getInt", return_value=(1, True)), \
+         patch("core.import_manager.cv2.VideoCapture", lambda p: _SlowCap(p)):
+        page.process_video_import(str(video_path), group_id=None)
+
+        ok = _pump_until(lambda: page.import_progress_bar.value() > 0, timeout=5.0)
+        assert ok, "没能观察到真实进度，取消窗口没抓住"
+
+        page._cancel_active_import()
+        _wait_import_done(page)
+
+    assert "已取消" in page.import_status_label.text()
+    assert page.import_progress_bar.value() < 100, "取消后不应该把进度条显示成 100% 完成"
+    assert len(page.images) < 40, "取消应该在导完全部帧之前生效"
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_import_page.py
+++ b/tests/test_import_page.py
@@ -22,12 +22,13 @@ import sys
 import time
 import tempfile
 from pathlib import Path
+from contextlib import ExitStack
 from unittest.mock import patch
 
 from PyQt6.QtGui import QImage, QColor
-from PyQt6.QtWidgets import QMessageBox, QInputDialog
+from PyQt6.QtWidgets import QFileDialog
 
-from gui.pages.import_page import ImportPage
+from gui.pages.import_page import ImportPage, short_task_label
 from gui.main_window import MainWindow
 from gui.workflow import PAGE_SETTINGS, STEP_IMPORT
 from core.import_manager import ImportManager
@@ -38,31 +39,49 @@ db = _bootstrap.db
 _TMP_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-import-page-"))
 
 
-class _SilentMessageBox:
-    """吞掉成功/失败弹窗，测试不该被模态框卡住。"""
+def _silent_dialogs():
+    """吞掉应用内弹窗（确认框 / 提示框），测试不该被模态框卡住。
 
-    StandardButton = QMessageBox.StandardButton
-    Icon = QMessageBox.Icon
+    页面现在用的是 gui.widgets.app_dialog 里那几个函数，不再是 QMessageBox，
+    所以要挡的是这几个名字。确认框一律当成「用户点了确认」。
+    """
+    stack = ExitStack()
+    stack.enter_context(patch("gui.pages.import_page.show_info"))
+    stack.enter_context(patch("gui.pages.import_page.show_warning"))
+    stack.enter_context(patch("gui.pages.import_page.confirm", return_value=True))
+    stack.enter_context(patch("gui.pages.import_page.confirm_destructive", return_value=True))
+    return stack
 
-    @staticmethod
-    def information(*_args, **_kwargs):
-        return QMessageBox.StandardButton.Ok
 
-    @staticmethod
-    def warning(*_args, **_kwargs):
-        return QMessageBox.StandardButton.Ok
-
-    @staticmethod
-    def critical(*_args, **_kwargs):
-        return QMessageBox.StandardButton.Ok
-
-    @staticmethod
-    def question(*_args, **_kwargs):
-        return QMessageBox.StandardButton.Yes
+def _video_plan(frame_interval=5, mode="interval", sample_count=None):
+    """替掉抽帧设置框：直接返回一个抽帧方案，不弹窗。"""
+    return patch(
+        "gui.pages.import_page.ask_video_extract_plan",
+        return_value={
+            'mode': mode,
+            'frame_interval': frame_interval,
+            'sample_count': sample_count,
+        },
+    )
 
 
 def _make_project() -> int:
     return _bootstrap.create_temp_project(name="导入页测试项目", project_type="detect", classes=[])
+
+
+def _make_annotated_project() -> int:
+    """一个已经有标注的项目：导入标注时才会问「要不要覆盖」。"""
+    project_id = _make_project()
+    image_path = _make_images(_TMP_DIR / f"annotated_{project_id}", 1)[0]
+    image_id = db.add_image(
+        project_id=project_id, filename=Path(image_path).name,
+        storage_path=image_path, width=32, height=32,
+    )
+    db.add_annotation(
+        image_id=image_id, project_id=project_id, class_id=0, class_name="人",
+        annotation_type="rectangle", data={'x': 1, 'y': 1, 'width': 5, 'height': 5},
+    )
+    return project_id
 
 
 def _make_images(folder: Path, count: int) -> list:
@@ -114,8 +133,8 @@ def test_video_import_shows_busy_state_within_same_call():
 
     video_path = _make_video(_TMP_DIR / "busy.mp4", frame_count=40)
 
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
-         patch.object(QInputDialog, "getInt", return_value=(5, True)):
+    with _silent_dialogs(), \
+         _video_plan(5):
         page.process_video_import(str(video_path), group_id=None)
 
         # 不经过任何 processEvents，直接检查：必须已经是「导入中」状态
@@ -125,18 +144,20 @@ def test_video_import_shows_busy_state_within_same_call():
         assert "打开视频" in page.import_status_label.text()
         assert page.btn_cancel_import.isHidden() is False
 
-        for button in (
+        # 会再起一个导入的、和会毁掉当前项目的，导入中都不能点。
+        # 后两个现在住在「管理」菜单里，禁的是菜单项本身
+        for control in (
             page.btn_import_folder, page.btn_import_images,
             page.btn_import_video, page.btn_import_annotations,
-            page.btn_delete_project, page.btn_clear,
+            page.action_delete_project, page.action_clear,
         ):
-            assert not button.isEnabled(), f"{button.text()} 导入中应该被禁用"
+            assert not control.isEnabled(), f"{control.text()} 导入中应该被禁用"
 
         _wait_import_done(page)
 
     assert len(page.images) > 0
-    for button in (page.btn_import_folder, page.btn_import_video, page.btn_delete_project):
-        assert button.isEnabled(), "导入结束后按钮应该恢复可用"
+    for control in (page.btn_import_folder, page.btn_import_video, page.action_delete_project):
+        assert control.isEnabled(), "导入结束后应该恢复可用"
 
 
 def test_images_import_shows_determinate_progress_immediately():
@@ -147,7 +168,7 @@ def test_images_import_shows_determinate_progress_immediately():
 
     file_paths = _make_images(_TMP_DIR / "determinate", 5)
 
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox):
+    with _silent_dialogs():
         page.process_image_import(file_paths, group_id=None)
 
         assert page._import_busy is True
@@ -266,7 +287,7 @@ def test_folder_and_images_import_do_not_block_caller_thread():
         time.sleep(0.5)
         return real_import_folder(self, *args, **kwargs)
 
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+    with _silent_dialogs(), \
          patch.object(ImportManager, "import_folder", slow_import_folder):
         start = time.monotonic()
         page.process_folder_import(str(folder), group_id=None)
@@ -308,8 +329,8 @@ def test_unknown_total_frames_video_import_completes_without_crash():
         def release(self):
             self._real.release()
 
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
-         patch.object(QInputDialog, "getInt", return_value=(5, True)), \
+    with _silent_dialogs(), \
+         _video_plan(5), \
          patch("core.import_manager.cv2.VideoCapture", lambda p: _FakeCap(p)):
         page.process_video_import(str(video_path), group_id=None)
         assert page.import_progress_bar.maximum() == 0
@@ -339,7 +360,7 @@ def test_project_switch_keeps_old_thread_alive_until_it_actually_finishes():
         time.sleep(0.3)
         return result
 
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+    with _silent_dialogs(), \
          patch.object(ImportManager, "import_folder", slow_import_folder):
         page.process_folder_import(str(folder), group_id=None)
         old_thread = page._active_import_thread
@@ -370,7 +391,7 @@ def test_normal_cancel_and_failure_paths_all_release_thread_reference():
 
     # 路径一：正常完成
     file_paths = _make_images(_TMP_DIR / "release_normal", 3)
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox):
+    with _silent_dialogs():
         page.process_image_import(file_paths, group_id=None)
         _wait_import_done(page)
         ok = _pump_until(lambda: page._active_import_thread is None and not page._retired_import_threads)
@@ -379,7 +400,7 @@ def test_normal_cancel_and_failure_paths_all_release_thread_reference():
     assert page._retired_import_threads == []
 
     # 路径二：失败（后台抛异常）
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
+    with _silent_dialogs(), \
          patch.object(ImportManager, "import_images", side_effect=RuntimeError("boom")):
         page.process_image_import(file_paths, group_id=None)
         _wait_import_done(page)
@@ -390,8 +411,8 @@ def test_normal_cancel_and_failure_paths_all_release_thread_reference():
 
     # 路径三：取消
     video_path = _make_video(_TMP_DIR / "release_cancel.mp4", frame_count=40)
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
-         patch.object(QInputDialog, "getInt", return_value=(1, True)):
+    with _silent_dialogs(), \
+         _video_plan(1):
         page.process_video_import(str(video_path), group_id=None)
         page._cancel_active_import()
         _wait_import_done(page)
@@ -431,8 +452,8 @@ def test_cancelled_import_progress_bar_is_not_shown_as_full_completion():
         def release(self):
             self._real.release()
 
-    with patch("gui.pages.import_page.QMessageBox", _SilentMessageBox), \
-         patch.object(QInputDialog, "getInt", return_value=(1, True)), \
+    with _silent_dialogs(), \
+         _video_plan(1), \
          patch("core.import_manager.cv2.VideoCapture", lambda p: _SlowCap(p)):
         page.process_video_import(str(video_path), group_id=None)
 
@@ -445,6 +466,232 @@ def test_cancelled_import_progress_bar_is_not_shown_as_full_completion():
     assert "已取消" in page.import_status_label.text()
     assert page.import_progress_bar.value() < 100, "取消后不应该把进度条显示成 100% 完成"
     assert len(page.images) < 40, "取消应该在导完全部帧之前生效"
+
+
+def test_new_project_uses_the_in_app_text_dialog_not_the_system_one():
+    """新建项目不能再弹系统的 QInputDialog：那个框跟原来那个丑抽帧框是同一个模子。"""
+    import gui.pages.import_page as import_page_module
+
+    assert not hasattr(import_page_module, "QInputDialog"), \
+        "导入页不该再依赖系统输入框"
+
+    page = ImportPage()
+    created = []
+    page.projects_changed.connect(created.append)
+
+    asked = {}
+
+    def fake_ask_text(_parent, title, _label, **kwargs):
+        asked['title'] = title
+        asked['confirm_text'] = kwargs.get('confirm_text')
+        return "新的安全帽项目"
+
+    with patch("gui.pages.import_page.ask_text", fake_ask_text), \
+         patch("gui.pages.import_page.ask_task_type", return_value="detect"):
+        page.create_new_project()
+
+    assert asked['title'] == "新建项目"
+    assert asked['confirm_text'] == "创建项目", "确认按钮要说清楚它会干什么"
+
+    assert len(created) == 1, "应该建出一个项目并通知主窗口"
+    project = db.get_project(created[0])
+    assert project['name'] == "新的安全帽项目"
+
+    db.delete_project(created[0])
+
+
+def test_new_project_is_not_created_when_the_name_dialog_is_cancelled():
+    """取消起名字（ask_text 返回 None）就什么都不建。"""
+    page = ImportPage()
+    created = []
+    page.projects_changed.connect(created.append)
+
+    with patch("gui.pages.import_page.ask_text", return_value=None), \
+         patch("gui.pages.import_page.ask_task_type", return_value="detect") as task_type:
+        page.create_new_project()
+
+    assert created == []
+    assert not task_type.called, "名字都没起，不该继续问任务类型"
+
+
+def test_annotation_import_confirmations_use_honest_button_labels():
+    """导入标注这一路上的两个二选一，按钮要照实说，不能都叫「取消」。
+
+    「不覆盖」实际是「保留现有标注」并继续导入，写「取消」会让人以为
+    整个导入都放弃了；「不另选图像文件夹」是「不用」，也不是取消。
+    """
+    project_id = _make_annotated_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    labels_dir = _TMP_DIR / "yolo_labels"
+    labels_dir.mkdir(parents=True, exist_ok=True)
+
+    calls = []
+
+    def record(_parent, title, _message, **kwargs):
+        calls.append((title, kwargs.get('confirm_text'), kwargs.get('cancel_text')))
+        return False  # 两个都选「安全的那一个」
+
+    with _silent_dialogs(), \
+         patch("gui.pages.import_page.confirm", record), \
+         patch("gui.pages.import_page.confirm_destructive", record), \
+         patch("gui.pages.import_page.ask_import_group", return_value=(True, None)), \
+         patch.object(QFileDialog, "getExistingDirectory", return_value=str(labels_dir)):
+        page.import_yolo_annotations(group_id=None)
+        _pump_until(lambda: not hasattr(page, 'loading_overlay'), timeout=10.0)
+
+    titles = {title: (confirm_text, cancel_text) for title, confirm_text, cancel_text in calls}
+
+    assert "图像文件夹" in titles, calls
+    assert titles["图像文件夹"] == ("去选择", "不用"), titles["图像文件夹"]
+
+    assert "覆盖已有标注" in titles, calls
+    assert titles["覆盖已有标注"] == ("覆盖", "保留现有标注"), titles["覆盖已有标注"]
+
+    for _title, _confirm_text, cancel_text in calls:
+        assert cancel_text != "取消", f"「{_title}」的安全按钮不该笼统叫「取消」"
+
+    db.delete_project(project_id)
+
+
+# ==================== 工具栏胶囊 / 管理菜单的状态 ====================
+
+def _seed_images(project_id, count=3):
+    for i in range(count):
+        db.add_image(project_id, f"seed_{i}.jpg", f"/tmp/seed_{i}.jpg", width=32, height=32)
+
+
+def test_task_chip_shows_the_short_chinese_label_only():
+    """工具栏胶囊只写中文：「任务：目标检测」，不再拖一个 detect 的尾巴。
+
+    共用的任务类型对话框仍然显示带英文的完整标签——那里 detect / segment
+    要和 YOLO 的术语对得上，是有用的；在胶囊上它只是把宽度撑长。
+    """
+    from gui.widgets.task_type_dialog import task_type_label
+
+    assert short_task_label('detect') == "目标检测"
+    assert short_task_label('segment') == "实例分割"
+    assert short_task_label(None) == "未设置"
+
+    # 对话框那份标签没被改动
+    assert task_type_label('detect') == "目标检测 detect"
+
+    project_id = _make_project()
+    page = ImportPage()
+    page.set_project(project_id)
+
+    assert page.btn_task_type.text() == "任务：目标检测", page.btn_task_type.text()
+
+    db.delete_project(project_id)
+
+
+def test_selection_actions_are_disabled_until_something_is_selected():
+    """没选图片时「移动分组 / 删除选中」就该是灰的。
+
+    以前它们一直亮着，点下去只弹一句「还没选图片」——用一个弹窗代替了
+    本来一眼就该看出来的状态。
+    """
+    project_id = _make_project()
+    _seed_images(project_id, 3)
+
+    page = ImportPage()
+    page.set_project(project_id)
+    _app.processEvents()
+
+    assert not page.action_move_group.isEnabled(), "没选图片，移动分组不该能点"
+    assert not page.action_delete_selected.isEnabled(), "没选图片，删除选中不该能点"
+
+    page.image_list.item(0).setSelected(True)
+    _app.processEvents()
+
+    assert page.action_move_group.isEnabled(), "选了图片就该能移动分组"
+    assert page.action_delete_selected.isEnabled(), "选了图片就该能删除选中"
+
+    page.image_list.clearSelection()
+    _app.processEvents()
+
+    assert not page.action_move_group.isEnabled(), "取消选中之后要变回灰的"
+    assert not page.action_delete_selected.isEnabled()
+
+    page.stop_image_loading()
+    db.delete_project(project_id)
+
+
+def test_menu_recomputes_state_when_it_opens():
+    """菜单弹出前重算一次：选中状态可能是在菜单关着的时候变的。"""
+    project_id = _make_project()
+    _seed_images(project_id, 2)
+
+    page = ImportPage()
+    page.set_project(project_id)
+    _app.processEvents()
+
+    # 绕过信号，直接把选中状态做出来——模拟「菜单不知道的变化」
+    page.action_move_group.setEnabled(False)
+    page.image_list.item(0).setSelected(True)
+    page.action_move_group.setEnabled(False)
+
+    page.manage_menu.aboutToShow.emit()
+
+    assert page.action_move_group.isEnabled(), "菜单打开时应该重算可用性"
+
+    page.stop_image_loading()
+    db.delete_project(project_id)
+
+
+def test_clear_all_is_disabled_when_there_is_nothing_to_clear():
+    """项目里没有图片时「清空全部图片」是灰的；有图片才亮。"""
+    project_id = _make_project()
+
+    page = ImportPage()
+    page.set_project(project_id)
+    _app.processEvents()
+
+    assert not page.action_clear.isEnabled(), "没有图片就没有东西可清空"
+    # 项目本身还是删得掉的
+    assert page.action_delete_project.isEnabled()
+
+    _seed_images(project_id, 2)
+    page.load_project_images()
+    _app.processEvents()
+
+    assert page.action_clear.isEnabled(), "有图片了就该能清空"
+
+    page.stop_image_loading()
+    db.delete_project(project_id)
+
+
+def test_import_busy_blocks_destruction_but_still_allows_moving_selected_images():
+    """导入中：清空 / 删除项目一律关掉；已选中图片的移动、删除照常可用。
+
+    正在往项目里写图片的时候不能把项目端了；但对已有图片的操作没有理由禁掉。
+    """
+    project_id = _make_project()
+    _seed_images(project_id, 3)
+
+    page = ImportPage()
+    page.set_project(project_id)
+    _app.processEvents()
+
+    page.image_list.item(0).setSelected(True)
+    _app.processEvents()
+
+    page._start_import_ui("正在导入…")
+
+    assert not page.action_clear.isEnabled(), "导入中不能清空图片"
+    assert not page.action_delete_project.isEnabled(), "导入中不能删除项目"
+    assert page.action_move_group.isEnabled(), "导入中仍然可以移动已选中的图片"
+    assert page.action_delete_selected.isEnabled(), "导入中仍然可以删除已选中的图片"
+
+    page._end_import_ui()
+    _app.processEvents()
+
+    assert page.action_clear.isEnabled(), "导入结束后要恢复"
+    assert page.action_delete_project.isEnabled()
+
+    page.stop_image_loading()
+    db.delete_project(project_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_layout_resilience.py
+++ b/tests/test_layout_resilience.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+"""布局韧性回归：三种支持尺寸下，控件不许被自己的样式或写死的数字挤坏。
+
+test_ui_layout.py 只问「文字有没有超出盒子」，问不到三件事：
+
+  1. 带下拉菜单的 QToolButton，右边那 24px 菜单区是画在按钮里面的——
+     文字宽度没超过按钮宽度，却已经压到箭头底下了。
+  2. setFixedHeight(32) 把高度钉死。开发机的字体正好装得下，换一台
+     字体度量更高的 macOS / Windows 就是纵向切字，而且怎么改字号都不动。
+  3. 导入页缩略图网格的 gridSize 是写死的 184px。视口宽度不是它的整数倍时，
+     右边永远剩一条放不下第五列的空带——用户看到的就是「幽灵列」。
+
+    python tests/test_layout_resilience.py
+    python -m pytest tests/test_layout_resilience.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from PyQt6.QtCore import Qt  # noqa: E402
+from PyQt6.QtGui import QColor, QImage  # noqa: E402
+from PyQt6.QtWidgets import (  # noqa: E402
+    QWIDGETSIZE_MAX,
+    QAbstractButton,
+    QListWidget,
+    QStyle,
+    QStyleOptionToolButton,
+    QToolButton,
+)
+
+from gui.main_window import MainWindow  # noqa: E402
+from gui.pages.import_page import _ResponsiveThumbnailGrid  # noqa: E402
+from gui.workflow import STEP_ANNOTATE, STEP_IMPORT  # noqa: E402
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+# 最小支持尺寸、用户报缺口的那台机器、14 寸笔记本
+SIZES = ((1100, 720), (1182, 752), (1470, 832))
+REPORTED_SIZE = (1182, 752)
+
+# 胶囊按钮的内边距契约（见 annotate_page._toolbar_chip_style: padding 4px 10px）：
+# 文字左边 10px，右边至少同样的 10px 才不会贴着菜单区；再留 6px 给字体度量的机器差异。
+LEFT_PADDING = 10
+RIGHT_BREATHING = 10
+SAFETY = 6
+
+MIN_CONTROL_HEIGHT = 32
+# 一行字上下各留 6px，才不会顶着边框
+TEXT_VERTICAL_PADDING = 12
+
+# 缩略图网格：一格允许在这个区间里随视口伸缩，但不许退回一个写死的数字
+GRID_WIDTH_RANGE = (156, 220)
+ICON_WIDTH_RANGE = (120, 160)
+# 完整列排完之后，右边最多只准剩这么点边距
+MAX_UNUSED_WIDTH = 12
+
+_IMAGE_TEMP_DIR = tempfile.TemporaryDirectory(prefix="ezyolo-resilience-")
+_IMAGE_DIR = Path(_IMAGE_TEMP_DIR.name)
+
+
+def _settle(rounds=5):
+    for _ in range(rounds):
+        _app.processEvents()
+
+
+def _temp_image() -> Path:
+    """一张临时 JPEG。数据库里每条记录文件名不同，但都指向它。"""
+    path = _IMAGE_DIR / "resilience.jpg"
+    if not path.exists():
+        image = QImage(320, 240, QImage.Format.Format_RGB888)
+        image.fill(QColor(120, 120, 130))
+        image.save(str(path))
+    return path
+
+
+def _seed_project(image_count: int) -> int:
+    project_id = _bootstrap.create_temp_project(
+        name="布局韧性测试项目",
+        project_type="detect",
+        classes=[{'id': 0, 'name': '猫', 'color': '#FF3B30'}],
+    )
+    path = _temp_image()
+    for index in range(image_count):
+        db.add_image(
+            project_id, f"resilience-{index:03d}.jpg", str(path), width=320, height=240
+        )
+    return project_id
+
+
+def _open_window(project_id: int, page_index: int, size) -> MainWindow:
+    from gui import main_window as main_window_module
+    main_window_module.db = db
+
+    window = MainWindow()
+    window.load_projects(select_id=project_id)
+    window.resize(*size)
+    window.show()
+    window.switch_page(page_index)
+    _settle()
+    return window
+
+
+def _wait_for_thumbnails(page, timeout=10.0):
+    """等缩略图后台线程跑完——网格尺寸要在图标真的进去之后才量。"""
+    deadline = time.monotonic() + timeout
+    while getattr(page, 'load_worker', None) is not None and time.monotonic() < deadline:
+        _app.processEvents()
+    _settle()
+
+
+def _describe(button) -> str:
+    return f"{type(button).__name__}({button.text()!r}, {button.width()}x{button.height()})"
+
+
+def _menu_rect_width(button) -> int:
+    """按钮自己那套样式里，下拉菜单区实际占了多宽——不猜，问 style。"""
+    option = QStyleOptionToolButton()
+    button.initStyleOption(option)
+    rect = button.style().subControlRect(
+        QStyle.ComplexControl.CC_ToolButton,
+        option,
+        QStyle.SubControl.SC_ToolButtonMenu,
+        button,
+    )
+    return rect.width()
+
+
+def _menu_buttons(page):
+    return [
+        button for button in page.findChildren(QToolButton)
+        if button.isVisible() and button.menu() is not None and button.text().strip()
+    ]
+
+
+def _split_button_problems(page, size, task_type):
+    problems = []
+    for button in _menu_buttons(page):
+        metrics = button.fontMetrics()
+        text_width = metrics.horizontalAdvance(button.text())
+        menu_width = _menu_rect_width(button)
+        needed_width = text_width + menu_width + LEFT_PADDING + RIGHT_BREATHING + SAFETY
+        if button.width() < needed_width:
+            problems.append(
+                f"[{size}/{task_type}] {_describe(button)} 的文字压进了下拉区："
+                f"文字 {text_width}px + 菜单 {menu_width}px + 左内边距 {LEFT_PADDING}px "
+                f"+ 右侧留白 {RIGHT_BREATHING}px + 余量 {SAFETY}px = {needed_width}px，"
+                f"按钮只有 {button.width()}px"
+            )
+
+        needed_height = max(
+            MIN_CONTROL_HEIGHT,
+            button.sizeHint().height(),
+            metrics.height() + TEXT_VERTICAL_PADDING,
+        )
+        if button.height() < needed_height:
+            problems.append(
+                f"[{size}/{task_type}] {_describe(button)} 高度不足："
+                f"需要 {needed_height}px，只有 {button.height()}px"
+            )
+    return problems
+
+
+def test_split_menu_buttons_reserve_space_for_their_arrow():
+    """带下拉的工具按钮，文字不许伸进右边的菜单区。
+
+    「画方框」「画多边形」的宽度目前是「文字 + 48」拍出来的：菜单区自己就要 24px，
+    剩下 24px 要分给左右两边的内边距——右边只剩 0。文字没有超出按钮边框，所以
+    旧的切字检查看不见它；用户看见的是文字直接顶在下拉箭头上。
+    """
+    project_id = _seed_project(3)
+    try:
+        problems = []
+        for size in SIZES:
+            window = _open_window(project_id, STEP_ANNOTATE, size)
+            try:
+                page = window.annotate_page
+                # detect → 画方框，segment → 画多边形，两个标签都得量到
+                for task_type in ("detect", "segment"):
+                    page.task_combo.setCurrentText(task_type)
+                    _settle()
+                    assert page.btn_draw_tool.isVisible(), f"[{size}/{task_type}] 绘制工具应该显示"
+                    buttons = _menu_buttons(page)
+                    assert page.btn_draw_tool in buttons and page.btn_delete in buttons, (
+                        f"[{size}/{task_type}] 没量到带菜单的工具按钮：{[b.text() for b in buttons]}"
+                    )
+                    problems += _split_button_problems(page, size, task_type)
+            finally:
+                window.close()
+
+        assert not problems, "下拉按钮的文字压住了箭头:\n" + "\n".join(problems)
+    finally:
+        db.delete_project(project_id)
+
+
+def test_topbar_controls_are_not_height_locked():
+    """顶栏控件的高度必须是「至少 32」，不能是「正好 32」。
+
+    setFixedHeight(32) 在开发机上看着没问题，是因为这台机器的字体正好塞得进去。
+    换一台字形更高的 macOS / Windows，同一行字要 34~36px，控件却被钉死在 32——
+    上下各切掉一点，而且改字号也救不回来。最大高度必须留空。
+    """
+    project_id = _seed_project(3)
+    window = None
+    try:
+        window = _open_window(project_id, STEP_ANNOTATE, REPORTED_SIZE)
+        page = window.annotate_page
+
+        targets = [
+            ("当前图片标签", page.image_name_label),
+            ("标注方式下拉", page.task_combo),
+            ("工具栏容器", page.toolbar),
+        ]
+        visible_buttons = [button for button in page.toolbar_buttons if button.isVisible()]
+        targets += [
+            (f"工具按钮 {button.text()!r}", button)
+            for button in visible_buttons
+        ]
+
+        problems = []
+        for label, widget in targets:
+            if widget.maximumHeight() != QWIDGETSIZE_MAX:
+                problems.append(
+                    f"{label} 的高度被钉死了：maximumHeight={widget.maximumHeight()}"
+                    f"（应为 QWIDGETSIZE_MAX，高度得能跟着字体长）"
+                )
+            # QStyleSheetStyle 会把控件属性里的 minimumHeight 显示成样式表盒模型的
+            # 下限（QComboBox 在 macOS 上会报 30），但它的 minimumSizeHint 已经按
+            # 字体、内边距和边框算出 33px。真正决定布局能不能压扁它的是两者较大值。
+            effective_minimum = max(widget.minimumHeight(), widget.minimumSizeHint().height())
+            if effective_minimum < MIN_CONTROL_HEIGHT:
+                problems.append(
+                    f"{label} 的有效最小高度只有 {effective_minimum}px，"
+                    f"点击区应该至少 {MIN_CONTROL_HEIGHT}px"
+                )
+            if widget.height() < effective_minimum:
+                problems.append(
+                    f"{label} 实际只有 {widget.height()}px，低于有效最小高度 "
+                    f"{effective_minimum}px"
+                )
+
+        button_height = max(button.height() for button in visible_buttons)
+        expected_separator_height = max(1, button_height - 8)
+        if page.toolbar_separator.height() != expected_separator_height:
+            problems.append(
+                f"工具栏分隔线高度 {page.toolbar_separator.height()}px 没跟着按钮 "
+                f"{button_height}px 变化（应为 {expected_separator_height}px）"
+            )
+
+        assert not problems, "顶栏控件的高度写死了:\n" + "\n".join(problems)
+    finally:
+        if window is not None:
+            window.close()
+        db.delete_project(project_id)
+
+
+def _grid_problems(page, size):
+    """网格必须把视口宽度用满：完整列排完之后不许剩下一条放不下下一列的空带。"""
+    grid = page.image_list.gridSize()
+    viewport_width = page.image_list.viewport().width()
+    problems = []
+
+    if grid.width() <= 0:
+        problems.append(f"[{size}] gridSize 宽度是 {grid.width()}，网格没有生效")
+        return problems, 0, grid.width()
+
+    columns = viewport_width // grid.width()
+    unused = viewport_width - columns * grid.width()
+
+    horizontal_max = page.image_list.horizontalScrollBar().maximum()
+    if horizontal_max != 0:
+        problems.append(
+            f"[{size}] 缩略图网格出现横向滚动：maximum={horizontal_max}（应为 0）"
+        )
+
+    if unused > MAX_UNUSED_WIDTH:
+        problems.append(
+            f"[{size}] 网格右边空了 {unused}px 放不下一列（视口 {viewport_width}px，"
+            f"一格 {grid.width()}px，排了 {columns} 列）——这就是用户看到的幽灵列"
+        )
+
+    if viewport_width >= GRID_WIDTH_RANGE[0] * 3:
+        if not (GRID_WIDTH_RANGE[0] <= grid.width() <= GRID_WIDTH_RANGE[1]):
+            problems.append(
+                f"[{size}] 一格宽 {grid.width()}px，超出了 "
+                f"{GRID_WIDTH_RANGE[0]}~{GRID_WIDTH_RANGE[1]}px 的合理区间"
+            )
+
+    icon_width = page.image_list.iconSize().width()
+    if not (ICON_WIDTH_RANGE[0] <= icon_width <= ICON_WIDTH_RANGE[1]):
+        problems.append(
+            f"[{size}] 缩略图宽 {icon_width}px，超出了 "
+            f"{ICON_WIDTH_RANGE[0]}~{ICON_WIDTH_RANGE[1]}px 的合理区间"
+        )
+
+    return problems, columns, grid.width()
+
+
+def test_import_grid_fills_the_viewport_at_every_size():
+    """导入页缩略图网格跟着视口走，不留幽灵列。
+
+    gridSize 现在是写死的 184x208。1182px 宽的窗口里，视口宽度不是 184 的整数倍，
+    右边剩下的那条空带装不下第五列——用户看到的就是「有位置却不放图」。
+    """
+    project_id = _seed_project(48)  # 足够多，纵向滚动条一定出来
+    window = None
+    try:
+        window = _open_window(project_id, STEP_IMPORT, SIZES[0])
+        page = window.import_page
+        _wait_for_thumbnails(page)
+
+        problems = []
+        layouts = {}
+        for size in SIZES:
+            window.resize(*size)
+            _settle()
+            _wait_for_thumbnails(page)
+
+            assert page.image_list.isVisible(), f"[{size}] 缩略图网格应该显示"
+            assert page.image_list.verticalScrollBar().maximum() > 0, (
+                f"[{size}] 图片没多到需要纵向滚动，这一条没测到东西"
+            )
+
+            size_problems, columns, grid_width = _grid_problems(page, size)
+            problems += size_problems
+            layouts[size] = (grid_width, columns)
+
+            if size == REPORTED_SIZE and columns < 5:
+                problems.append(
+                    f"[{size}] 只排了 {columns} 列（视口 "
+                    f"{page.image_list.viewport().width()}px），至少应该排下 5 列"
+                )
+
+        # 窗口一变宽，网格必须有反应——要么格子变宽，要么多排一列
+        if len(set(layouts.values())) <= 1:
+            problems.append(
+                f"窗口从 {SIZES[0]} 拉到 {SIZES[-1]}，网格纹丝不动：{layouts}"
+            )
+
+        assert not problems, "导入页缩略图网格没有跟着视口走:\n" + "\n".join(problems)
+    finally:
+        if window is not None:
+            window.close()
+        db.delete_project(project_id)
+
+
+def test_import_grid_reacts_when_only_the_viewport_width_changes():
+    """滚动条或系统边距只改 viewport 时，也要立刻重排，不必拖动主窗口。
+
+    setViewportMargins 模拟 Windows 常驻滚动条占掉一条宽度：外层列表尺寸不变，
+    只有内部 viewport 变窄。QAbstractScrollArea 会把这种变化送进 resizeEvent，
+    响应式网格必须重新计算格宽，避免旧列数突然掉一列后留下大空带。
+    """
+    grid = _ResponsiveThumbnailGrid()
+    try:
+        grid.setViewMode(QListWidget.ViewMode.IconMode)
+        grid.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        grid.resize(890, 500)
+        grid.show()
+        _settle()
+
+        outer_width = grid.width()
+        viewport_before = grid.viewport().width()
+        grid_before = grid.gridSize().width()
+
+        grid.setViewportMargins(0, 0, 18, 0)
+        _settle()
+
+        viewport_after = grid.viewport().width()
+        grid_after = grid.gridSize().width()
+        assert grid.width() == outer_width, "这个测试只该改变 viewport，不该改变外层列表"
+        assert viewport_after == viewport_before - 18, (
+            f"viewport 没按预期缩小 18px：{viewport_before} -> {viewport_after}"
+        )
+        assert grid_after != grid_before, (
+            f"viewport 已变窄，格宽却还停在 {grid_before}px，没有重新计算"
+        )
+
+        columns = viewport_after // grid_after
+        unused = viewport_after - columns * grid_after
+        assert unused <= MAX_UNUSED_WIDTH, (
+            f"viewport 单独变窄后又出现 {unused}px 幽灵空带"
+        )
+    finally:
+        grid.close()
+
+
+def _text_button_problems(page, size, page_name):
+    """所有带文字的按钮（不只是 QPushButton）都得装得下自己的文字。
+
+    旧的切字检查只找 QLabel 和 QPushButton——QToolButton 不是 QPushButton 的子类，
+    整条工具栏都在检查范围之外。这里按 QAbstractButton 扫，把那个盲区堵上。
+    """
+    problems = []
+    checked = 0
+    for button in page.findChildren(QAbstractButton):
+        if not button.isVisible() or button.width() <= 0 or button.height() <= 0:
+            continue
+        text = button.text()
+        if not text.strip():
+            continue
+        checked += 1
+
+        metrics = button.fontMetrics()
+        if button.height() < metrics.height():
+            problems.append(
+                f"[{size}/{page_name}] {_describe(button)} 纵向切字："
+                f"一行字要 {metrics.height()}px，按钮只有 {button.height()}px"
+            )
+        needed_width = button.minimumSizeHint().width()
+        if button.width() < needed_width:
+            problems.append(
+                f"[{size}/{page_name}] {_describe(button)} 横向切字："
+                f"最小需要 {needed_width}px，按钮只有 {button.width()}px"
+            )
+    if checked == 0:
+        problems.append(f"[{size}/{page_name}] 没找到任何可见文字按钮，检查可能空跑")
+    return problems
+
+
+def test_every_text_bearing_button_fits_its_text():
+    """导入页和标注页上每个有文字的按钮，横竖都装得下自己的文字。"""
+    project_id = _seed_project(6)
+    try:
+        problems = []
+        for size in SIZES:
+            window = _open_window(project_id, STEP_IMPORT, size)
+            try:
+                _wait_for_thumbnails(window.import_page)
+                problems += _text_button_problems(window.import_page, size, "导入页")
+
+                window.switch_page(STEP_ANNOTATE)
+                _settle()
+                problems += _text_button_problems(window.annotate_page, size, "标注页")
+            finally:
+                window.close()
+
+        assert not problems, "有按钮装不下自己的文字:\n" + "\n".join(problems)
+    finally:
+        db.delete_project(project_id)
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_menu_arrow_styles.py
+++ b/tests/test_menu_arrow_styles.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""菜单按钮必须使用项目自己的向下箭头，不能退回 Qt 原生指示器。
+
+    python tests/test_menu_arrow_styles.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import re
+import sys
+from pathlib import Path
+
+from PyQt6.QtWidgets import QPushButton  # noqa: E402
+
+from gui.main_window import MainWindow  # noqa: E402
+from gui.pages.auto_label_dialog import AutoLabelDialog  # noqa: E402
+from gui.styles import COLORS, generate_stylesheet  # noqa: E402
+
+_app = _bootstrap.app()
+_ASSETS_DIR = Path(__file__).parent.parent / "gui" / "assets"
+
+
+def _make_window():
+    from gui import main_window as main_window_module
+    main_window_module.db = _bootstrap.db
+    return MainWindow()
+
+
+def test_menu_chevron_assets_and_global_qss_are_explicit():
+    expected_colors = {
+        "chevron_down.svg": "#007AFF",
+        "chevron_down_disabled.svg": "#AEAEB2",
+        "chevron_down_white.svg": "#FFFFFF",
+        "chevron_down_red.svg": "#D70015",
+    }
+    for name, color in expected_colors.items():
+        asset = _ASSETS_DIR / name
+        assert asset.is_file(), name
+        svg = asset.read_text(encoding="utf-8")
+        assert 'width="12" height="12"' in svg
+        assert 'stroke-width="1.6"' in svg
+        assert f'stroke="{color}"' in svg
+
+    stylesheet = generate_stylesheet(COLORS)
+    assert 'QPushButton[menuIndicator="true"]' in stylesheet
+    assert 'padding-right: 32px;' in stylesheet
+    assert 'QPushButton#primary[menuIndicator="true"]::menu-indicator' in stylesheet
+    assert 'chevron_down.svg' in stylesheet
+    assert 'chevron_down_white.svg' in stylesheet
+    assert 'chevron_down_disabled.svg' in stylesheet
+    assert not re.search(r"^\s*QPushButton::menu-indicator", stylesheet, re.MULTILINE)
+
+
+def test_all_menu_pushbuttons_are_marked_and_sam_refreshes_dynamically():
+    window = _make_window()
+    try:
+        annotate = window.annotate_page
+        train = window.train_page
+        result = window.result_page
+
+        expected = {
+            annotate.btn_auto_label,
+            annotate.btn_llm_label,
+            train.btn_template_menu,
+            result.btn_export_model,
+        }
+        assert all(button.menu() is not None for button in expected)
+        assert all(button.property("menuIndicator") is True for button in expected)
+
+        original_method = AutoLabelDialog.__dict__["get_saved_sam_config"]
+        AutoLabelDialog.get_saved_sam_config = classmethod(
+            lambda cls: {"sam_type": "SAM2", "usage_mode": "memory"}
+        )
+        try:
+            annotate.apply_sam_button_mode()
+            assert annotate.btn_sam.menu() is not None
+            assert annotate.btn_sam.property("menuIndicator") is True
+        finally:
+            AutoLabelDialog.get_saved_sam_config = original_method
+
+        AutoLabelDialog.get_saved_sam_config = classmethod(
+            lambda cls: {"sam_type": "SAM", "usage_mode": "normal"}
+        )
+        try:
+            annotate.apply_sam_button_mode()
+            assert annotate.btn_sam.menu() is None
+            assert annotate.btn_sam.property("menuIndicator") is False
+        finally:
+            AutoLabelDialog.get_saved_sam_config = original_method
+
+        for button in window.findChildren(QPushButton):
+            if button.menu() is not None:
+                assert button.property("menuIndicator") is True, button.text()
+    finally:
+        window.close()
+
+
+def test_annotate_tool_menu_arrows_have_roles_and_space():
+    window = _make_window()
+    try:
+        annotate = window.annotate_page
+        draw_style = annotate.btn_draw_tool.styleSheet()
+        delete_style = annotate.btn_delete.styleSheet()
+
+        assert annotate.btn_draw_tool.menu() is not None
+        assert annotate.btn_delete.menu() is not None
+        assert 'QToolButton::menu-arrow' in draw_style
+        assert 'QToolButton::menu-indicator' in draw_style
+        assert 'chevron_down.svg' in draw_style
+        assert 'chevron_down_disabled.svg' in draw_style
+        assert 'width: 24px;' in draw_style
+        assert 'width: 12px;' in draw_style
+        assert 'background-color: #FFFFFF;' in draw_style
+
+        assert 'QToolButton::menu-arrow' in delete_style
+        assert 'QToolButton::menu-indicator' in delete_style
+        assert 'chevron_down_red.svg' in delete_style
+        assert 'chevron_down_disabled.svg' in delete_style
+        assert 'width: 24px;' in delete_style
+        assert 'width: 12px;' in delete_style
+
+        for button in (annotate.btn_draw_tool, annotate.btn_delete):
+            assert button.width() >= button.minimumSizeHint().width()
+    finally:
+        window.close()
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+"""导航与配置入口：界面上写着「去别处配置」的地方，必须真的能点开配置。
+
+死文字（「配置入口在数据标注 → 自动标注」）不算入口：用户还得自己找。
+这里查的是三件事——
+  1. 设置页有一个真按钮，点了会请求打开自动标注配置；
+  2. 主窗口接住这个请求，真的把 AutoLabelDialog 开出来，关掉后刷新状态；
+  3. 标注页缺 SAM / 缺 API Key 时给的是「去配置」动作，不是一段路径说明。
+
+    python tests/test_navigation.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+
+from PyQt6.QtCore import QTimer  # noqa: E402
+from PyQt6.QtWidgets import QPushButton, QMessageBox, QDialog  # noqa: E402
+
+from gui.workflow import PAGE_SETTINGS  # noqa: E402
+from gui.main_window import MainWindow  # noqa: E402
+from gui.pages import annotate_page as annotate_module  # noqa: E402
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+# 兜底：模态窗的 exec() 会自己开一个事件循环，没人点就永远不返回——测试直接挂死，
+# 只能靠外面 kill。所以留一个定时器在（模态自己的事件循环里也照样跑）：真有窗弹出来
+# 就当场关掉、记一笔，最后由 test_zz_* 报错。测试是失败，不是卡住。
+ESCAPED_MODALS = []
+
+
+def _sweep_modals():
+    widget = _app.activeModalWidget()
+    if widget is not None:
+        ESCAPED_MODALS.append(type(widget).__name__)
+        widget.close()
+
+
+_watchdog = QTimer()
+_watchdog.timeout.connect(_sweep_modals)
+_watchdog.start(200)
+
+
+def make_window() -> MainWindow:
+    """建一个窗口，并且把「真的会弹出模态窗」的那一个出口堵上。
+
+    设置页的按钮是真按钮：点下去信号会一路走到 MainWindow.open_auto_label_config，
+    再到标注页把 AutoLabelDialog.exec() 开出来。离屏跑测试时那个模态窗没人点，
+    exec() 就永远不返回——测试挂死。所以这里统一换成替身：只记「请求打开哪一页」，
+    不开窗。要验证「窗口层真的会把对话框开出来」的测试自己再换一个更细的替身
+    （见 test_main_window_opens_the_config_dialog_and_refreshes_status）。
+
+    返回 (window, opened)，opened 里是被请求打开的 section 列表。
+    """
+    from gui import main_window as mw
+    mw.db = db
+    window = MainWindow()
+
+    opened = []
+    window.annotate_page.open_auto_label_config = (
+        lambda section="": (opened.append(section), False)[1]
+    )
+    return window, opened
+
+
+def test_settings_page_has_a_real_config_button():
+    """「AI 与自动标注」里必须有能点的入口按钮，而不只是一句说明。"""
+    window, _ = make_window()
+    page = window.settings_page
+
+    labels = [
+        btn.text() for btn in page.findChildren(QPushButton)
+        if btn.text().strip()
+    ]
+    assert "打开自动标注配置" in labels, f"设置页没有配置入口按钮，只有: {labels}"
+
+    window.close()
+
+
+def test_settings_buttons_emit_config_request():
+    """三个入口按钮分别请求打开：默认页 / SAM / LLM，并且请求真的送到了窗口层。
+
+    只断言信号还不够——信号没人接也一样过。所以同时看替身收到了什么：
+    按钮 → 信号 → MainWindow → 标注页的配置窗口，这条线整条都得通。
+    """
+    window, opened = make_window()
+    page = window.settings_page
+
+    requested = []
+    page.auto_label_config_requested.connect(requested.append)
+
+    page.btn_open_auto_label.click()
+    page.btn_config_sam.click()
+    page.btn_config_llm.click()
+
+    assert requested == ['', 'sam', 'llm'], requested
+    assert opened == ['', 'sam', 'llm'], f"请求没走到标注页的配置窗口: {opened}"
+
+    window.close()
+
+
+def test_settings_status_refreshes_after_config_closes():
+    """配置窗口一关，设置页显示的 SAM / LLM 状态必须重新读一遍。
+
+    否则用户刚配好，回到设置页看到的还是「还没配置过」。
+    """
+    window, _ = make_window()
+
+    refreshed = []
+    window.settings_page.refresh_ai_status = lambda: refreshed.append(True)
+
+    window.settings_page.btn_config_sam.click()
+
+    assert refreshed, "配置窗口关掉之后没有刷新设置页的状态"
+
+    window.close()
+
+
+def test_config_entry_works_without_a_project():
+    """没有项目也要能配 SAM / LLM——配置是全局文件，不该被「先建项目」挡住。"""
+    window, opened = make_window()
+    window.current_project_id = None
+
+    window.settings_page.btn_config_llm.click()
+
+    assert opened == ['llm'], f"没有项目时配置入口被挡住了: {opened}"
+
+    window.close()
+
+
+def test_main_window_opens_the_config_dialog_and_refreshes_status():
+    """点设置页的按钮 → 主窗口真的把配置对话框开出来，关掉之后刷新 SAM/LLM 状态。
+
+    这个测试要验证的正是 make_window() 堵掉的那一段，所以把真的
+    open_auto_label_config 还回来，只把最里面那层模态 exec() 换成替身
+    （PyQt 的类方法改不动，实例属性可以）：不弹窗，只确认「开的是哪一个
+    对话框、落在哪一页」。exec() 立刻返回 Rejected，测试不会等任何人点。
+    """
+    window, _ = make_window()
+    del window.annotate_page.open_auto_label_config  # 恢复类上的真实现
+
+    window.switch_page(PAGE_SETTINGS)
+    _app.processEvents()
+
+    page = window.annotate_page
+    page.init_auto_label_components()
+    dialog = page.auto_label_dialog
+
+    opened = {}
+
+    def fake_exec():
+        opened['tab'] = dialog.tab_widget.currentIndex()
+        opened['dialog'] = type(dialog).__name__
+        return QDialog.DialogCode.Rejected
+
+    dialog.exec = fake_exec
+
+    refreshed = []
+    original_refresh = window.settings_page.refresh_ai_status
+
+    def counting_refresh():
+        refreshed.append(True)
+        original_refresh()
+
+    window.settings_page.refresh_ai_status = counting_refresh
+
+    window.settings_page.btn_config_llm.click()
+
+    assert opened.get('dialog') == 'AutoLabelDialog', opened
+    assert opened.get('tab') == 2, f"LLM 入口应该直接落在 LLM 视觉那一页，实际 {opened.get('tab')}"
+    assert refreshed, "配置窗口关掉之后没有重新读一次 SAM/LLM 状态"
+
+    # 入口靠信号 + 主窗口胶水连起来：用户不用先被扔到标注页去找按钮
+    assert window.content_stack.currentWidget() is window.settings_page
+
+    window.close()
+
+
+class _ConfigClickingBox(QMessageBox):
+    """替身提示框：直接点掉「去配置」，测试里不需要真人点。"""
+
+    seen = {}
+
+    def exec(self):
+        _ConfigClickingBox.seen = {
+            'text': self.text(),
+            'buttons': [b.text() for b in self.buttons()],
+        }
+        for button in self.buttons():
+            if "配置" in button.text():
+                self._picked = button
+                return 0
+        self._picked = None
+        return 0
+
+    def clickedButton(self):
+        return self._picked
+
+
+def test_missing_sam_offers_a_config_action():
+    """SAM 没配置时，给的是「去配置」按钮，而且点了真的开配置窗口的 SAM 页。"""
+    window, calls = make_window()
+    page = window.annotate_page
+
+    original_box = annotate_module.QMessageBox
+    annotate_module.QMessageBox = _ConfigClickingBox
+    try:
+        page._offer_auto_label_config(
+            "还没配置 SAM 模型", "SAM 交互分割要先选好分割模型和权重文件。", 'sam'
+        )
+    finally:
+        annotate_module.QMessageBox = original_box
+
+    seen = _ConfigClickingBox.seen
+    assert any("配置" in text for text in seen.get('buttons', [])), seen
+    assert calls == ['sam'], f"点「去配置」应该打开 SAM 那一页，实际: {calls}"
+    # 提示里不再只是甩一句「点击: 自动标注 → 设置 → …」的路径
+    assert "点击:" not in seen.get('text', '')
+
+    window.close()
+
+
+def test_missing_llm_key_offers_a_config_action():
+    """没填 API Key 时，_require_llm_config 给的是配置入口，而不是一句说明就完事。"""
+    window, _ = make_window()
+    page = window.annotate_page
+
+    page._load_llm_config = staticmethod(lambda: {'api_key': '', 'model_name': ''})
+
+    offered = []
+
+    def fake_offer(title, message, section):
+        offered.append(section)
+        return False  # 用户点了取消
+
+    page._offer_auto_label_config = fake_offer
+
+    assert page._require_llm_config() is None
+    assert offered == ['llm'], offered
+
+    window.close()
+
+
+def test_zz_no_real_modal_window_was_opened():
+    """整个文件跑下来，一个真的模态窗都不该被打开过。
+
+    名字带 zz 是为了排在最后：前面的测试都跑完，看板才有意义。
+    """
+    assert not ESCAPED_MODALS, (
+        f"有真模态窗被打开了（已被兜底关掉，否则测试会挂死）: {ESCAPED_MODALS}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""快捷键：设置页收得下的键，消费端就必须认得。
+
+以前设置页会老老实实存下 DELETE / SPACE / 方向键并显示「已经生效」，
+可消费端比的是 event.text()——这几个键根本没有可打印字符
+（分别是 '\x7f'、' '、''），于是键是哑的，用户还以为改成功了。
+现在两边都按键码比对。
+
+组合键（Ctrl+S）明确拒绝：消费端是单键匹配，收下也用不了。
+
+运行：
+    python -m pytest tests/test_shortcuts.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+
+from PyQt6.QtCore import Qt, QEvent, QSettings
+from PyQt6.QtGui import QKeyEvent
+
+from gui.pages.settings_page import (
+    SHORTCUTS, event_matches_shortcut, normalize_shortcut, shortcut_key_code,
+)
+
+_app = _bootstrap.app()
+
+
+def key_event(qt_key, text="", modifiers=Qt.KeyboardModifier.NoModifier):
+    return QKeyEvent(QEvent.Type.KeyPress, qt_key, modifiers, text)
+
+
+def test_named_keys_are_accepted():
+    for name in ("DELETE", "SPACE", "UP", "DOWN", "LEFT", "RIGHT", "BACKSPACE"):
+        assert normalize_shortcut(name) == name, name
+        assert shortcut_key_code(name) is not None, name
+
+
+def test_letters_and_digits_are_accepted():
+    assert normalize_shortcut("w") == "W"
+    assert normalize_shortcut("3") == "3"
+
+
+def test_combos_are_rejected():
+    """消费端是单键匹配，组合键不能收。"""
+    for combo in ("Ctrl+S", "Alt+F4", "Shift+A"):
+        assert normalize_shortcut(combo) == "", combo
+        assert shortcut_key_code(combo) is None, combo
+
+
+def test_garbage_is_rejected():
+    for bad in ("", "   ", "NOPE", "不是键"):
+        assert normalize_shortcut(bad) == ""
+        assert shortcut_key_code(bad) is None
+
+
+def test_named_keys_actually_match_their_events():
+    """这就是原来那个 bug：这些键 event.text() 匹配不上，键码才匹配得上。"""
+    cases = [
+        ("DELETE", Qt.Key.Key_Delete, "\x7f"),
+        ("SPACE", Qt.Key.Key_Space, " "),
+        ("UP", Qt.Key.Key_Up, ""),
+        ("LEFT", Qt.Key.Key_Left, ""),
+        ("W", Qt.Key.Key_W, "w"),
+        ("3", Qt.Key.Key_3, "3"),
+    ]
+    for stored, qt_key, text in cases:
+        event = key_event(qt_key, text)
+        assert event_matches_shortcut(event, stored), f"{stored} 匹配不上自己的按键事件"
+        # 旧写法（拿 event.text() 比）对无字符的键必然失效
+        if stored in ("DELETE", "SPACE", "UP", "LEFT"):
+            assert event.text().upper() != stored
+
+
+def test_shortcut_does_not_fire_with_ctrl_alt_meta():
+    """单键快捷键不能被 Ctrl+W 这类组合键误触发（Ctrl+Z 撤销要还能用）。"""
+    for modifier in (
+        Qt.KeyboardModifier.ControlModifier,
+        Qt.KeyboardModifier.AltModifier,
+        Qt.KeyboardModifier.MetaModifier,
+    ):
+        event = key_event(Qt.Key.Key_W, "w", modifier)
+        assert not event_matches_shortcut(event, "W")
+
+
+def test_wrong_key_does_not_match():
+    event = key_event(Qt.Key.Key_P, "p")
+    assert not event_matches_shortcut(event, "W")
+
+
+def test_defaults_all_resolve():
+    """设置页列出来的默认键位，一个都不能是哑的。"""
+    for setting_key, name, default in SHORTCUTS:
+        assert shortcut_key_code(default) is not None, f"{name} 的默认键 {default} 解析不了"
+
+
+def test_settings_are_isolated_from_real_user_settings():
+    """测试用的 QSettings 必须落在临时目录里。"""
+    settings = QSettings("EzYOLO", "Settings")
+    assert str(_bootstrap.SETTINGS_DIR) in settings.fileName(), settings.fileName()
+    assert settings.format() == QSettings.Format.IniFormat
+
+    settings.setValue("delete_shortcut", "SPACE")
+    assert QSettings("EzYOLO", "Settings").value("delete_shortcut") == "SPACE"
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+"""构造页面不许动用户的文件；路径不许跟着当前工作目录走。
+
+两个真实事故：
+  1. TestPage.__init__ 里 rmtree 了 outputs/test_images 和 outputs/test_videos。
+     MainWindow 一启动就构造所有页面 —— 应用打开的那一刻，用户上一次的测试结果
+     就没了，而他根本没点过「开始测试」。
+  2. result_page 用 Path.cwd() 算展示路径。双击 EzYOLO.app 启动时 cwd 是 /，
+     结果页找结果、显示路径全跟着错。
+
+运行：
+    python -m pytest tests/test_side_effects.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import os
+import sys
+from pathlib import Path
+
+from gui.pages.result_page import ResultPage
+from gui.pages.test_page import TestPage, annotated_output_path, is_video_path
+from gui.workflow import APP_ROOT
+
+_app = _bootstrap.app()
+
+OUTPUTS = APP_ROOT / "outputs"
+
+
+def test_constructing_test_page_keeps_existing_results():
+    """哨兵文件：构造 TestPage 之后必须原封不动。"""
+    image_dir = OUTPUTS / "test_images"
+    video_dir = OUTPUTS / "test_videos"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    video_dir.mkdir(parents=True, exist_ok=True)
+
+    sentinels = [
+        image_dir / "sentinel_keep_me_annotated.jpg",
+        video_dir / "sentinel_keep_me_annotated.mp4",
+    ]
+    for s in sentinels:
+        s.write_bytes(b"user result, do not delete")
+
+    try:
+        before = {s: s.read_bytes() for s in sentinels}
+
+        TestPage()  # 构造页面 —— 这一步以前会把整个目录 rmtree 掉
+
+        for s in sentinels:
+            assert s.exists(), f"构造 TestPage 删掉了 {s}"
+            assert s.read_bytes() == before[s], f"构造 TestPage 改写了 {s}"
+    finally:
+        for s in sentinels:
+            s.unlink(missing_ok=True)
+
+
+def test_test_page_init_touches_no_directories(tmp_path=None):
+    """构造 TestPage 不该创建目录，也不该删目录。"""
+    page = TestPage()
+    assert page.output_root == OUTPUTS
+    assert page.image_output_dir == OUTPUTS / "test_images"
+    assert page.video_output_dir == OUTPUTS / "test_videos"
+    # startup 那把 rmtree 已经彻底没了
+    assert not hasattr(page, "_clear_test_outputs_on_startup")
+
+
+def test_clear_outputs_for_run_only_removes_its_own_targets(tmp_path=None):
+    """只删这次测试会覆盖的那几个文件，别人的结果一个都不碰。"""
+    import tempfile
+
+    page = TestPage()
+    sandbox = Path(tempfile.mkdtemp(prefix="ezyolo-outputs-"))
+    page.output_root = sandbox
+    page.image_output_dir = sandbox / "test_images"
+    page.video_output_dir = sandbox / "test_videos"
+    page.image_output_dir.mkdir(parents=True)
+    page.video_output_dir.mkdir(parents=True)
+
+    mine_img = page.image_output_dir / "a_annotated.jpg"
+    mine_vid = page.video_output_dir / "clip_annotated.mp4"
+    someone_else = page.image_output_dir / "old_run_annotated.jpg"
+    for f in (mine_img, mine_vid, someone_else):
+        f.write_bytes(b"x")
+
+    page._clear_outputs_for_run(["/data/a.jpg", "/data/clip.mp4"])
+
+    assert not mine_img.exists(), "本次会覆盖的图片结果没清掉"
+    assert not mine_vid.exists(), "本次会覆盖的视频结果没清掉"
+    assert someone_else.exists(), "把不相干的结果也删了"
+
+
+def test_clear_outputs_for_run_survives_missing_files():
+    """目标文件本来就不存在时不该抛异常。"""
+    page = TestPage()
+    import tempfile
+    sandbox = Path(tempfile.mkdtemp(prefix="ezyolo-outputs-"))
+    page.image_output_dir = sandbox / "test_images"
+    page.video_output_dir = sandbox / "test_videos"
+    page._clear_outputs_for_run(["/nope/x.jpg"])  # 不该炸
+
+
+def test_output_naming_rule():
+    assert is_video_path("/a/b/c.MP4") is True
+    assert is_video_path("/a/b/c.jpg") is False
+
+    img_dir, vid_dir = Path("/i"), Path("/v")
+    assert annotated_output_path("/data/cat.png", img_dir, vid_dir) == img_dir / "cat_annotated.jpg"
+    assert annotated_output_path("/data/clip.mov", img_dir, vid_dir) == vid_dir / "clip_annotated.mp4"
+
+
+def test_result_page_display_path_is_cwd_independent():
+    """从任意 cwd 启动，结果页的短路径都得算对。"""
+    page = ResultPage()
+    run_dir = APP_ROOT / "runs" / "train" / "exp_1"
+
+    original = os.getcwd()
+    try:
+        os.chdir("/")  # 模拟双击 EzYOLO.app：cwd 是 /
+        assert page._display_path(run_dir) == "runs/train/exp_1"
+    finally:
+        os.chdir(original)
+
+    # 在项目目录里也一样
+    assert page._display_path(run_dir) == "runs/train/exp_1"
+
+    # 应用根目录之外的路径，原样显示绝对路径
+    assert page._display_path(Path("/tmp/elsewhere")) == "/tmp/elsewhere"
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_task_feedback.py
+++ b/tests/test_task_feedback.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""任务反馈回归测试：耗时任务不能冻界面、取消要立刻生效、密钥不能泄露。
+
+覆盖两条最近改过的路径：
+    LLMBatchWorker（gui/pages/annotate_page.py）——网络请求搬到后台线程
+    TestPage.stop_inference（gui/pages/test_page.py）——停止不再 wait() 界面线程
+
+llm_detect 全程用 monkeypatch 换掉：不发真实请求、不读真实配置、不需要 API Key。
+QMessageBox 一律替换成不弹窗的桩，任何模态都会让离屏测试挂死。
+
+运行：
+    python -m pytest tests/test_task_feedback.py -q
+    或
+    python tests/test_task_feedback.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys  # noqa: E402
+import tempfile  # noqa: E402
+import threading  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from PyQt6.QtCore import Qt, QThread  # noqa: E402
+
+from gui.pages import annotate_page, test_page  # noqa: E402
+from gui.pages.annotate_page import LLMBatchWorker  # noqa: E402
+
+_app = _bootstrap.app()
+
+FAKE_CONFIG = {
+    'api_key': 'TEST_SECRET_MUST_NOT_LEAK_0123456789',
+    'base_url': 'http://127.0.0.1:0/never-called',
+    'model_name': 'fake-model',
+    'system_prompt': 'sys',
+    'user_prompt': '{target}',
+}
+
+_TMP = Path(tempfile.mkdtemp(prefix="ezyolo-taskfeedback-"))
+
+
+class _NoModalMessageBox:
+    """QMessageBox 的桩：不弹窗，直接返回。测试里任何模态都会挂死。"""
+
+    class StandardButton:
+        Yes = 1
+        No = 0
+        Ok = 1
+        Cancel = 0
+
+    calls = []
+
+    @classmethod
+    def information(cls, *args, **kwargs):
+        cls.calls.append(('information', args[2] if len(args) > 2 else ''))
+        return cls.StandardButton.Ok
+
+    warning = critical = information
+
+    @classmethod
+    def question(cls, *args, **kwargs):
+        cls.calls.append(('question', args[2] if len(args) > 2 else ''))
+        return cls.StandardButton.Yes
+
+
+def _make_image(name: str) -> str:
+    """造一张真实存在的临时文件——worker 只做 os.path.exists 检查。"""
+    path = _TMP / name
+    path.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg")
+    return str(path)
+
+
+def _images(n: int):
+    return [
+        {'id': 100 + i, 'filename': f"img{i}.jpg", 'storage_path': _make_image(f"img{i}.jpg")}
+        for i in range(n)
+    ]
+
+
+class _Patch:
+    """临时替换模块属性，退出时还原。"""
+
+    def __init__(self, module, **attrs):
+        self.module = module
+        self.attrs = attrs
+        self.saved = {}
+
+    def __enter__(self):
+        for k, v in self.attrs.items():
+            self.saved[k] = getattr(self.module, k)
+            setattr(self.module, k, v)
+        return self
+
+    def __exit__(self, *exc):
+        for k, v in self.saved.items():
+            setattr(self.module, k, v)
+        return False
+
+
+def _run_worker(worker: LLMBatchWorker, on_started=None, timeout_ms=5000):
+    """跑一个 worker 到线程真正退出为止，返回 (image_done 记录, batch_finished 记录)。
+
+    信号用 DirectConnection：槽在 worker 线程里执行，不需要界面事件循环。
+    收集只是往 list 里 append，够安全。
+    """
+    done = []
+    finished = []
+    worker.image_done.connect(
+        lambda image_id, dets, err: done.append((image_id, dets, err)),
+        Qt.ConnectionType.DirectConnection,
+    )
+    worker.batch_finished.connect(
+        lambda ok, bad, cancelled: finished.append((ok, bad, cancelled)),
+        Qt.ConnectionType.DirectConnection,
+    )
+    if on_started is not None:
+        worker.image_started.connect(on_started, Qt.ConnectionType.DirectConnection)
+
+    worker.start()
+    assert worker.wait(timeout_ms), "worker 线程没有在超时内退出"
+    assert not worker.isRunning()
+    return done, finished
+
+
+# --- 1) llm_detect 必须在后台线程里被调用 ---
+
+def test_llm_detect_runs_off_the_gui_thread():
+    main_qthread = QThread.currentThread()
+    main_pythread = threading.current_thread().ident
+    seen = []
+
+    def fake_llm_detect(config, image_path, target):
+        seen.append((QThread.currentThread(), threading.current_thread().ident))
+        return [{'label': target, 'bbox': [1, 2, 3, 4]}]
+
+    with _Patch(annotate_page, llm_detect=fake_llm_detect, QMessageBox=_NoModalMessageBox):
+        worker = LLMBatchWorker(FAKE_CONFIG, _images(2), "cat")
+        done, finished = _run_worker(worker)
+
+    assert len(seen) == 2, f"llm_detect 应被调用 2 次，实际 {len(seen)}"
+    for qthread, ident in seen:
+        assert qthread is not main_qthread, "llm_detect 跑在了界面线程上"
+        assert qthread is worker, "llm_detect 应该跑在 LLMBatchWorker 这个 QThread 里"
+        assert ident != main_pythread
+
+    assert [d[2] for d in done] == ["", ""]
+    assert done[0][1] == [{'label': 'cat', 'bbox': [1, 2, 3, 4]}]
+    assert finished == [(2, 0, False)]
+
+
+# --- 2) 取消后最多做完当前这张，不再开下一张 ---
+
+def test_cancel_stops_after_current_image():
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def fake_llm_detect(config, image_path, target):
+        calls.append(image_path)
+        started.set()
+        release.wait(5)  # 卡住第一张，给主线程时间发出取消
+        return []
+
+    with _Patch(annotate_page, llm_detect=fake_llm_detect, QMessageBox=_NoModalMessageBox):
+        worker = LLMBatchWorker(FAKE_CONFIG, _images(4), "cat")
+
+        done = []
+        finished = []
+        worker.image_done.connect(
+            lambda i, d, e: done.append((i, d, e)), Qt.ConnectionType.DirectConnection
+        )
+        worker.batch_finished.connect(
+            lambda ok, bad, c: finished.append((ok, bad, c)), Qt.ConnectionType.DirectConnection
+        )
+
+        worker.start()
+        assert started.wait(5), "worker 没有开始处理第一张"
+        worker.cancel()          # 界面线程只置标志，不阻塞
+        release.set()            # 放行当前这张
+
+        assert worker.wait(5000), "取消后线程没退出"
+
+    assert not worker.isRunning()
+    assert len(calls) == 1, f"取消后不该再调 llm_detect，实际调了 {len(calls)} 次"
+    assert len(done) == 1, "取消后只应有当前这一张的结果"
+    assert finished == [(1, 0, True)], f"batch_finished 应带 cancelled=True，实际 {finished}"
+
+
+# --- 3) 异常里的 API Key 不能经 error signal 泄露 ---
+
+def test_error_message_does_not_leak_api_key():
+    key = FAKE_CONFIG['api_key']
+
+    def fake_llm_detect(config, image_path, target):
+        raise RuntimeError(f"401 Unauthorized: Bearer {key} rejected by http://x/v1")
+
+    with _Patch(annotate_page, llm_detect=fake_llm_detect, QMessageBox=_NoModalMessageBox):
+        worker = LLMBatchWorker(FAKE_CONFIG, _images(1), "cat")
+        done, finished = _run_worker(worker)
+
+    assert len(done) == 1
+    reason = done[0][2]
+    assert reason, "失败应该给出原因"
+    assert key not in reason, "error signal 里带出了 API Key"
+    assert "***" in reason
+    assert "401 Unauthorized" in reason  # 抹掉密钥，但别把有用的信息也抹了
+    assert finished == [(0, 1, False)]  # 成功 0 / 失败 1 / 未取消
+
+
+# --- 4)(5) TestPage.stop_inference：正在跑的线程只 stop 不 wait；非运行线程安全复位 ---
+
+class _FakeThread:
+    """假的推理线程：只记录被调了什么，绝不真起线程。"""
+
+    def __init__(self, running: bool):
+        self._running = running
+        self.stop_calls = 0
+        self.wait_calls = 0
+
+    def isRunning(self):
+        return self._running
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def wait(self, *args):
+        self.wait_calls += 1
+        return True
+
+
+def _make_test_page():
+    page = test_page.TestPage()
+    page.data_paths = ["a.jpg", "b.jpg"]
+    page.is_running = True
+    page._stopping = False
+    page.btn_stop_inference.setVisible(True)
+    page.btn_stop_inference.setEnabled(True)
+    page.btn_stop_inference.setText("停止")
+    return page
+
+
+def test_stop_inference_does_not_block_gui_thread():
+    with _Patch(test_page, QMessageBox=_NoModalMessageBox):
+        page = _make_test_page()
+        thread = _FakeThread(running=True)
+        page.inference_thread = thread
+
+        page.stop_inference()
+
+    assert thread.stop_calls == 1, "应该请求线程停止"
+    assert thread.wait_calls == 0, "界面线程不得 wait() 推理线程"
+    assert page._stopping is True
+    assert page.btn_stop_inference.text() == "正在停止…"
+    assert not page.btn_stop_inference.isEnabled()
+    assert page.status_label.text() == "正在停止…"
+    # 还没收尾：停止按钮仍在，等 inference_finished 回调复位
+    assert page.is_running is True
+
+
+def test_stop_inference_resets_when_thread_not_running():
+    for thread in (_FakeThread(running=False), None):
+        with _Patch(test_page, QMessageBox=_NoModalMessageBox):
+            page = _make_test_page()
+            page.inference_thread = thread
+
+            page.stop_inference()
+
+        if thread is not None:
+            assert thread.stop_calls == 0, "非运行线程不该再 stop"
+            assert thread.wait_calls == 0
+
+        assert page._stopping is False
+        assert page.is_running is False
+        assert page.btn_stop_inference.text() == "停止"
+        assert page.btn_stop_inference.isHidden()
+        assert not page.btn_stop_inference.isEnabled()
+        assert page.status_label.text() == "已停止"
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(dict(globals())))

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -1,0 +1,409 @@
+# -*- coding: utf-8 -*-
+"""布局测试：两种窗口尺寸下，七个页面都不许把文字或按钮切掉。
+
+冒烟测试只管「页面能不能打开」，这里管「打开之后有没有被切」。
+判据只有一条，但足够狠：一个控件如果画出来的文字比它自己的盒子还宽，
+用户就会看到半个字——不管它是标签还是按钮。
+
+    python tests/test_ui_layout.py
+    python -m pytest tests/test_ui_layout.py -q
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import tempfile
+from pathlib import Path
+
+from PyQt6.QtWidgets import QLabel, QPushButton  # noqa: E402
+from PyQt6.QtGui import QImage, QColor  # noqa: E402
+
+from gui.workflow import (  # noqa: E402
+    STEP_IMPORT, STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST,
+    PAGE_SETTINGS, PAGE_ABOUT,
+)
+from gui.main_window import MainWindow  # noqa: E402
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+# 要覆盖的窗口尺寸：最小支持尺寸，和一台 14 寸笔记本的常见可用区域
+SIZES = [(1100, 720), (1470, 832)]
+
+PAGES = [
+    STEP_IMPORT, STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST,
+    PAGE_SETTINGS, PAGE_ABOUT,
+]
+
+# 字体渲染在不同机器上有 1px 级别的出入，留一点余量，只抓真正切字的情况
+SLACK = 2
+
+_IMAGE_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-layout-"))
+
+
+def seed_project() -> int:
+    """一个「什么都有」的项目：有图、有标注、有类别，页面才会显示满内容。"""
+    project_id = _bootstrap.create_temp_project(
+        name="布局测试项目",
+        project_type="detect",
+        classes=[{'id': 0, 'name': '猫', 'color': '#FF3B30'}],
+    )
+    for i in range(3):
+        path = _IMAGE_DIR / f"layout{i}.jpg"
+        image = QImage(320, 240, QImage.Format.Format_RGB888)
+        image.fill(QColor(120, 120, 130))
+        image.save(str(path))
+
+        image_id = db.add_image(project_id, path.name, str(path), width=320, height=240)
+        db.add_annotation(
+            image_id=image_id,
+            project_id=project_id,
+            class_id=0,
+            class_name="猫",
+            annotation_type="bbox",
+            data={'x': 0.5, 'y': 0.5, 'width': 0.4, 'height': 0.4},
+        )
+        db.update_image_status(image_id, 'annotated')
+    return project_id
+
+
+def make_window() -> MainWindow:
+    from gui import main_window as mw
+    mw.db = db
+    return MainWindow()
+
+
+def _skip_widget(widget) -> bool:
+    text = widget.text()
+    if not text.strip():
+        return True
+    # 富文本（HTML）用字体度量算尺寸没有意义
+    if '<' in text and '>' in text:
+        return True
+    # 显示图片的标签，text() 只是占位说明
+    if isinstance(widget, QLabel):
+        pixmap = widget.pixmap()
+        if pixmap is not None and not pixmap.isNull():
+            return True
+    return False
+
+
+def _text_is_clipped(widget) -> bool:
+    """控件里的文字有没有横向超出它自己的盒子。"""
+    if _skip_widget(widget):
+        return False
+
+    if isinstance(widget, QLabel):
+        # 会换行的标签靠高度容纳文字，不存在横向切字
+        if widget.wordWrap():
+            return False
+        needed = widget.fontMetrics().horizontalAdvance(widget.text())
+        margins = widget.contentsMargins()
+        available = widget.width() - margins.left() - margins.right()
+        return needed > available + SLACK
+
+    # 按钮：minimumSizeHint 已经把文字宽度和内边距算进去了
+    return widget.width() + SLACK < widget.minimumSizeHint().width()
+
+
+def _needed_height(widget) -> int:
+    """这个控件要把文字完整画出来，至少得有多高。
+
+    横向切字看宽度，纵向切字看的是「一行字的高度」——macOS 上一个 13px 的
+    中文字形连基线一起要 18~19px，控件只有 11px 高时上下都会被削掉。
+    会换行的标签按当前宽度问 heightForWidth，行数变了也算得对。
+    """
+    if isinstance(widget, QLabel) and widget.wordWrap() and widget.width() > 0:
+        return widget.heightForWidth(widget.width())
+    return widget.fontMetrics().height()
+
+
+def _text_is_vertically_clipped(widget) -> bool:
+    """文字有没有被上下切掉：可用高度装不下一行（或换行后的若干行）字。"""
+    if _skip_widget(widget):
+        return False
+
+    margins = widget.contentsMargins()
+    available = widget.height() - margins.top() - margins.bottom()
+    return _needed_height(widget) > available + SLACK
+
+
+def _describe(widget) -> str:
+    return (
+        f"{type(widget).__name__}(objectName={widget.objectName()!r}, "
+        f"text={widget.text()[:40]!r}, "
+        f"size={widget.width()}x{widget.height()})"
+    )
+
+
+def _clipped_widgets(page):
+    found = []
+    for widget in page.findChildren((QLabel, QPushButton)):
+        if not widget.isVisible():
+            continue
+        if widget.width() <= 0 or widget.height() <= 0:
+            continue
+        if _text_is_clipped(widget):
+            found.append(f"横向切字 {_describe(widget)}")
+        if _text_is_vertically_clipped(widget):
+            found.append(
+                f"纵向切字 {_describe(widget)} "
+                f"需要 {_needed_height(widget)}px，只有 {widget.height()}px"
+            )
+    return found
+
+
+def _check_all_pages(window, width, height):
+    problems = []
+    window.resize(width, height)
+    window.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    for index in PAGES:
+        window.switch_page(index)
+        for _ in range(3):
+            _app.processEvents()
+
+        # 从窗口往下找：侧边栏、页头和当前页面一起查；
+        # 堆栈里没显示的页面 isVisible() 为假，会被跳过
+        for problem in _clipped_widgets(window):
+            problems.append(f"[{width}x{height} 第 {index} 页] {problem}")
+
+        page = window.content_stack.currentWidget()
+        # 页面不该比窗口还宽——宽出去的部分用户根本看不到
+        if page.width() > window.width():
+            problems.append(
+                f"[{width}x{height} 第 {index} 页] 页面宽度 {page.width()} 超过窗口 {window.width()}"
+            )
+    return problems
+
+
+def test_no_clipped_text_at_min_size():
+    """1100x720（应用支持的最小窗口）下不许切字。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+
+    problems = _check_all_pages(window, 1100, 720)
+    assert not problems, "有控件的文字被切掉:\n" + "\n".join(problems)
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_no_clipped_text_at_laptop_size():
+    """1470x832 下同样不许切字（也顺带确认放大后不塌）。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+
+    problems = _check_all_pages(window, 1470, 832)
+    assert not problems, "有控件的文字被切掉:\n" + "\n".join(problems)
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def _nav_label_problems(index, item):
+    """一步里的三个标签（状态符号 / 名称 / 进展），横竖都不许被切。
+
+    符号那一列以前是 setFixedWidth(16) ——一个写死的数字。'✓' 在 Cocoa 上会落到
+    别的字体里，字宽跟着系统走，写死就有被竖着切掉半个的风险。所以这里按每个
+    标签自己的字体度量去量，而不是拿 16 去比。
+    """
+    problems = []
+    visible = item.contentsRect()
+
+    for role, label in (("符号", item.mark), ("名称", item.name), ("进展", item.status)):
+        text = label.text()
+        if not text.strip():
+            continue
+
+        metrics = label.fontMetrics()
+
+        needed_h = metrics.height()
+        if label.height() + SLACK < needed_h:
+            problems.append(
+                f"第 {index} 步的{role}「{text}」被纵向切掉："
+                f"需要 {needed_h}px，只有 {label.height()}px"
+            )
+
+        needed_w = metrics.horizontalAdvance(text)
+        if label.width() + SLACK < needed_w:
+            problems.append(
+                f"第 {index} 步的{role}「{text}」被横向切掉："
+                f"需要 {needed_w}px，只有 {label.width()}px"
+            )
+
+        # 控件自己画得再大，超出父控件可见区域一样看不到
+        geo = label.geometry()
+        if geo.bottom() > visible.bottom() + SLACK:
+            problems.append(
+                f"第 {index} 步的{role}超出可见区域（下）：{geo.bottom()} > {visible.bottom()}"
+            )
+        if geo.right() > visible.right() + SLACK:
+            problems.append(
+                f"第 {index} 步的{role}超出可见区域（右）：{geo.right()} > {visible.right()}"
+            )
+    return problems
+
+
+def _step_nav_problems(window):
+    """五步导航：每一步的符号、名称和进展都得完整显示。
+
+    StepNavItem 是一个内部放了布局的 QPushButton。QPushButton 的 sizeHint 只按
+    它自己那段（空的）文本算，根本不看子布局——父布局照这个高度给格子，里面
+    两行字就被压扁。所以这里既查控件够不够高，也查它报出去的尺寸提示对不对。
+    """
+    problems = []
+    for index, item in window.step_nav.items.items():
+        content = item.layout().minimumSize().height()
+        if item.minimumSizeHint().height() < content:
+            problems.append(
+                f"第 {index} 步的 minimumSizeHint 高度 {item.minimumSizeHint().height()} "
+                f"低于内容需要的 {content}px——父布局会照这个值把它压扁"
+            )
+        if item.height() < content:
+            problems.append(
+                f"第 {index} 步实际高度 {item.height()} 装不下内容需要的 {content}px"
+            )
+
+        problems += _nav_label_problems(index, item)
+    return problems
+
+
+def test_step_nav_text_is_not_clipped():
+    """五个步骤的符号、名称和进展，在两种窗口尺寸下都不许被切（横竖都算）。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+
+    problems = []
+    for width, height in SIZES:
+        window.resize(width, height)
+        window.show()
+        for _ in range(3):
+            _app.processEvents()
+        problems += [f"[{width}x{height}] {p}" for p in _step_nav_problems(window)]
+
+    assert not problems, "流程导航的文字被切:\n" + "\n".join(problems)
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_step_nav_marks_fit_in_every_state():
+    """四种状态的符号（✓ ● ○）都得装得下——符号那一列的宽度不是写死的 16px。"""
+    from gui.workflow import DONE, CURRENT, READY, LOCKED
+    from gui.widgets.workflow_widgets import STATE_MARK
+
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    problems = []
+    for state in (DONE, CURRENT, READY, LOCKED):
+        for index, item in window.step_nav.items.items():
+            item.apply_state(state, "已标注 3/3")
+        for _ in range(3):
+            _app.processEvents()
+
+        for index, item in window.step_nav.items.items():
+            assert item.mark.text() == STATE_MARK[state]
+            problems += [f"[{state}] {p}" for p in _nav_label_problems(index, item)]
+
+    assert not problems, "某个状态下的导航文字被切:\n" + "\n".join(problems)
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_step_nav_height_is_computed_not_hardcoded():
+    """字号一大，格子必须跟着变高——高度是按字体度量算出来的，不是拍一个数字顶上去。
+
+    这是「根因到底修没修」的判据。Cocoa / 高 DPI 上同样一段 13px 的中文，
+    字形比别的平台高、也比别的平台宽；只要高度还是从布局（→ 字体度量）来的，
+    这些机器上就自动够用。反过来，哪天有人把高度改回一个写死的常量，
+    这个测试会当场失败。
+
+    直接换构造期的字号，而不是事后改 QLabel 的 font：布局把 minimumSize 缓存了，
+    事后改字体量不到；何况平台字体本来就是控件建出来的那一刻定下的。
+    """
+    from gui.widgets.workflow_widgets import StepNavItem
+    from gui.workflow import WORKFLOW_STEPS, CURRENT
+
+    step = WORKFLOW_STEPS[0]
+
+    small = StepNavItem(step)
+    small.apply_state(CURRENT, "3 张图片")
+
+    original = (StepNavItem.NAME_PX, StepNavItem.STATUS_PX)
+    try:
+        StepNavItem.NAME_PX = original[0] + 8
+        StepNavItem.STATUS_PX = original[1] + 8
+        big = StepNavItem(step)
+        big.apply_state(CURRENT, "3 张图片")
+    finally:
+        StepNavItem.NAME_PX, StepNavItem.STATUS_PX = original
+
+    assert big.minimumSizeHint().height() > small.minimumSizeHint().height(), (
+        f"字号大了 8px，格子的最小高度却没变"
+        f"（{small.minimumSizeHint().height()}px → {big.minimumSizeHint().height()}px）"
+        "——高度多半是写死的，字一大就会被切"
+    )
+    # 符号那一列的宽度同样跟着字体走，不是写死的 16px
+    assert big.mark.minimumWidth() > small.mark.minimumWidth(), (
+        "字号变大，状态符号那一列的宽度没跟着变——宽度是写死的，'✓' 会被切"
+    )
+
+    # 大字号下真摆出来，横竖都不许切
+    big.resize(220, big.sizeHint().height())
+    big.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    problems = _nav_label_problems(STEP_IMPORT, big)
+    assert not problems, "字号调大之后文字被切:\n" + "\n".join(problems)
+
+    big.close()
+    small.close()
+
+
+def test_gate_text_is_not_width_locked():
+    """前置条件页的说明不能被写死宽度——窄窗口下要能跟着缩，而不是被切掉。"""
+    window = make_window()
+    window.resize(1100, 720)
+    window.show()
+    _app.processEvents()
+
+    # 没有项目 → 标注页被挡住，显示 Gate
+    window.switch_page(STEP_ANNOTATE)
+    for _ in range(3):
+        _app.processEvents()
+
+    gate = window.gate
+    assert gate.title.wordWrap() and gate.reason.wordWrap()
+
+    # 卡片可以有上限，但不能是「最小宽度 == 最大宽度」的死宽度
+    assert gate.minimumWidth() < gate.maximumWidth()
+
+    for problem in _clipped_widgets(gate):
+        raise AssertionError(f"前置条件页文字被切: {problem}")
+
+    window.close()
+
+
+def test_startup_notice_stays_quiet_when_nothing_is_wrong():
+    """数据自检没差异时，窗口里不该出现任何通知条。"""
+    window = make_window()
+    assert not window.notice.isVisible()
+    window.close()
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -15,14 +15,15 @@ import sys
 import tempfile
 from pathlib import Path
 
+from PyQt6.QtCore import Qt  # noqa: E402
 from PyQt6.QtWidgets import QLabel, QPushButton  # noqa: E402
-from PyQt6.QtGui import QImage, QColor  # noqa: E402
+from PyQt6.QtGui import QImage, QColor, QFontMetrics  # noqa: E402
 
 from gui.workflow import (  # noqa: E402
     STEP_IMPORT, STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST,
     PAGE_SETTINGS, PAGE_ABOUT,
 )
-from gui.main_window import MainWindow  # noqa: E402
+from gui.main_window import MainWindow, GATE_INDEX  # noqa: E402
 
 _app = _bootstrap.app()
 db = _bootstrap.db
@@ -403,6 +404,355 @@ def test_startup_notice_stays_quiet_when_nothing_is_wrong():
     window = make_window()
     assert not window.notice.isVisible()
     window.close()
+
+
+def test_long_project_name_is_elided_not_cut_in_half():
+    """侧栏项目名装不下时要以省略号收尾，不能把最后一个中文字切掉一半。
+
+    上面那套切字检查只看 QLabel 和 QPushButton，下拉框漏在外面——
+    而 QComboBox 恰恰是不会自己省略的：文字比框宽就直接裁掉。给下拉箭头
+    留出内边距之后，长项目名正好会露出半个字。
+    """
+    long_name = "安全帽检测很长的项目名字测试用例"
+    project_id = _bootstrap.create_temp_project(name=long_name, project_type="detect")
+
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    combo = window.project_combo
+    metrics = QFontMetrics(combo.font())
+
+    # 前提：这个名字确实装不下，否则这个测试什么都没测到
+    assert metrics.horizontalAdvance(long_name) > combo.width(), "名字应该长到装不下"
+
+    painted = combo.elided_text()
+    assert painted != long_name, "装不下却原样画出来，最后一个字会被切掉"
+    assert painted.endswith("…"), f"应该用省略号收尾，实际是 {painted!r}"
+    assert metrics.horizontalAdvance(painted) <= combo.width(), "省略之后仍然超出框宽"
+
+    # 完整名字要还能看得到
+    assert combo.itemData(combo.currentIndex(), Qt.ItemDataRole.ToolTipRole) == long_name
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_project_identity_is_not_repeated_on_the_pages():
+    """项目名只由左侧流程栏负责。标注页和导入页不再各放一份。
+
+    同一屏把项目名写三遍不会让人更清楚自己在哪，只会把宽度从真正要看的东西
+    （标注页的画布、导入页的图片区）里抠走。
+    """
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    assert not hasattr(window.annotate_page, 'project_name_label'), \
+        "标注页信息条不该再有「当前项目」这一格"
+    assert not hasattr(window.import_page, 'project_bar'), \
+        "导入页不该再有项目信息卡片"
+
+    # 侧栏那一份还在——不能把项目身份整个弄丢
+    assert window.project_combo is not None
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_annotate_toolbar_is_one_quiet_row_without_group_captions():
+    """标注工具栏是一行控件，不是一张带小标题的卡片。
+
+    「标注工具」「修改」这两行常驻小标题各占一行高度，三五个按钮不需要目录；
+    卡片边框还把它框成一个和画布平起平坐的区块——画布因此矮了一截。
+    """
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    window.switch_page(STEP_ANNOTATE)
+    for _ in range(3):
+        _app.processEvents()
+
+    page = window.annotate_page
+
+    captions = [label.text() for label in page.toolbar.findChildren(QLabel)]
+    assert "标注工具" not in captions and "修改" not in captions, \
+        f"工具栏里不该再有常驻的分组标题：{captions}"
+
+    # 一行：所有可见按钮的垂直区间必须互相重叠
+    visible = [b for b in page.toolbar_buttons if b.isVisible()]
+    assert len(visible) >= 3
+    tops = {b.y() for b in visible}
+    assert len(tops) == 1, f"工具栏按钮不在同一行上：{[(b.text(), b.y()) for b in visible]}"
+
+    # 高度一致：QToolButton（带下拉箭头）和普通 QPushButton 默认对不齐
+    heights = {b.height() for b in visible}
+    assert len(heights) == 1, \
+        f"按钮高度不一致，中间那根分隔线两边会高低不平：{[(b.text(), b.height()) for b in visible]}"
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_advanced_and_destructive_panels_start_collapsed():
+    """样本管理（会真删图片文件）和数据导出默认收起，不常驻占地方。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    window.switch_page(STEP_ANNOTATE)
+    for _ in range(3):
+        _app.processEvents()
+
+    page = window.annotate_page
+
+    # 收起时里面的按钮是看不见的，但控件还在——展开就能用，没有被删掉
+    assert not page.btn_delete_random_samples.isVisible()
+    assert not page.btn_export_dataset.isVisible()
+    assert not page.btn_batch_process.isVisible(), "批处理已经挪进样本管理（进阶）里"
+
+    # 类别和 AI 入口是主路径，必须一进来就看得见
+    assert page.class_list.isVisible()
+    assert page.btn_auto_label.isVisible()
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_expanded_sections_do_not_clip_their_contents():
+    """收起只是默认值，不是把问题藏起来——展开之后一样不许切字。"""
+    from gui.widgets.collapsible_section import CollapsibleSection
+
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    window.switch_page(STEP_ANNOTATE)
+    for _ in range(3):
+        _app.processEvents()
+
+    sections = window.annotate_page.right_panel.findChildren(CollapsibleSection)
+    assert len(sections) == 2, f"应该有样本管理和数据导出两个折叠区，实际 {len(sections)}"
+
+    for section in sections:
+        assert not section.is_expanded(), f"{section.toggle.text()} 默认应该是收起的"
+        section.set_expanded(True)
+    for _ in range(3):
+        _app.processEvents()
+
+    problems = []
+    for section in sections:
+        problems += _clipped_widgets(section)
+    assert not problems, "折叠区展开后文字被切:\n" + "\n".join(problems)
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_import_page_keeps_task_type_and_hides_rare_actions_in_a_menu():
+    """导入页：任务类型是工具栏上的一个胶囊，罕用和破坏性的动作进「管理」菜单。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    window.switch_page(STEP_IMPORT)
+    for _ in range(3):
+        _app.processEvents()
+
+    page = window.import_page
+
+    assert page.btn_task_type.isVisible()
+    assert "目标检测" in page.btn_task_type.text(), page.btn_task_type.text()
+
+    labels = [a.text() for a in page.manage_menu.actions() if a.text()]
+    for wanted in ("移动分组", "删除选中的图片", "清空全部图片", "删除项目"):
+        assert wanted in labels, f"「{wanted}」应该在管理菜单里：{labels}"
+
+    # 破坏性的两个要看得出来是破坏性的
+    for action in page.destructive_actions:
+        assert action.property('destructive') is True
+        assert not action.icon().isNull(), f"{action.text()} 应该带一个红点"
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_header_hidden_on_import_and_annotate_business_pages():
+    """导入 / 标注是业务页：左侧 StepNav 已经承担了流程和下一步导航，
+    PageHeader 整块（标题、序号、说明、下一步按钮）不该再显示第二遍。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    window.switch_page(STEP_IMPORT)
+    for _ in range(3):
+        _app.processEvents()
+    assert not window.header.isVisible(), "导入页不该显示 PageHeader"
+
+    window.switch_page(STEP_ANNOTATE)
+    for _ in range(3):
+        _app.processEvents()
+    assert not window.header.isVisible(), "标注页不该显示 PageHeader"
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_header_visible_on_non_business_pages():
+    """训练、结果、测试、设置、关于继续显示 PageHeader。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    for _ in range(3):
+        _app.processEvents()
+
+    for index in (STEP_TRAIN, STEP_RESULT, STEP_TEST, PAGE_SETTINGS, PAGE_ABOUT):
+        window.switch_page(index)
+        for _ in range(3):
+            _app.processEvents()
+        assert window.header.isVisible(), f"第 {index} 页应该显示 PageHeader"
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_header_visible_when_gate_blocks_annotate_without_project():
+    """没有项目时进标注页会被 StepGate 挡住——挡住的是业务页，不是页头。
+    Gate 本身的上下文（第几步、说明）仍然要靠 PageHeader 显示。"""
+    window = make_window()
+    window.resize(1100, 720)
+    window.show()
+    _app.processEvents()
+
+    window.switch_page(STEP_ANNOTATE)
+    for _ in range(3):
+        _app.processEvents()
+
+    assert window.content_stack.currentIndex() == GATE_INDEX
+    assert window.header.isVisible(), "Gate 挡住业务页时，PageHeader 应该继续显示"
+
+    window.close()
+
+
+def test_import_toolbar_moves_up_without_header():
+    """页头隐藏后，工具栏是导入页第一个主要区块，离窗口顶部应该只剩页面自己的
+    上边距（约 16~18px），而不是页头（标题+说明）撑出来的六七十像素。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.resize(1100, 720)
+    window.show()
+    window.switch_page(STEP_IMPORT)
+    for _ in range(3):
+        _app.processEvents()
+
+    toolbar = window.import_page.toolbar
+    top_y = toolbar.mapTo(window, toolbar.rect().topLeft()).y()
+    assert top_y < 40, (
+        f"工具栏离窗口顶部还有 {top_y}px，页头似乎没有真正隐藏（应该只剩页面自身的上边距）"
+    )
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_train_page_config_panel_width_is_fixed_across_sizes():
+    """训练页左边配置栏宽度固定 360px，窗口变宽时增量都该给右边监控面板，
+    不再靠 QSplitter 拖来拖去导致卡片横向漂移。"""
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.switch_page(STEP_TRAIN)
+
+    page = window.train_page
+    assert hasattr(page, 'config_panel') and hasattr(page, 'monitor_panel')
+
+    widths = {}
+    for width, height in SIZES:
+        window.resize(width, height)
+        window.show()
+        for _ in range(3):
+            _app.processEvents()
+        widths[width] = page.config_panel.width()
+
+        assert page.monitor_panel.isVisible()
+        assert page.monitor_panel.width() >= 340
+
+        problems = _clipped_widgets(page)
+        assert not problems, f"[{width}x{height}] 训练页文字被切:\n" + "\n".join(problems)
+
+    assert widths[1100] == 360, f"1100 宽时左栏应该是 360px，实际 {widths[1100]}"
+    assert widths[1470] == 360, f"1470 宽时左栏应该仍是 360px，实际 {widths[1470]}"
+
+    window.close()
+    db.delete_project(project_id)
+
+
+def test_train_page_template_row_does_not_scroll_horizontally():
+    """训练模板这一行（下拉 + 套用 + 管理）挤在固定 360px 左栏里，只许纵向滚动。
+
+    以前这一行把 scroll_content 撑得比视口宽，QScrollArea 底部会冒出一条横向
+    滚动条，基础配置右边的控件（边框、下拉箭头）跟着被裁掉一截。真正的判据
+    不是「有没有滚动条控件」，而是内容本身有没有比视口宽——横向滚动条被关掉
+    之后，撑宽的内容会变成永久裁切，比留着滚动条更糟。
+    """
+    project_id = seed_project()
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    window.switch_page(STEP_TRAIN)
+
+    page = window.train_page
+    scroll = page.config_scroll
+
+    for width, height in SIZES:
+        window.resize(width, height)
+        window.show()
+        for _ in range(3):
+            _app.processEvents()
+
+        assert scroll.horizontalScrollBar().maximum() == 0, (
+            f"[{width}x{height}] 配置栏出现横向滚动，maximum="
+            f"{scroll.horizontalScrollBar().maximum()}（应为 0）"
+        )
+
+        viewport_width = scroll.viewport().width()
+        for widget, label in (
+            (page.template_combo, "训练模板下拉"),
+            (page.btn_apply_template, "「套用」按钮"),
+            (page.btn_template_menu, "「管理」按钮"),
+        ):
+            top_left = widget.mapTo(scroll.viewport(), widget.rect().topLeft())
+            bottom_right = widget.mapTo(scroll.viewport(), widget.rect().bottomRight())
+            assert top_left.x() >= 0 and bottom_right.x() <= viewport_width + SLACK, (
+                f"[{width}x{height}] {label}超出了 scroll viewport 可见范围: "
+                f"x={top_left.x()}..{bottom_right.x()}，viewport 宽度 {viewport_width}"
+            )
+
+        for btn in (page.btn_apply_template, page.btn_template_menu):
+            assert not _text_is_clipped(btn), (
+                f"[{width}x{height}] {btn.text()!r} 按钮的文字被切掉了"
+            )
+
+    window.close()
+    db.delete_project(project_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""界面冒烟测试：主窗口能起来，五个步骤都能打开，前置条件页会正确挡人。
+
+离屏渲染，不弹真窗口。数据库、QSettings、启动期文件同步都在 _bootstrap 里换掉了，
+所以测试不碰 data/、outputs/ 和用户的真实设置。
+
+运行：
+    python -m pytest tests/test_ui_smoke.py -q
+    或
+    python tests/test_ui_smoke.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+
+from gui.workflow import (  # noqa: E402
+    STEP_IMPORT, STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST,
+    PAGE_SETTINGS, PAGE_ABOUT,
+)
+from gui.main_window import MainWindow, GATE_INDEX  # noqa: E402
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+
+def make_window() -> MainWindow:
+    from gui import main_window as mw
+    mw.db = db
+    return MainWindow()
+
+
+def test_window_opens_on_first_step():
+    window = make_window()
+    assert window.current_index == STEP_IMPORT
+    assert window.content_stack.currentIndex() == STEP_IMPORT
+    # 没有项目时，页头不该催下一步
+    assert window.header.next_btn.isHidden()
+
+
+def test_all_steps_reachable_and_gated_without_project():
+    window = make_window()
+
+    # 没有项目：导入页可以进，后面四步都被挡在前置条件页
+    window.switch_page(STEP_IMPORT)
+    assert window.content_stack.currentIndex() == STEP_IMPORT
+
+    for index in (STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST):
+        window.switch_page(index)
+        assert window.content_stack.currentIndex() == GATE_INDEX, index
+        assert window.gate.title.text()
+        assert window.gate.goto_btn.text()
+
+
+def test_settings_and_about_open_directly():
+    window = make_window()
+
+    window.switch_page(PAGE_SETTINGS)
+    assert window.content_stack.currentIndex() == PAGE_SETTINGS
+    assert window.btn_settings.isChecked()
+
+    window.switch_page(PAGE_ABOUT)
+    assert window.content_stack.currentIndex() == PAGE_ABOUT
+    assert window.btn_about.isChecked()
+    assert not window.btn_settings.isChecked()
+
+
+def test_project_with_images_opens_annotate_but_blocks_train():
+    project_id = _bootstrap.create_temp_project(name="冒烟项目", project_type="detect", classes=[])
+    db.add_image(project_id, "a.jpg", "/tmp/does-not-matter-a.jpg", width=10, height=10)
+
+    window = make_window()
+    window.load_projects(select_id=project_id)
+    assert window.current_project_id == project_id
+
+    # 有图片 → 标注页能进
+    window.switch_page(STEP_ANNOTATE)
+    assert window.content_stack.currentIndex() == STEP_ANNOTATE
+
+    # 一张都没标 → 训练被挡住，并指回标注
+    window.switch_page(STEP_TRAIN)
+    assert window.content_stack.currentIndex() == GATE_INDEX
+    assert window.gate._goto_index == STEP_ANNOTATE
+
+    # 页头的下一步应该指向标注
+    window.switch_page(STEP_IMPORT)
+    assert window.header.next_btn.isVisible() or window.header._next_index == STEP_ANNOTATE
+
+    db.delete_project(project_id)
+
+
+def test_gate_bypass_lets_user_into_test_page():
+    project_id = _bootstrap.create_temp_project(name="跳过项目", project_type="detect", classes=[])
+    db.add_image(project_id, "b.jpg", "/tmp/does-not-matter-b.jpg", width=10, height=10)
+
+    window = make_window()
+    window.load_projects(select_id=project_id)
+
+    window.switch_page(STEP_TEST)
+    assert window.content_stack.currentIndex() == GATE_INDEX
+
+    # 「我有现成的模型，直接测试」
+    window.on_gate_bypassed()
+    assert window.content_stack.currentIndex() == STEP_TEST
+
+    db.delete_project(project_id)
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -34,8 +34,9 @@ def test_window_opens_on_first_step():
     window = make_window()
     assert window.current_index == STEP_IMPORT
     assert window.content_stack.currentIndex() == STEP_IMPORT
-    # 没有项目时，页头不该催下一步
-    assert window.header.next_btn.isHidden()
+    # 没有项目时，工作流的下一步数据也不该催下一步
+    # （导入页是业务页，PageHeader 本身也不显示，见 test_ui_layout.py）
+    assert window.header._next_index is None
 
 
 def test_all_steps_reachable_and_gated_without_project():
@@ -82,9 +83,10 @@ def test_project_with_images_opens_annotate_but_blocks_train():
     assert window.content_stack.currentIndex() == GATE_INDEX
     assert window.gate._goto_index == STEP_ANNOTATE
 
-    # 页头的下一步应该指向标注
+    # 工作流的下一步数据应该指向标注（导入页是业务页，页头本身不显示，
+    # 见 test_ui_layout.py 的 header 隐藏测试；这里只验证数据仍然对）
     window.switch_page(STEP_IMPORT)
-    assert window.header.next_btn.isVisible() or window.header._next_index == STEP_ANNOTATE
+    assert window.header._next_index == STEP_ANNOTATE
 
     db.delete_project(project_id)
 

--- a/tests/test_video_extract.py
+++ b/tests/test_video_extract.py
@@ -1,0 +1,437 @@
+# -*- coding: utf-8 -*-
+"""视频抽帧：元信息、两种抽法、抽帧设置框。
+
+覆盖的真实问题：
+    1. 原来只有 QInputDialog.getInt 问一个「间隔多少帧」，用户根本不知道最后能得到几张图。
+       现在开抽之前先读元信息（只读属性，不解码、不导入任何一帧），并实时算出预计张数。
+    2. 随机抽取要的是「不重复的 N 张」，而且必须按帧号升序导入——乱序就得来回 seek，
+       很多容器 seek 不准。
+    3. 总帧数读不到时：固定间隔照常能用，随机抽取必须禁掉（不知道有多少帧就没法随机取 N 张），
+       而不是让它看着能点然后炸掉。
+    4. 随机抽取一样能中途取消，且不会把进度条显示成 100% 完成。
+
+运行：
+    python tests/test_video_extract.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import random
+import re
+import sys
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import cv2
+import numpy as np
+
+from core.import_manager import (
+    ImportManager, VIDEO_MODE_INTERVAL, VIDEO_MODE_RANDOM,
+    probe_video_metadata, estimate_interval_frame_count, plan_random_frame_indices,
+)
+from gui.widgets.video_extract_dialog import (
+    DIALOG_WIDTH, VideoExtractDialog, format_duration,
+)
+
+_app = _bootstrap.app()
+db = _bootstrap.db
+
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="ezyolo-video-extract-"))
+
+
+def _make_project() -> int:
+    return _bootstrap.create_temp_project(name="抽帧测试项目", project_type="detect", classes=[])
+
+
+def _make_video(path: Path, frame_count: int = 30, fps: float = 10.0, size=(64, 48)) -> Path:
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, fps, size)
+    for i in range(frame_count):
+        frame = np.zeros((size[1], size[0], 3), dtype=np.uint8)
+        frame[:] = (i * 5 % 255, 0, 0)
+        writer.write(frame)
+    writer.release()
+    return path
+
+
+def _saved_frame_numbers(project_id: int) -> list:
+    """从落库的文件名里把帧号读回来（保存时写的是 ..._frame_000123.jpg）。"""
+    numbers = []
+    for image in db.get_project_images(project_id):
+        match = re.search(r"_frame_(\d+)\.jpg$", image['filename'])
+        if match:
+            numbers.append(int(match.group(1)))
+    return numbers
+
+
+class _FakeCapUnknownTotal:
+    """真的 VideoCapture 包一层，只是把总帧数汇报成 0（有些视频就是不写这个值）。"""
+
+    real = cv2.VideoCapture
+
+    def __init__(self, path):
+        self._real = _FakeCapUnknownTotal.real(path)
+
+    def isOpened(self):
+        return self._real.isOpened()
+
+    def get(self, prop):
+        if prop == cv2.CAP_PROP_FRAME_COUNT:
+            return 0
+        return self._real.get(prop)
+
+    def read(self):
+        return self._real.read()
+
+    def release(self):
+        self._real.release()
+
+
+# ==================== 元信息 ====================
+
+def test_metadata_is_read_without_importing_any_frame():
+    """读元信息只是打开文件读几个属性：拿到帧数/fps/时长，一张图都不会进项目。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "meta.mp4", frame_count=30, fps=10.0)
+
+    meta = probe_video_metadata(str(video_path))
+
+    assert meta['total_frames'] == 30, meta
+    assert abs(meta['fps'] - 10.0) < 0.5, meta
+    assert abs(meta['duration'] - 3.0) < 0.5, meta
+    assert db.get_project_images(project_id) == [], "读元信息不该导入任何一帧"
+
+
+def test_metadata_unknown_total_is_reported_as_zero_not_garbage():
+    """总帧数读不到时给 0 / duration=None，而不是一个假的负数或 nan。"""
+    video_path = _make_video(_TMP_DIR / "meta_unknown.mp4", frame_count=10)
+
+    with patch("core.import_manager.cv2.VideoCapture", _FakeCapUnknownTotal):
+        meta = probe_video_metadata(str(video_path))
+
+    assert meta['total_frames'] == 0, meta
+    assert meta['duration'] is None, meta
+
+
+# ==================== 固定间隔 ====================
+
+def test_interval_estimate_rounds_up_and_handles_unknown_total():
+    """预计张数向上取整；总帧数未知时说「不知道」（None），不能编一个数出来。"""
+    assert estimate_interval_frame_count(31, 30) == 2   # 第 0 帧和第 30 帧
+    assert estimate_interval_frame_count(30, 30) == 1
+    assert estimate_interval_frame_count(100, 1) == 100
+    assert estimate_interval_frame_count(0, 30) is None
+    assert estimate_interval_frame_count(-1, 30) is None
+
+
+# ==================== 随机抽取 ====================
+
+def test_random_indices_are_unique_sorted_and_in_range():
+    """随机帧号：要几个给几个，不重复，升序，都落在 [0, 总帧数) 里。"""
+    indices = plan_random_frame_indices(200, 12, rng=random.Random(7))
+
+    assert len(indices) == 12
+    assert len(set(indices)) == 12, "帧号不能重复"
+    assert indices == sorted(indices), "必须升序，否则抽帧要来回 seek"
+    assert all(0 <= i < 200 for i in indices), indices
+
+
+def test_random_count_is_capped_at_total_frames():
+    """要得比总帧数还多：按总帧数封顶，而不是报错或重复抽。"""
+    indices = plan_random_frame_indices(5, 50, rng=random.Random(1))
+
+    assert len(indices) == 5
+    assert sorted(set(indices)) == [0, 1, 2, 3, 4]
+
+
+def test_random_rejects_unknown_total_and_zero_count():
+    """总帧数未知 / 张数 < 1：直接拒绝，不要走到解码那一步才发现干不了。"""
+    for total, count in ((0, 10), (-3, 10), (100, 0)):
+        try:
+            plan_random_frame_indices(total, count)
+        except ValueError:
+            continue
+        raise AssertionError(f"total={total} count={count} 应该抛 ValueError")
+
+
+def test_random_import_saves_exactly_the_planned_unique_frames_in_order():
+    """随机导入：张数正好、帧号不重复、按升序落库（同一个种子可复现）。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "random.mp4", frame_count=40)
+
+    total = probe_video_metadata(str(video_path))['total_frames']
+    expected = plan_random_frame_indices(total, 6, rng=random.Random(2026))
+
+    manager = ImportManager(project_id)
+    imported, skipped = manager.import_video(
+        str(video_path), mode=VIDEO_MODE_RANDOM, sample_count=6,
+        rng=random.Random(2026),
+    )
+
+    assert imported == 6, f"要 6 张，实际 {imported}"
+    assert skipped == 0
+
+    saved = _saved_frame_numbers(project_id)
+    assert saved == expected, f"落库帧号应该等于计划帧号且升序: {saved} vs {expected}"
+
+
+def test_random_import_stops_decoding_after_the_last_wanted_frame():
+    """最后一个要的帧存完就收工，不再往下解码整段视频。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "random_stop.mp4", frame_count=60)
+
+    reads = {'count': 0}
+    real_capture = cv2.VideoCapture
+
+    class _CountingCap:
+        def __init__(self, path):
+            self._real = real_capture(path)
+
+        def isOpened(self):
+            return self._real.isOpened()
+
+        def get(self, prop):
+            return self._real.get(prop)
+
+        def read(self):
+            reads['count'] += 1
+            return self._real.read()
+
+        def release(self):
+            self._real.release()
+
+    # 固定种子挑 3 张，最大帧号一定小于 60；解码次数不该到 60
+    rng_seed = 99
+    expected = plan_random_frame_indices(60, 3, rng=random.Random(rng_seed))
+
+    manager = ImportManager(project_id)
+    with patch("core.import_manager.cv2.VideoCapture", _CountingCap):
+        imported, _ = manager.import_video(
+            str(video_path), mode=VIDEO_MODE_RANDOM, sample_count=3,
+            rng=random.Random(rng_seed),
+        )
+
+    assert imported == 3
+    # 读到最后一个要的帧就停：读取次数 = 最大帧号 + 1
+    assert reads['count'] == expected[-1] + 1, (
+        f"应该在第 {expected[-1]} 帧之后停止解码，实际读了 {reads['count']} 次"
+    )
+
+
+def test_random_import_without_total_frames_refuses_instead_of_guessing():
+    """总帧数读不到还硬要随机 N 张：抛 ValueError，不解码、不导入半成品。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "random_unknown.mp4", frame_count=20)
+
+    manager = ImportManager(project_id)
+    with patch("core.import_manager.cv2.VideoCapture", _FakeCapUnknownTotal):
+        try:
+            manager.import_video(str(video_path), mode=VIDEO_MODE_RANDOM, sample_count=5)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("总帧数未知时随机抽取应该抛 ValueError")
+
+    assert db.get_project_images(project_id) == [], "失败时不该留下半截导入的图片"
+
+
+def test_random_import_can_be_cancelled_midway():
+    """随机抽取也能喊停：停在半路，最终进度不显示成 100%。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "random_cancel.mp4", frame_count=60)
+
+    cancel_event = threading.Event()
+    seen = []
+
+    def progress_callback(progress, message):
+        seen.append((progress, message))
+        # 存下 2 张之后喊停
+        if message.startswith("正在抽取") and len([m for _, m in seen if m.startswith("正在抽取")]) >= 2:
+            cancel_event.set()
+
+    manager = ImportManager(project_id)
+    imported, _ = manager.import_video(
+        str(video_path), mode=VIDEO_MODE_RANDOM, sample_count=20,
+        progress_callback=progress_callback, cancel_event=cancel_event,
+        rng=random.Random(5),
+    )
+
+    assert imported < 20, "取消之后不该把 20 张全抽完"
+    final_progress, final_message = seen[-1]
+    assert "已取消" in final_message, final_message
+    assert final_progress < 100, f"取消不是完成，进度不该是 100：{final_progress}"
+
+
+def test_progress_messages_state_mode_and_target_count():
+    """进度和完成提示要说清楚「用的哪种抽法、目标多少张」。"""
+    project_id = _make_project()
+    video_path = _make_video(_TMP_DIR / "messages.mp4", frame_count=20)
+
+    manager = ImportManager(project_id)
+
+    random_calls = []
+    manager.import_video(
+        str(video_path), mode=VIDEO_MODE_RANDOM, sample_count=4,
+        progress_callback=lambda p, m: random_calls.append(m), rng=random.Random(3),
+    )
+    assert "随机抽取 4 张" in random_calls[1], random_calls[1]
+    assert "随机 4 张" in random_calls[-1], random_calls[-1]
+
+    project_id2 = _make_project()
+    manager2 = ImportManager(project_id2)
+    interval_calls = []
+    manager2.import_video(
+        str(video_path), frame_interval=5, mode=VIDEO_MODE_INTERVAL,
+        progress_callback=lambda p, m: interval_calls.append(m),
+    )
+    assert "间隔 5" in interval_calls[1] and "预计抽取 4 张" in interval_calls[1], interval_calls[1]
+    assert "每 5 帧取 1 张" in interval_calls[-1], interval_calls[-1]
+
+
+# ==================== 抽帧设置框 ====================
+
+def test_dialog_shows_metadata_and_live_estimate():
+    """框里要直接告诉用户：这视频多少帧多长，按现在填的数能抽出几张。
+
+    「几张」就跟在输入框那一行后面——用户改的是那个数字，结果也该出现在那儿，
+    而不是让他往下找一段说明文字。
+    """
+    meta = {'total_frames': 300, 'fps': 30.0, 'duration': 10.0}
+    dialog = VideoExtractDialog(None, meta, filename="test.mp4")
+
+    assert "300 帧" in dialog.lbl_meta.text()
+    assert "30 fps" in dialog.lbl_meta.text()
+    assert "10 秒" in dialog.lbl_meta.text()
+
+    dialog.sb_interval.setValue(30)
+    inline = dialog.lbl_interval_estimate.text()
+    assert "预计 10 张" in inline, inline
+    # fps 已知时要把间隔折算成时间，用户想的是「几秒一张」不是「几帧一张」
+    assert "每 1.0 秒" in inline, inline
+
+    dialog.sb_interval.setValue(60)
+    assert "预计 5 张" in dialog.lbl_interval_estimate.text(), dialog.lbl_interval_estimate.text()
+
+    plan = dialog.get_plan()
+    assert plan == {'mode': VIDEO_MODE_INTERVAL, 'frame_interval': 60, 'sample_count': None}
+
+
+def test_result_block_only_appears_when_it_has_something_to_add():
+    """底下那块说明只在真有话说时出现：能算出张数的固定间隔模式不留空灰条。
+
+    张数和「几秒一张」上面那行已经写了，再原样重复一遍只是把框撑高。
+    随机模式（要给建议）和总帧数未知（要解释为什么算不出来）才该出现。
+    """
+    known = {'total_frames': 300, 'fps': 30.0, 'duration': 10.0}
+    dialog = VideoExtractDialog(None, known, filename="test.mp4")
+    dialog.show()
+    _app.processEvents()
+
+    assert not dialog.result_box.isVisible(), (
+        f"固定间隔 + 总帧数已知时不该出现说明块：{dialog.lbl_estimate.text()!r}"
+    )
+
+    # 随机模式：抽几张全靠用户拍脑袋，必须给参照
+    dialog.rbtn_random.setChecked(True)
+    _app.processEvents()
+    assert dialog.result_box.isVisible()
+    assert "10 秒" in dialog.lbl_estimate.text(), dialog.lbl_estimate.text()
+
+    dialog.close()
+
+    # 总帧数未知：要解释为什么给不出预计张数
+    unknown = VideoExtractDialog(None, {'total_frames': 0, 'fps': 0.0, 'duration': None})
+    unknown.show()
+    _app.processEvents()
+
+    assert unknown.result_box.isVisible()
+    assert "总帧数未知" in unknown.lbl_estimate.text(), unknown.lbl_estimate.text()
+    assert "张数未知" in unknown.lbl_interval_estimate.text()
+
+    unknown.close()
+
+
+def test_dialog_random_mode_bounds_count_and_gives_advice():
+    """随机模式：张数上限是总帧数，并按时长给一句人话建议。"""
+    meta = {'total_frames': 300, 'fps': 30.0, 'duration': 10.0}
+    dialog = VideoExtractDialog(None, meta, filename="test.mp4")
+
+    dialog.rbtn_random.setChecked(True)
+
+    assert dialog.sb_random_count.maximum() == 300, "随机张数不能超过总帧数"
+    assert dialog.sb_random_count.minimum() == 1
+
+    dialog.sb_random_count.setValue(12)
+    text = dialog.lbl_estimate.text()
+    assert "随机抽取 12 张" in text, text
+    assert "10 秒" in text, text  # 建议里用时长说话
+
+    plan = dialog.get_plan()
+    assert plan['mode'] == VIDEO_MODE_RANDOM
+    assert plan['sample_count'] == 12
+
+
+def test_dialog_disables_random_mode_when_total_is_unknown():
+    """总帧数未知：随机抽取整个禁掉并说明原因，固定间隔照常能用。"""
+    meta = {'total_frames': 0, 'fps': 0.0, 'duration': None}
+    dialog = VideoExtractDialog(None, meta, filename="stream.mp4")
+
+    assert not dialog.rbtn_random.isEnabled(), "总帧数未知时随机抽取必须禁用"
+    assert not dialog.sb_random_count.isEnabled()
+    assert "总帧数" in dialog.rbtn_random.toolTip(), dialog.rbtn_random.toolTip()
+    assert "读不到总帧数" in dialog.lbl_meta.text(), dialog.lbl_meta.text()
+
+    assert dialog.rbtn_interval.isChecked(), "应该默认落在还能用的固定间隔上"
+    assert dialog.sb_interval.isEnabled()
+    dialog.sb_interval.setValue(10)
+    assert "总帧数未知" in dialog.lbl_estimate.text(), dialog.lbl_estimate.text()
+
+    plan = dialog.get_plan()
+    assert plan['mode'] == VIDEO_MODE_INTERVAL and plan['frame_interval'] == 10
+
+
+def test_switching_to_random_mode_grows_the_dialog_instead_of_squashing_the_text():
+    """切到随机模式时说明从一行变三行——框子必须跟着长高。
+
+    QLabel 的换行高度默认传不到对话框：不处理的话多出来的两行会直接画在
+    「取消 / 开始抽帧」上面，用户看到的是半截压着按钮的字。
+    """
+    meta = {'total_frames': 3000, 'fps': 30.0, 'duration': 100.0}
+    dialog = VideoExtractDialog(None, meta, filename="长视频.mp4")
+    dialog.show()
+    _app.processEvents()
+
+    dialog.rbtn_random.setChecked(True)
+    for _ in range(3):
+        _app.processEvents()
+
+    label = dialog.lbl_estimate
+    needed = label.heightForWidth(label.width())
+    assert label.height() >= needed, (
+        f"建议文字需要 {needed}px，标签只有 {label.height()}px——会被压掉几行"
+    )
+
+    # 说明块不能压到按钮上
+    assert dialog.result_box.geometry().bottom() <= dialog.btn_confirm.geometry().top(), \
+        "说明块和按钮重叠了"
+
+    # 长高不等于变窄：让高度自适应的那套做法很容易顺手把固定宽度也一起解开，
+    # 框子会缩成一条窄柱子，说明文字被挤成每行三四个字
+    assert dialog.width() == DIALOG_WIDTH, (
+        f"对话框宽度应该稳定在 {DIALOG_WIDTH}，实际 {dialog.width()}"
+    )
+
+    dialog.close()
+
+
+def test_duration_is_spoken_in_plain_chinese():
+    assert format_duration(45) == "45 秒"
+    assert format_duration(72) == "1 分 12 秒"
+    assert format_duration(0) == ""
+    assert format_duration(None) == ""
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(dict(globals())))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""主流程状态机的轻量测试。
+
+只测「事实 → 状态 / 拦截原因 / 下一步」这层纯逻辑，不需要真的起界面，
+所以跑起来很快，也不会碰数据库和用户文件。
+
+运行：
+    python -m pytest tests/test_workflow.py -q
+    或
+    python tests/test_workflow.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+from pathlib import Path
+
+from gui.workflow import (  # noqa: E402
+    STEP_IMPORT, STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST,
+    DONE, CURRENT, READY, LOCKED,
+    compute_step_states, get_blocker, get_next_action, step_status_text,
+)
+
+
+def snapshot(**kwargs):
+    base = {
+        'project_id': 1,
+        'image_count': 0,
+        'annotated_count': 0,
+        'class_count': 0,
+        'run_dirs': [],
+        'weights': None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_no_project_locks_everything_after_import():
+    snap = snapshot(project_id=None)
+    states = compute_step_states(snap)
+
+    assert states[STEP_IMPORT] == CURRENT
+    for index in (STEP_ANNOTATE, STEP_TRAIN, STEP_RESULT, STEP_TEST):
+        assert states[index] == LOCKED
+
+    blocker = get_blocker(STEP_ANNOTATE, snap)
+    assert blocker is not None
+    assert blocker['action_index'] == STEP_IMPORT
+
+
+def test_empty_project_blocks_annotate_with_reason():
+    snap = snapshot(image_count=0)
+
+    assert get_blocker(STEP_IMPORT, snap) is None
+
+    blocker = get_blocker(STEP_ANNOTATE, snap)
+    assert blocker['action_index'] == STEP_IMPORT
+    assert '图片' in blocker['title']
+
+
+def test_images_without_annotation_block_training():
+    snap = snapshot(image_count=10, annotated_count=0)
+    states = compute_step_states(snap)
+
+    assert states[STEP_IMPORT] == DONE
+    assert states[STEP_ANNOTATE] == CURRENT
+    assert states[STEP_TRAIN] == LOCKED
+
+    assert get_blocker(STEP_ANNOTATE, snap) is None
+
+    blocker = get_blocker(STEP_TRAIN, snap)
+    assert blocker['action_index'] == STEP_ANNOTATE
+
+
+def test_partial_annotation_unlocks_training():
+    snap = snapshot(image_count=10, annotated_count=4)
+    states = compute_step_states(snap)
+
+    assert states[STEP_ANNOTATE] == CURRENT
+    assert states[STEP_TRAIN] == CURRENT
+    assert get_blocker(STEP_TRAIN, snap) is None
+
+    assert step_status_text(STEP_ANNOTATE, snap, states) == "已标注 4/10"
+
+
+def test_all_annotated_marks_annotate_done():
+    snap = snapshot(image_count=6, annotated_count=6)
+    states = compute_step_states(snap)
+    assert states[STEP_ANNOTATE] == DONE
+
+
+def test_result_and_test_need_training_output():
+    snap = snapshot(image_count=6, annotated_count=6)
+    states = compute_step_states(snap)
+
+    assert states[STEP_RESULT] == LOCKED
+    assert states[STEP_TEST] == LOCKED
+    assert get_blocker(STEP_RESULT, snap)['action_index'] == STEP_TRAIN
+
+    test_blocker = get_blocker(STEP_TEST, snap)
+    assert test_blocker['action_index'] == STEP_TRAIN
+    # 已经有现成权重的用户可以跳过训练直接测试
+    assert test_blocker.get('bypass_text')
+
+
+def test_trained_project_unlocks_result_and_test():
+    snap = snapshot(
+        image_count=6, annotated_count=6,
+        run_dirs=[Path('runs/train/exp_1')],
+        weights=Path('runs/train/exp_1/weights/best.pt'),
+    )
+    states = compute_step_states(snap)
+
+    assert states[STEP_TRAIN] == DONE
+    assert states[STEP_RESULT] == READY
+    assert states[STEP_TEST] == READY
+    assert get_blocker(STEP_RESULT, snap) is None
+    assert get_blocker(STEP_TEST, snap) is None
+
+
+def test_next_action_walks_the_flow():
+    def next_index(snap, current):
+        action = get_next_action(snap, compute_step_states(snap), current)
+        return action['index'] if action else None
+
+    # 空项目 → 先导入
+    assert next_index(snapshot(), STEP_ANNOTATE) == STEP_IMPORT
+    # 有图没标 → 先标注
+    assert next_index(snapshot(image_count=5), STEP_IMPORT) == STEP_ANNOTATE
+    # 标了一半，站在导入页 → 回去把标注做完
+    assert next_index(snapshot(image_count=5, annotated_count=2), STEP_IMPORT) == STEP_ANNOTATE
+    # 标了一半，正站在标注页 → 可以去训练了
+    assert next_index(snapshot(image_count=5, annotated_count=2), STEP_ANNOTATE) == STEP_TRAIN
+    # 站在训练页但还没训练过 → 动作是页面里的「开始训练」，页头不再催
+    assert next_index(snapshot(image_count=5, annotated_count=5), STEP_TRAIN) is None
+    # 训练完站在训练页 → 去看结果
+    trained = snapshot(image_count=5, annotated_count=5,
+                       run_dirs=[Path('runs/train/exp_1')],
+                       weights=Path('runs/train/exp_1/weights/best.pt'))
+    assert next_index(trained, STEP_TRAIN) == STEP_RESULT
+    # 看完结果 → 去测试
+    assert next_index(trained, STEP_RESULT) == STEP_TEST
+    # 已经在最后一步 → 不再催下一步
+    assert next_index(trained, STEP_TEST) is None
+
+
+def test_settings_and_about_are_never_blocked():
+    from gui.workflow import PAGE_SETTINGS, PAGE_ABOUT
+
+    snap = snapshot(project_id=None)
+    assert get_blocker(PAGE_SETTINGS, snap) is None
+    assert get_blocker(PAGE_ABOUT, snap) is None
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            try:
+                func()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    print(f"\n{'all passed' if not failures else f'{failures} failed'}")
+    sys.exit(1 if failures else 0)

--- a/tests/test_zoom_math.py
+++ b/tests/test_zoom_math.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""缩放数学：不导入 Qt，直接验证倍率、边界和锚点公式。
+
+    python tests/test_zoom_math.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import math
+import sys
+import time
+
+from gui.view_zoom import (  # noqa: E402
+    ZOOM_MAX, ZOOM_MIN, native_zoom_factor, pinch_zoom_factor,
+    wheel_zoom_factor, zoom_at,
+)
+
+
+def test_input_factors_are_safe_and_directional():
+    assert wheel_zoom_factor(120) == 1.1
+    assert wheel_zoom_factor(-1) == 0.9
+    assert wheel_zoom_factor(0) == 1.0
+    assert wheel_zoom_factor(float('nan')) == 1.0
+
+    assert native_zoom_factor(0.25) == 1.25
+    assert native_zoom_factor(float('inf')) == 1.0
+    assert pinch_zoom_factor(1.2) == 1.2
+    assert pinch_zoom_factor(0) == 1.0
+    assert pinch_zoom_factor(-1) == 1.0
+    assert pinch_zoom_factor(float('nan')) == 1.0
+
+
+def test_zoom_at_maps_and_keeps_the_anchor_on_the_same_image_point():
+    scale, offset_x, offset_y = 1.5, 37.0, -12.0
+    anchor_x, anchor_y = 160.0, 90.0
+    image_x = (anchor_x - offset_x) / scale
+    image_y = (anchor_y - offset_y) / scale
+
+    new_scale, new_offset_x, new_offset_y = zoom_at(
+        scale, offset_x, offset_y, anchor_x, anchor_y, 1.2, (ZOOM_MIN, ZOOM_MAX)
+    )
+
+    assert math.isclose(new_scale, 1.8)
+    assert math.isclose((anchor_x - new_offset_x) / new_scale, image_x)
+    assert math.isclose((anchor_y - new_offset_y) / new_scale, image_y)
+
+
+def test_zoom_at_clamps_without_moving_a_clamped_anchor():
+    result = zoom_at(4.9, 10.0, 20.0, 100.0, 80.0, 2.0, (ZOOM_MIN, ZOOM_MAX))
+    assert result[0] == ZOOM_MAX
+
+    result = zoom_at(0.11, 10.0, 20.0, 100.0, 80.0, 0.1, (ZOOM_MIN, ZOOM_MAX))
+    assert result[0] == ZOOM_MIN
+
+    already_max = (ZOOM_MAX, 10.0, 20.0)
+    assert zoom_at(*already_max, 100.0, 80.0, 1.1, (ZOOM_MIN, ZOOM_MAX)) == already_max
+
+
+def test_zoom_at_rejects_invalid_and_noop_inputs_without_throwing():
+    cases = (
+        (1.0, 10.0, 20.0, 100.0, 80.0, 1.0, (ZOOM_MIN, ZOOM_MAX)),
+        (1.0, 10.0, 20.0, 100.0, 80.0, 0.0, (ZOOM_MIN, ZOOM_MAX)),
+        (0.0, 10.0, 20.0, 100.0, 80.0, 1.1, (ZOOM_MIN, ZOOM_MAX)),
+        (1.0, 10.0, 20.0, 100.0, 80.0, float('nan'), (ZOOM_MIN, ZOOM_MAX)),
+        (1.0, 10.0, 20.0, 100.0, 80.0, 1.1, (5.0, 0.1)),
+    )
+    for args in cases:
+        assert zoom_at(*args) == args[:3]
+
+
+def test_zoom_at_50000_calls_stays_fast_enough_for_continuous_input():
+    """回归护栏，不是机器性能基准。"""
+    started = time.perf_counter()
+    scale, offset_x, offset_y = 1.0, 0.0, 0.0
+    for index in range(50_000):
+        factor = 1.01 if index % 2 == 0 else 1 / 1.01
+        scale, offset_x, offset_y = zoom_at(
+            scale, offset_x, offset_y, 180.0, 120.0, factor, (ZOOM_MIN, ZOOM_MAX)
+        )
+    elapsed = time.perf_counter() - started
+
+    assert ZOOM_MIN <= scale <= ZOOM_MAX
+    assert elapsed < 2.0, f"50000 次 zoom_at 花了 {elapsed:.3f}s"
+    print(f"50000 次 zoom_at: {elapsed:.3f}s")
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))

--- a/tests/test_zoom_stress.py
+++ b/tests/test_zoom_stress.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""连续缩放事件的轻量回归护栏。
+
+    python tests/test_zoom_stress.py
+"""
+
+import _bootstrap  # noqa: F401  必须第一个导入
+
+import sys
+import time
+
+from PyQt6.QtCore import QPoint, QPointF, Qt  # noqa: E402
+from PyQt6.QtGui import (  # noqa: E402
+    QColor, QNativeGestureEvent, QPointingDevice, QPixmap,
+)
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from gui.pages.annotate_page import AnnotationCanvas  # noqa: E402
+from gui.view_zoom import ZOOM_MAX, ZOOM_MIN  # noqa: E402
+
+_app = _bootstrap.app()
+
+
+def _native_event(canvas, local, value):
+    position = QPointF(local)
+    return QNativeGestureEvent(
+        Qt.NativeGestureType.ZoomNativeGesture,
+        QPointingDevice.primaryPointingDevice(),
+        0,
+        position,
+        position,
+        QPointF(canvas.mapToGlobal(local)),
+        value,
+        QPointF(),
+        1,
+    )
+
+
+def test_600_continuous_zoom_events_stay_bounded_anchored_and_single_refresh():
+    """回归护栏，不是机器性能基准。"""
+    canvas = AnnotationCanvas()
+    canvas.resize(420, 320)
+    canvas.show()
+    _app.processEvents()
+    image = QPixmap(800, 600)
+    image.fill(QColor(120, 120, 130))
+    canvas.current_image = image
+    canvas.image_scale = 1.0
+    canvas.image_offset = QPoint(20, 15)
+
+    updates = []
+    canvas.update = lambda *args: updates.append(args)
+    anchor = QPoint(170, 110)
+    original_image_point = canvas.widget_to_image(anchor.x(), anchor.y())
+
+    started = time.perf_counter()
+    for index in range(600):
+        value = 0.01 if index % 2 == 0 else -(1 - 1 / 1.01)
+        native = _native_event(canvas, anchor, value)
+        native.ignore()
+        before_updates = len(updates)
+        assert QApplication.sendEvent(canvas, native)
+        assert len(updates) - before_updates <= 1, "一个 native 事件触发了多次 update"
+        assert ZOOM_MIN <= canvas.image_scale <= ZOOM_MAX
+    elapsed = time.perf_counter() - started
+
+    final_image_point = canvas.widget_to_image(anchor.x(), anchor.y())
+    drift = max(
+        abs(final_image_point[0] - original_image_point[0]),
+        abs(final_image_point[1] - original_image_point[1]),
+    )
+    assert drift <= 3, f"600 次连续缩放后锚点漂移 {drift:.2f}px"
+    assert elapsed < 2.0, f"600 个连续事件花了 {elapsed:.3f}s"
+    print(f"600 个 native 缩放事件: {elapsed:.3f}s，锚点漂移 {drift:.2f}px")
+    canvas.close()
+
+
+if __name__ == "__main__":
+    sys.exit(_bootstrap.run_module_tests(globals()))


### PR DESCRIPTION
## 变更目标

本 PR 基于上游当前 `main`，对 EzYOLO 从项目创建、数据导入、数据标注、模型训练到结果分析与测试的完整流程进行了界面和交互改造。

主要目标是：减少重复信息和无效留白，让耗时任务始终有明确反馈，改善标注效率，并增强 macOS 与 Windows 下的交互一致性和可维护性。

## 一、对原有功能的修改

### 1. 主窗口与全流程导航

- 重新整理五步工作流的导航状态、完成状态和阻塞提示。
- 减少页面内部重复出现的步骤数字、下一步提示和说明文字，将有效空间留给实际操作内容。
- 优化项目切换、页面切换和窗口状态恢复，避免切换页面后任务进度或有效状态消失。
- 统一各页面的标题、卡片、按钮、下拉框、禁用态和危险操作样式。

### 2. 数据导入

- 导入图片、文件夹、视频和已有标注的入口重新排版，减少无效占位。
- 视频导入后立即显示准备状态和抽帧进度，不再出现长时间无反馈。
- 后台导入期间切换页面后，返回导入页仍能恢复任务状态和进度。
- 图片网格根据窗口宽度自动计算列数和卡片尺寸，不再出现右侧大面积空白假列。
- 优化长文件名显示，真实文件名仍保留在提示信息中。

### 3. 数据标注

- 将当前图片、工具和标注方式整合到更紧凑的顶部操作区。
- 图片列表支持收起和展开，收起后空间自动让给标注画布。
- 调整类别区域和 AI 自动标注区域的宽度、层级及按钮比例。
- 统一上一张、下一张、添加类别和修改类别等成组按钮的尺寸。
- 修复不同窗口尺寸和系统字体下文字截断、重叠以及菜单箭头挤压文字的问题。
- 强化当前图片、标注数量、当前类别和当前工具的状态展示。

### 4. 自动标注设置

- 调整 YOLO、SAM 和视觉大模型配置页面的布局与说明层级。
- 保存成功后提供明确反馈并正确关闭窗口。
- 保存失败或部分保存失败时保留窗口，并明确指出失败项。
- 从设置页进入配置后保持在设置页，从标注页进入时保持正确的调用页面，避免错误跳转。
- 补充自定义模型缺少文件等配置错误的页面内校验。

### 5. 模型训练、结果分析与模型测试

- 收紧过大的基础配置框和会随窗口无规律变化的区域。
- 重新组织数据准备、基础配置、训练控制和训练监控的页面层级。
- 加强训练轮数、YOLO 版本和模型规格等关键参数的视觉区分。
- 统一结果、测试、可视化和批处理页面的卡片、状态和操作样式。

### 6. 对话框与通用交互

- 统一确认、输入、信息提示、加载和危险操作对话框。
- 危险操作默认聚焦安全选项，减少误删除风险。
- 优化下拉菜单箭头、折叠箭头、锁定图标和禁用状态的可见性。
- 对较长的下拉选项和标签增加省略显示及完整提示。

## 二、新增功能

### 1. 视频抽帧双模式

新增独立的视频抽帧设置窗口，支持：

- 固定间隔抽帧：每 N 帧取 1 张。
- 随机抽帧：从视频中随机抽取指定数量，帧号不重复并按时间顺序导入。
- 显示视频总帧数、帧率、时长和预计抽取数量。
- 根据视频长度给出便于理解的抽帧建议。
- 支持抽帧进度提示和中途取消。

### 2. 跨平台画布缩放

- 新增统一的缩放数学模块。
- 支持鼠标滚轮缩放。
- 支持 macOS 触控板像素滚动和捏合手势。
- 兼容 Windows 常见滚轮与触控板事件。
- 缩放时保持鼠标或手势中心对应的图片位置，减少画面跳动。
- 避免同一次触控板操作触发两次缩放。

### 3. 视图比例与位置锁定

- 在标注画布上增加锁定按钮。
- 锁定后切换图片可以保持缩放比例和观察位置，适合连续标注相同机位或相同区域。
- 解锁后切换图片恢复默认适配视图。
- 不同尺寸图片之间切换时进行安全约束，避免图片完全离开画布。

### 4. 友好图片名称

- 对视频抽帧生成的长文件名显示为简洁的帧号。
- 不同视频出现相同帧号时，自动使用日期、时间或稳定序号进行区分。
- 用户原始文件名保持不变。
- 界面显示名称与真实存储名称分离，降低对数据库和文件路径的影响。

### 5. 可复用界面组件

新增并拆分了以下通用组件：

- 应用统一对话框。
- 可折叠区域。
- 长文本省略下拉框。
- 视频抽帧设置窗口。
- 工作流状态与导航组件。
- 画布缩放计算模块。
- 下拉箭头、锁定状态和导航方向 SVG 图标资源。

这些模块可以独立测试，减少后续页面继续堆叠重复代码。

## 三、工程化与可靠性

- 增加项目切换、数据库同步、后台任务反馈和页面副作用的回归测试。
- 增加标注手势、画布锁定、缩放性能和连续缩放稳定性测试。
- 增加响应式布局、文字完整显示、菜单箭头和不同窗口尺寸测试。
- 增加视频元数据、固定抽帧、随机抽帧、取消导入和未知帧数测试。
- 增加对话框保存成功、失败、部分失败以及安全默认选项测试。
- 增加友好图片名称及重名消歧测试。

## 四、验证结果

- 在 `QT_QPA_PLATFORM=offscreen` 环境下运行 21 个测试模块，全部通过，失败 0。
- 相关 Python 文件通过 `py_compile` 语法检查。
- Git 差异格式检查通过。
- 在 macOS Qt/Cocoa 环境实际检查了响应式图片网格、工具栏文字、菜单箭头、触控板缩放和视图锁定。

## 五、兼容性与范围说明

- 本 PR 未增加新的第三方依赖。
- 本机运行配置 `config/sam_config.json` 未包含在提交中。
- macOS 已进行实际界面和手势验证。
- Windows 相关事件分支和自动化测试已经覆盖，但尚未在 Windows 实体机上完成触控板与鼠标 smoke test，建议合并前在 Windows 上补一次实际操作验证。

由于本次变更覆盖完整工作流，建议按以下顺序审查：主窗口与工作流状态 → 数据导入 → 数据标注与缩放 → 自动标注配置 → 训练和结果页面 → 通用组件与测试。